### PR TITLE
Actor Health Check 방식 변경

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
@@ -92,14 +92,17 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
     }
 
     private Behavior<ChannelReaderRegistryCommand> onSpawnedChannelReaderActor(SpawnedChannelReaderActor command) {
-        ChannelReaderNode channelReaderNode = new ChannelReaderNode(command.reader(), command.readerName());
+        ChannelReaderNode channelReaderNode = readers.get(command.channelId());
 
-        channelReaderNode.clientSessions.add(command.clientSession());
-        readers.put(command.channelId(), channelReaderNode);
+        if (channelReaderNode == null) {
+            return this;
+        }
 
-        EntityRef<ChannelEntityCommand> channelEntityRef = findChannelEntityRef(command.channelId());
+        channelReaderNode.readerName = command.readerName();
 
-        channelEntityRef.tell(new RegisterReader(command.readerName(), command.reader()));
+        EntityRef<ChannelEntityCommand> channelEntity = findChannelEntity(command.channelId());
+
+        channelEntity.tell(new RegisterReader(command.readerName(), command.reader()));
         return this;
     }
 
@@ -141,7 +144,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
             if (readerNode.clientSessions.isEmpty()) {
                 getContext().stop(readerNode.reader);
 
-                EntityRef<ChannelEntityCommand> channelEntity = findChannelEntityRef(channelId);
+                EntityRef<ChannelEntityCommand> channelEntity = findChannelEntity(channelId);
                 channelEntity.tell(new RemoveShutdownReader(readerNode.readerName));
             }
         }
@@ -167,25 +170,28 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
             Long channelId,
             ActorRef<ClientSessionCommand> clientSession
     ) {
-        EntityRef<ChannelEntityCommand> chatChannelEntityRef = findChannelEntityRef(channelId);
-        ActorRef<ChannelReaderCommand> chatChannelReaderRef = getContext().spawn(
+        EntityRef<ChannelEntityCommand> channelEntity = findChannelEntity(channelId);
+        ActorRef<ChannelReaderCommand> channelReader = getContext().spawn(
                 Behaviors.supervise(
                         ChannelReaderActor.create(
                                 channelId,
                                 new ChatMessages(),
-                                chatChannelEntityRef,
-                                clientSession,
+                                channelEntity,
                                 getContext().getSelf()
                         )
                 ).onFailure(SupervisorStrategy.restart()),
                 "chat-channel-reader-" + System.nanoTime() + "-" + channelId
         );
 
-        getContext().watch(chatChannelReaderRef);
-        return chatChannelReaderRef;
+        ChannelReaderNode channelReaderNode = new ChannelReaderNode(channelReader);
+
+        channelReaderNode.clientSessions.add(clientSession);
+        readers.put(channelId, channelReaderNode);
+
+        return channelReader;
     }
 
-    private EntityRef<ChannelEntityCommand> findChannelEntityRef(Long channelId) {
+    private EntityRef<ChannelEntityCommand> findChannelEntity(Long channelId) {
         return clusterSharding.entityRefFor(
                 ChannelEntity.ENTITY_TYPE_KEY, String.valueOf(channelId)
         );
@@ -194,12 +200,11 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
     private static class ChannelReaderNode {
 
         private final ActorRef<ChannelReaderCommand> reader;
-        private final String readerName;
         private final List<ActorRef<ClientSessionCommand>> clientSessions = new ArrayList<>();
+        private String readerName;
 
-        private ChannelReaderNode(ActorRef<ChannelReaderCommand> reader, String readerName) {
+        private ChannelReaderNode(ActorRef<ChannelReaderCommand> reader) {
             this.reader = reader;
-            this.readerName = readerName;
         }
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
@@ -11,11 +11,11 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderComm
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +70,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
                                   .onMessage(SpawnedChannelReaderActor.class, this::onSpawnedChannelReaderActor)
                                   .onMessage(ReleaseChannelReaderActor.class, this::onReleaseChannelReaderActor)
                                   .onMessage(ReportUnhealthyChannelReader.class, this::onReportUnhealthyChannelReader)
+                                  .onMessage(ReportUnhealthyClientSession.class, this::onReportUnhealthyClientSession)
                                   .onMessage(HeartBeat.class, this::onHeartBeat)
                                   .build();
     }
@@ -81,7 +82,11 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
                        .collect(
                                Collectors.toMap(
                                        Function.identity(),
-                                       channelId -> findSingletonChannelReaderActor(channelId, command.replyTo())
+                                       channelId -> findSingletonChannelReaderActor(
+                                               command.userId(),
+                                               channelId,
+                                               command.replyTo()
+                                       )
                                )
                        );
 
@@ -111,7 +116,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
                .stream()
                .map(readers::get)
                .filter(Objects::nonNull)
-               .forEach(readerNode -> readerNode.clientSessions.remove(command.clientSession()));
+               .forEach(readerNode -> readerNode.clientSessions.remove(command.userId()));
 
         return this;
     }
@@ -125,8 +130,21 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
             if (unHealthyReaderNode != null) {
                 getContext().stop(unHealthyReaderNode.reader);
                 unHealthyReaderNode.clientSessions
+                        .values()
                         .forEach(clientSession -> clientSession.tell(new UnregisterChannelReader(channelId)));
             }
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderRegistryCommand> onReportUnhealthyClientSession(
+            ReportUnhealthyClientSession command
+    ) {
+        ChannelReaderNode channelReaderNode = readers.get(command.channelId());
+
+        if (channelReaderNode != null) {
+            channelReaderNode.clientSessions.remove(command.userId());
         }
 
         return this;
@@ -153,20 +171,22 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
     }
 
     private ActorRef<ChannelReaderCommand> findSingletonChannelReaderActor(
+            Long userId,
             Long channelId,
             ActorRef<ClientSessionCommand> clientSession
     ) {
         ChannelReaderNode channelReaderNode = readers.get(channelId);
 
         if (channelReaderNode != null) {
-            channelReaderNode.clientSessions.add(clientSession);
+            channelReaderNode.clientSessions.put(userId, clientSession);
             return channelReaderNode.reader;
         }
 
-        return spawnChatChannelReaderActor(channelId, clientSession);
+        return spawnChatChannelReaderActor(userId, channelId, clientSession);
     }
 
     private ActorRef<ChannelReaderCommand> spawnChatChannelReaderActor(
+            Long userId,
             Long channelId,
             ActorRef<ClientSessionCommand> clientSession
     ) {
@@ -185,7 +205,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
 
         ChannelReaderNode channelReaderNode = new ChannelReaderNode(channelReader);
 
-        channelReaderNode.clientSessions.add(clientSession);
+        channelReaderNode.clientSessions.put(userId, clientSession);
         readers.put(channelId, channelReaderNode);
 
         return channelReader;
@@ -200,7 +220,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
     private static class ChannelReaderNode {
 
         private final ActorRef<ChannelReaderCommand> reader;
-        private final List<ActorRef<ClientSessionCommand>> clientSessions = new ArrayList<>();
+        private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions = new HashMap<>();
         private String readerName;
 
         private ChannelReaderNode(ActorRef<ChannelReaderCommand> reader) {
@@ -208,6 +228,6 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
         }
     }
 
-    public record GetChannelReaderActor(List<Long> channelIds, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderRegistryCommand { }
+    public record GetChannelReaderActor(Long userId, List<Long> channelIds, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderRegistryCommand { }
     private record HeartBeat() implements ChannelReaderRegistryCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
@@ -8,22 +8,24 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RegisterReader;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemoveShutdownReader;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromRegistry;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.PongHealthCheck;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.pekko.actor.Cancellable;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
-import org.apache.pekko.actor.typed.Terminated;
+import org.apache.pekko.actor.typed.SupervisorStrategy;
 import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
@@ -33,15 +35,15 @@ import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 
 public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRegistryCommand> {
 
-    public static Behavior<ChannelReaderRegistryCommand> create(ClusterSharding clusterSharding) {
+    public static Behavior<ChannelReaderRegistryCommand> create(
+            ClusterSharding clusterSharding,
+            Duration heartBeatDuration
+    ) {
         return Behaviors.setup(
                 context ->
                         Behaviors.withTimers(
                                 timers -> {
-                                    timers.startTimerWithFixedDelay(
-                                            new HealthCheckHeartBeat(),
-                                            Duration.ofSeconds(30L)
-                                    );
+                                    timers.startTimerWithFixedDelay(new HeartBeat(), heartBeatDuration);
 
                                     return new ChannelReaderRegistryActor(context, clusterSharding);
                                 }
@@ -51,7 +53,6 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
 
     private final ClusterSharding clusterSharding;
     private final Map<Long, ChannelReaderNode> readers;
-    private final Map<Long, Cancellable> healthCheckTimeouts;
 
     public ChannelReaderRegistryActor(
             ActorContext<ChannelReaderRegistryCommand> context,
@@ -61,28 +62,26 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
 
         this.clusterSharding = clusterSharding;
         this.readers = new HashMap<>();
-        this.healthCheckTimeouts = new HashMap<>();
     }
 
     @Override
     public Receive<ChannelReaderRegistryCommand> createReceive() {
-        return newReceiveBuilder().onMessage(GetChannelReaderActorRef.class, this::onGetChannelReaderRef)
+        return newReceiveBuilder().onMessage(GetChannelReaderActor.class, this::onGetChannelReaderRef)
                                   .onMessage(SpawnedChannelReaderActor.class, this::onSpawnedChannelReaderActor)
-                                  .onMessage(HealthCheckHeartBeat.class, this::onHealthCheckHeartBeat)
-                                  .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
-                                  .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
-                                  .onSignal(Terminated.class, this::onTerminated)
+                                  .onMessage(ReleaseChannelReaderActor.class, this::onReleaseChannelReaderActor)
+                                  .onMessage(ReportUnhealthyChannelReader.class, this::onReportUnhealthyChannelReader)
+                                  .onMessage(HeartBeat.class, this::onHeartBeat)
                                   .build();
     }
 
-    private Behavior<ChannelReaderRegistryCommand> onGetChannelReaderRef(GetChannelReaderActorRef command) {
+    private Behavior<ChannelReaderRegistryCommand> onGetChannelReaderRef(GetChannelReaderActor command) {
         Map<Long, ActorRef<ChannelReaderCommand>> chatChannelReaderRefs =
                 command.channelIds()
                        .stream()
                        .collect(
                                Collectors.toMap(
                                        Function.identity(),
-                                       this::findSingletonChannelReaderActorRef
+                                       channelId -> findSingletonChannelReaderActor(channelId, command.replyTo())
                                )
                        );
 
@@ -95,100 +94,90 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
     private Behavior<ChannelReaderRegistryCommand> onSpawnedChannelReaderActor(SpawnedChannelReaderActor command) {
         ChannelReaderNode channelReaderNode = new ChannelReaderNode(command.reader(), command.readerName());
 
+        channelReaderNode.clientSessions.add(command.clientSession());
         readers.put(command.channelId(), channelReaderNode);
 
-        EntityRef<ChannelEntityCommand> chatChannelEntityRef = findChatChannelEntityRef(command.channelId());
+        EntityRef<ChannelEntityCommand> channelEntityRef = findChannelEntityRef(command.channelId());
 
-        chatChannelEntityRef.tell(new RegisterReader(command.readerName(), command.reader()));
+        channelEntityRef.tell(new RegisterReader(command.readerName(), command.reader()));
         return this;
     }
 
-    private Behavior<ChannelReaderRegistryCommand> onHealthCheckHeartBeat(HealthCheckHeartBeat command) {
-        if (readers.isEmpty()) {
-            return this;
-        }
+    private Behavior<ChannelReaderRegistryCommand> onReleaseChannelReaderActor(ReleaseChannelReaderActor command) {
+        command.channelIds()
+               .stream()
+               .map(readers::get)
+               .filter(Objects::nonNull)
+               .forEach(readerNode -> readerNode.clientSessions.remove(command.clientSession()));
 
-        for (Entry<Long, ChannelReaderNode> readerEntry : readers.entrySet()) {
-            Long channelId = readerEntry.getKey();
-            ActorRef<ChannelReaderCommand> readerRef = readerEntry.getValue().reader;
+        return this;
+    }
 
-            readerRef.tell(new PingHealthCheckFromRegistry(getContext().getSelf()));
+    private Behavior<ChannelReaderRegistryCommand> onReportUnhealthyChannelReader(
+            ReportUnhealthyChannelReader command
+    ) {
+        for (Long channelId : command.channelIds()) {
+            ChannelReaderNode unHealthyReaderNode = readers.remove(channelId);
 
-            Cancellable timeoutSchedule = getContext().scheduleOnce(
-                    Duration.ofSeconds(60L),
-                    getContext().getSelf(),
-                    new PongHealthCheckTimeout(channelId)
-            );
-
-            Cancellable oldSchedule = healthCheckTimeouts.put(channelId, timeoutSchedule);
-
-            if (oldSchedule != null) {
-                oldSchedule.cancel();
+            if (unHealthyReaderNode != null) {
+                getContext().stop(unHealthyReaderNode.reader);
+                unHealthyReaderNode.clientSessions
+                        .forEach(clientSession -> clientSession.tell(new UnregisterChannelReader(channelId)));
             }
         }
 
         return this;
     }
 
-    private Behavior<ChannelReaderRegistryCommand> onPongHealthCheck(PongHealthCheck command) {
-        Cancellable schedule = healthCheckTimeouts.remove(command.channelId());
+    private Behavior<ChannelReaderRegistryCommand> onHeartBeat(HeartBeat command) {
+        if (readers.isEmpty()) {
+            return this;
+        }
 
-        if (schedule != null) {
-            schedule.cancel();
+        for (Entry<Long, ChannelReaderNode> readerEntry : readers.entrySet()) {
+            Long channelId = readerEntry.getKey();
+            ChannelReaderNode readerNode = readerEntry.getValue();
+
+            if (readerNode.clientSessions.isEmpty()) {
+                getContext().stop(readerNode.reader);
+
+                EntityRef<ChannelEntityCommand> channelEntity = findChannelEntityRef(channelId);
+                channelEntity.tell(new RemoveShutdownReader(readerNode.readerName));
+            }
         }
 
         return this;
     }
 
-    private Behavior<ChannelReaderRegistryCommand> onPongHealthCheckTimeout(PongHealthCheckTimeout command) {
-        healthCheckTimeouts.remove(command.channelId());
-
-        ChannelReaderNode channelReaderNode = readers.remove(command.channelId());
-
-        if (channelReaderNode != null) {
-            getContext().unwatch(channelReaderNode.reader);
-            getContext().stop(channelReaderNode.reader);
-        }
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderRegistryCommand> onTerminated(Terminated signal) {
-        readers.entrySet()
-               .stream()
-               .filter(entry -> entry.getValue().reader.path().equals(signal.getRef().path()))
-               .map(Map.Entry::getKey)
-               .findFirst()
-               .ifPresent(channelId -> {
-                   ChannelReaderNode channelReaderNode = readers.remove(channelId);
-                   healthCheckTimeouts.remove(channelId);
-
-                   if (channelReaderNode != null) {
-                       EntityRef<ChannelEntityCommand> channelEntityRef = findChatChannelEntityRef(channelId);
-
-                       channelEntityRef.tell(new RemoveShutdownReader(channelReaderNode.readerName));
-                   }
-               });
-
-        return this;
-    }
-
-    private ActorRef<ChannelReaderCommand> findSingletonChannelReaderActorRef(Long channelId) {
+    private ActorRef<ChannelReaderCommand> findSingletonChannelReaderActor(
+            Long channelId,
+            ActorRef<ClientSessionCommand> clientSession
+    ) {
         ChannelReaderNode channelReaderNode = readers.get(channelId);
 
         if (channelReaderNode != null) {
+            channelReaderNode.clientSessions.add(clientSession);
             return channelReaderNode.reader;
         }
 
-        return spawnChatChannelReaderActor(channelId);
+        return spawnChatChannelReaderActor(channelId, clientSession);
     }
 
-    private ActorRef<ChannelReaderCommand> spawnChatChannelReaderActor(Long channelId) {
-        EntityRef<ChannelEntityCommand> chatChannelEntityRef = findChatChannelEntityRef(channelId);
+    private ActorRef<ChannelReaderCommand> spawnChatChannelReaderActor(
+            Long channelId,
+            ActorRef<ClientSessionCommand> clientSession
+    ) {
+        EntityRef<ChannelEntityCommand> chatChannelEntityRef = findChannelEntityRef(channelId);
         ActorRef<ChannelReaderCommand> chatChannelReaderRef = getContext().spawn(
-                ChannelReaderActor.create(
-                        channelId, new ChatMessages(), chatChannelEntityRef, getContext().getSelf()
-                ),
+                Behaviors.supervise(
+                        ChannelReaderActor.create(
+                                channelId,
+                                new ChatMessages(),
+                                chatChannelEntityRef,
+                                clientSession,
+                                getContext().getSelf()
+                        )
+                ).onFailure(SupervisorStrategy.restart()),
                 "chat-channel-reader-" + System.nanoTime() + "-" + channelId
         );
 
@@ -196,7 +185,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
         return chatChannelReaderRef;
     }
 
-    private EntityRef<ChannelEntityCommand> findChatChannelEntityRef(Long channelId) {
+    private EntityRef<ChannelEntityCommand> findChannelEntityRef(Long channelId) {
         return clusterSharding.entityRefFor(
                 ChannelEntity.ENTITY_TYPE_KEY, String.valueOf(channelId)
         );
@@ -206,6 +195,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
 
         private final ActorRef<ChannelReaderCommand> reader;
         private final String readerName;
+        private final List<ActorRef<ClientSessionCommand>> clientSessions = new ArrayList<>();
 
         private ChannelReaderNode(ActorRef<ChannelReaderCommand> reader, String readerName) {
             this.reader = reader;
@@ -213,7 +203,6 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
         }
     }
 
-    public record GetChannelReaderActorRef(List<Long> channelIds, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderRegistryCommand { }
-    private record HealthCheckHeartBeat() implements ChannelReaderRegistryCommand { }
-    private record PongHealthCheckTimeout(Long channelId) implements ChannelReaderRegistryCommand { }
+    public record GetChannelReaderActor(List<Long> channelIds, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderRegistryCommand { }
+    private record HeartBeat() implements ChannelReaderRegistryCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -153,7 +153,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         ActorRef<ChannelReaderCommand> reader = readers.get(command.channelId());
 
         if (reader == null) {
-            readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
+            readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
             pendingRequestHistory.put(command.channelId(), command);
             return this;
         }
@@ -187,7 +187,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onFoundRegisteredChannelIds(FoundRegisteredChannelIds command) {
-        readerRegistry.tell(new GetChannelReaderActor(command.channelIds(), getContext().getSelf()));
+        readerRegistry.tell(new GetChannelReaderActor(userId, command.channelIds(), getContext().getSelf()));
 
         return this;
     }
@@ -243,7 +243,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onSyncJoinChannel(SyncJoinChannel command) {
-        readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
+        readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
         return this;
     }
 
@@ -283,7 +283,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     private Behavior<ClientSessionCommand> onShutdown(Shutdown command) {
         ArrayList<Long> channelIds = new ArrayList<>(readers.keySet());
 
-        readerRegistry.tell(new ReleaseChannelReaderActor(channelIds, getContext().getSelf()));
+        readerRegistry.tell(new ReleaseChannelReaderActor(userId, channelIds));
         readers.values()
                .forEach(reader -> reader.tell(new UnregisterClientSession(userId)));
         readers.clear();

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -1,6 +1,6 @@
 package com.tok.pekko.adapter.out.websocket;
 
-import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActorRef;
+import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
@@ -141,6 +141,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         ActorRef<ChannelReaderCommand> reader = readers.get(command.channelId());
 
         if (reader == null) {
+            readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
             return this;
         }
 
@@ -173,7 +174,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onFoundRegisteredChannelIds(FoundRegisteredChannelIds command) {
-        readerRegistry.tell(new GetChannelReaderActorRef(command.channelIds(), getContext().getSelf()));
+        readerRegistry.tell(new GetChannelReaderActor(command.channelIds(), getContext().getSelf()));
 
         return this;
     }
@@ -211,7 +212,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onSyncJoinChannel(SyncJoinChannel command) {
-        readerRegistry.tell(new GetChannelReaderActorRef(List.of(command.channelId()), getContext().getSelf()));
+        readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
         return this;
     }
 
@@ -266,7 +267,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             getContext().unwatch(readerRef);
         }
 
-        readerRegistry.tell(new GetChannelReaderActorRef(List.of(command.channelId()), getContext().getSelf()));
+        readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
 
         return this;
     }
@@ -298,7 +299,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                            }
 
                            readerRegistry.tell(
-                                   new GetChannelReaderActorRef(List.of(channelId), getContext().getSelf())
+                                   new GetChannelReaderActor(List.of(channelId), getContext().getSelf())
                            );
                        }
                );

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -3,11 +3,13 @@ package com.tok.pekko.adapter.out.websocket;
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
@@ -17,22 +19,24 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.JoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.LeaveChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PongHealthCheck;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.apache.pekko.actor.Cancellable;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
-import org.apache.pekko.actor.typed.Terminated;
 import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
@@ -40,7 +44,11 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
+    private static final long TIMER_DURATION = 190L;
+    private static final int MINIMUM_PING_COUNT = 3;
+
     public static Behavior<ClientSessionCommand> create(
+            Clock clock,
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
@@ -53,10 +61,11 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
                     return Behaviors.withTimers(
                             timers -> {
-                                timers.startTimerAtFixedRate(new HealthCheckHeartBeat(), Duration.ofSeconds(30));
+                                timers.startTimerAtFixedRate(new HeartBeat(), Duration.ofSeconds(TIMER_DURATION));
 
                                 return new ClientSessionActor(
                                         context,
+                                        clock,
                                         userId,
                                         clientMessageSender,
                                         messageStoragePort,
@@ -69,16 +78,19 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         );
     }
 
+    private final Clock clock;
     private final Long userId;
     private final ClientMessageSender clientMessageSender;
     private final MessageStoragePort messageStoragePort;
     private final ChannelMembershipPort channelMembershipPort;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
-    private final Map<Long, Cancellable> healthCheckTimeouts;
+    private final Map<Long, CounterNode> pingCounter;
+    private final Map<Long, RequestHistory> pendingRequestHistory;
 
     private ClientSessionActor(
             ActorContext<ClientSessionCommand> context,
+            Clock clock,
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
@@ -87,13 +99,15 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     ) {
         super(context);
 
+        this.clock = clock;
         this.userId = userId;
         this.messageStoragePort = messageStoragePort;
         this.clientMessageSender = clientMessageSender;
         this.channelMembershipPort = channelMembershipPort;
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
-        this.healthCheckTimeouts = new HashMap<>();
+        this.pingCounter = new HashMap<>();
+        this.pendingRequestHistory = new HashMap<>();
     }
 
     @Override
@@ -111,11 +125,9 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
                                   .onMessage(LeaveChannel.class, this::onLeaveChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
-                                  .onMessage(HealthCheckHeartBeat.class, this::onHealthCheckHeartBeat)
-                                  .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
-                                  .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
+                                  .onMessage(PingHealthCheck.class, this::onPingHealthCheck)
+                                  .onMessage(HeartBeat.class, this::onHeartBeat)
                                   .onMessage(Shutdown.class, this::onShutdown)
-                                  .onSignal(Terminated.class, this::onTerminated)
                                   .build();
     }
 
@@ -142,6 +154,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
         if (reader == null) {
             readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
+            pendingRequestHistory.put(command.channelId(), command);
             return this;
         }
 
@@ -180,28 +193,46 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onUnregisterChannelReader(UnregisterChannelReader command) {
-        healthCheckTimeouts.remove(command.channelId());
+        readers.remove(command.channelId());
+        pingCounter.remove(command.channelId());
+        return this;
+    }
 
-        ActorRef<ChannelReaderCommand> unregisterChannelReader = readers.remove(command.channelId());
+    private Behavior<ClientSessionCommand> onPingHealthCheck(PingHealthCheck command) {
+        CounterNode counterNode = pingCounter.get(command.channelId());
 
-        if (unregisterChannelReader != null) {
-            getContext().unwatch(unregisterChannelReader);
+        if (counterNode != null) {
+            counterNode.pingCount++;
+
+            return this;
         }
 
+        pingCounter.put(command.channelId(), new CounterNode(clock));
+        command.replyTo()
+               .tell(new PongHealthCheck(userId));
         return this;
     }
 
     private Behavior<ClientSessionCommand> onFoundChannelReaders(FoundChannelReaders command) {
-        readers.putAll(command.chatChannelReaderRefs());
+        for (Entry<Long, ActorRef<ChannelReaderCommand>> readerEntry : command.chatChannelReaderRefs().entrySet()) {
+            Long channelId = readerEntry.getKey();
+            ActorRef<ChannelReaderCommand> reader = readerEntry.getValue();
 
-        command.chatChannelReaderRefs()
-               .values()
-               .forEach(
-                       reader -> {
-                           getContext().watch(reader);
-                           reader.tell(new RegisterClientSession(userId, getContext().getSelf()));
-                       }
-               );
+            readers.put(channelId, reader);
+            pingCounter.put(channelId, new CounterNode(clock));
+            reader.tell(new RegisterClientSession(userId, getContext().getSelf()));
+
+            RequestHistory requestHistoryCommand = this.pendingRequestHistory.remove(channelId);
+
+            if (requestHistoryCommand != null) {
+                reader.tell(
+                        new GetHistory(
+                                requestHistoryCommand.messageSequence(),
+                                requestHistoryCommand.size(), getContext().getSelf()
+                        )
+                );
+            }
+        }
 
         return this;
     }
@@ -231,98 +262,59 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         return this;
     }
 
-    private Behavior<ClientSessionCommand> onHealthCheckHeartBeat(HealthCheckHeartBeat command) {
-        if (readers.isEmpty()) {
-            return this;
-        }
+    private Behavior<ClientSessionCommand> onHeartBeat(HeartBeat command) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<Long> unHealthChannelIds = pingCounter.entrySet()
+                                                   .stream()
+                                                   .filter(entry -> entry.getValue().isUnHealthy(now))
+                                                   .map(Entry::getKey)
+                                                   .toList();
 
-        for (Entry<Long, ActorRef<ChannelReaderCommand>> readerEntry : readers.entrySet()) {
-            Long channelId = readerEntry.getKey();
-            ActorRef<ChannelReaderCommand> readerRef = readerEntry.getValue();
-
-            readerRef.tell(new PingHealthCheckFromClientSession(getContext().getSelf()));
-
-            Cancellable timeoutSchedule = getContext().scheduleOnce(
-                    Duration.ofSeconds(60L),
-                    getContext().getSelf(),
-                    new PongHealthCheckTimeout(channelId)
-            );
-
-            Cancellable oldSchedule = healthCheckTimeouts.put(channelId, timeoutSchedule);
-
-            if (oldSchedule != null) {
-                oldSchedule.cancel();
-            }
-        }
-
-        return this;
-    }
-
-    private Behavior<ClientSessionCommand> onPongHealthCheckTimeout(PongHealthCheckTimeout command) {
-        healthCheckTimeouts.remove(command.channelId());
-
-        ActorRef<ChannelReaderCommand> readerRef = readers.remove(command.channelId());
-
-        if (readerRef != null) {
-            getContext().unwatch(readerRef);
-        }
-
-        readerRegistry.tell(new GetChannelReaderActor(List.of(command.channelId()), getContext().getSelf()));
-
-        return this;
-    }
-
-    private Behavior<ClientSessionCommand> onPongHealthCheck(PongHealthCheck command) {
-        Cancellable schedule = healthCheckTimeouts.remove(command.channelId());
-
-        if (schedule != null) {
-            schedule.cancel();
-        }
-
-        return this;
-    }
-
-    private Behavior<ClientSessionCommand> onTerminated(Terminated signal) {
-        readers.entrySet()
-               .stream()
-               .filter(entry -> entry.getValue().path().equals(signal.getRef().path()))
-               .map(Map.Entry::getKey)
-               .findFirst()
-               .ifPresent(
-                       channelId -> {
-                           readers.remove(channelId);
-
-                           Cancellable schedule = healthCheckTimeouts.remove(channelId);
-
-                           if (schedule != null) {
-                               schedule.cancel();
-                           }
-
-                           readerRegistry.tell(
-                                   new GetChannelReaderActor(List.of(channelId), getContext().getSelf())
-                           );
-                       }
-               );
+        readerRegistry.tell(new ReportUnhealthyChannelReader(unHealthChannelIds));
+        unHealthChannelIds.forEach(channelId -> {
+            readers.remove(channelId);
+            pingCounter.remove(channelId);
+        });
+        pingCounter.values().forEach(counterNode -> counterNode.reset(clock));
 
         return this;
     }
 
     private Behavior<ClientSessionCommand> onShutdown(Shutdown command) {
-        readers.values()
-               .forEach(
-                       reader -> {
-                           reader.tell(new UnregisterClientSession(userId));
-                           getContext().unwatch(reader);
-                       });
-        readers.clear();
+        ArrayList<Long> channelIds = new ArrayList<>(readers.keySet());
 
-        healthCheckTimeouts.values().forEach(Cancellable::cancel);
-        healthCheckTimeouts.clear();
+        readerRegistry.tell(new ReleaseChannelReaderActor(channelIds, getContext().getSelf()));
+        readers.values()
+               .forEach(reader -> reader.tell(new UnregisterClientSession(userId)));
+        readers.clear();
+        pingCounter.clear();
+        pendingRequestHistory.clear();
 
         return Behaviors.stopped();
     }
 
+    private static class CounterNode {
+
+        private LocalDateTime readerSpawnedAt;
+        private int pingCount;
+
+        private CounterNode(Clock clock) {
+            this.readerSpawnedAt = LocalDateTime.now(clock);
+            this.pingCount = 0;
+        }
+
+        private boolean isUnHealthy(LocalDateTime now) {
+            long elapsedSeconds = ChronoUnit.SECONDS.between(readerSpawnedAt, now);
+
+            return elapsedSeconds >= TIMER_DURATION && pingCount < MINIMUM_PING_COUNT;
+        }
+
+        private void reset(Clock clock) {
+            this.readerSpawnedAt = LocalDateTime.now(clock);
+            this.pingCount = 0;
+        }
+    }
+
     public record FoundChannelReaders(Map<Long, ActorRef<ChannelReaderCommand>> chatChannelReaderRefs) implements ClientSessionCommand { }
-    private record HealthCheckHeartBeat() implements ClientSessionCommand { }
-    private record PongHealthCheckTimeout(Long channelId) implements ClientSessionCommand { }
+    private record HeartBeat() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -41,7 +41,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
             Long channelId,
             ChatMessages messages,
             EntityRef<ChannelEntityCommand> channelEntity,
-            ActorRef<ClientSessionCommand> clientSession,
             ActorRef<ChannelReaderRegistryCommand> replyTo
     ) {
         return Behaviors.setup(
@@ -51,7 +50,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                     String readerName = context.getSelf().path().address().toString() + "/"
                             + context.getSelf().path().name();
 
-                    replyTo.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName, clientSession));
+                    replyTo.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName));
 
                     return Behaviors.withTimers(
                             timers -> {

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -7,12 +7,12 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderComm
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
@@ -41,7 +41,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
             Long channelId,
             ChatMessages messages,
             EntityRef<ChannelEntityCommand> channelEntity,
-            ActorRef<ChannelReaderRegistryCommand> replyTo
+            ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
         return Behaviors.setup(
                 context -> {
@@ -50,7 +50,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                     String readerName = context.getSelf().path().address().toString() + "/"
                             + context.getSelf().path().name();
 
-                    replyTo.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName));
+                    readerRegistry.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName));
 
                     return Behaviors.withTimers(
                             timers -> {
@@ -61,7 +61,8 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                         context,
                                         channelId,
                                         messages,
-                                        channelEntity
+                                        channelEntity,
+                                        readerRegistry
                                 );
                             }
                     );
@@ -72,6 +73,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private final Long channelId;
     private final ChatMessages messages;
     private final EntityRef<ChannelEntityCommand> channelEntity;
+    private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions;
     private final Map<Long, Cancellable> healthCheckTimeouts;
 
@@ -79,13 +81,15 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
             ActorContext<ChannelReaderCommand> context,
             Long channelId,
             ChatMessages messages,
-            EntityRef<ChannelEntityCommand> channelEntity
+            EntityRef<ChannelEntityCommand> channelEntity,
+            ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
         super(context);
 
         this.channelId = channelId;
         this.messages = messages;
         this.channelEntity = channelEntity;
+        this.readerRegistry = readerRegistry;
         this.clientSessions = new HashMap<>();
         this.healthCheckTimeouts = new HashMap<>();
     }
@@ -95,14 +99,13 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         return newReceiveBuilder().onMessage(SyncNewMessage.class, this::onSyncNewMessage)
                                   .onMessage(SyncUpdate.class, this::onSyncUpdate)
                                   .onMessage(SyncDeletion.class, this::onSyncDeletion)
-                                  .onMessage(SyncMessageHeartBeat.class, this::onHeartBeat)
+                                  .onMessage(SyncMessageHeartBeat.class, this::onSyncMessageHeartBeat)
                                   .onMessage(DeliverSyncMessages.class, this::onDeliverSyncMessages)
                                   .onMessage(GetHistory.class, this::onGetHistory)
                                   .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
                                   .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
                                   .onMessage(UnregisterClientSession.class, this::onUnregisterClientSession)
-                                  .onMessage(Shutdown.class, this::onShutdown)
                                   .onSignal(Terminated.class, this::onTerminated)
                                   .onSignal(PostStop.class, this::onPostStop)
                                   .build();
@@ -151,7 +154,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         return this;
     }
 
-    private Behavior<ChannelReaderCommand> onHeartBeat(SyncMessageHeartBeat command) {
+    private Behavior<ChannelReaderCommand> onSyncMessageHeartBeat(SyncMessageHeartBeat command) {
         channelEntity.tell(new RequestSyncMessages(getContext().getSelf()));
 
         return this;
@@ -187,7 +190,14 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
         if (clientSession != null) {
             getContext().unwatch(clientSession);
+            readerRegistry.tell(new ReportUnhealthyClientSession(command.userId(), command.userId()));
         }
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onUnregisterClientSession(UnregisterClientSession command) {
+        clientSessions.remove(command.userId());
 
         return this;
     }
@@ -199,21 +209,11 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                       .map(Map.Entry::getKey)
                       .findFirst()
                       .ifPresent(userId -> {
-                                  healthCheckTimeouts.remove(userId);
-                                  clientSessions.remove(userId);
-                              });
+                          healthCheckTimeouts.remove(userId);
+                          clientSessions.remove(userId);
+                      });
 
         return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onUnregisterClientSession(UnregisterClientSession command) {
-        clientSessions.remove(command.userId());
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onShutdown(Shutdown command) {
-        return Behaviors.stopped();
     }
 
     private Behavior<ChannelReaderCommand> onPostStop(PostStop signal) {

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -4,7 +4,6 @@ import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
@@ -15,19 +14,16 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.apache.pekko.actor.Cancellable;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
@@ -103,8 +99,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(SyncMessageHeartBeat.class, this::onHeartBeat)
                                   .onMessage(DeliverSyncMessages.class, this::onDeliverSyncMessages)
                                   .onMessage(GetHistory.class, this::onGetHistory)
-                                  .onMessage(PingHealthCheckFromClientSession.class, this::onPingHealthCheckFromClientSession)
-                                  .onMessage(ClientSessionHealthCheckHeartBeat.class, this::onClientSessionHealthCheckHeartBeat)
                                   .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
                                   .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
@@ -170,45 +164,9 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         return this;
     }
 
-    private Behavior<ChannelReaderCommand> onPingHealthCheckFromClientSession(PingHealthCheckFromClientSession command) {
-        command.replyTo()
-               .tell(new ClientSessionProtocol.PongHealthCheck(channelId));
-
-        return this;
-    }
-
     private Behavior<ChannelReaderCommand> onRegisterClientSession(RegisterClientSession command) {
         clientSessions.put(command.userId(), command.clientSession());
         getContext().watch(command.clientSession());
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onClientSessionHealthCheckHeartBeat(
-            ClientSessionHealthCheckHeartBeat command
-    ) {
-        if (clientSessions.isEmpty()) {
-            return this;
-        }
-
-        for (Entry<Long, ActorRef<ClientSessionCommand>> clientSessionEntry : clientSessions.entrySet()) {
-            Long userId = clientSessionEntry.getKey();
-            ActorRef<ClientSessionCommand> clientSession = clientSessionEntry.getValue();
-
-            clientSession.tell(new PingHealthCheck(getContext().getSelf()));
-
-            Cancellable timeoutSchedule = getContext().scheduleOnce(
-                    Duration.ofSeconds(60L),
-                    getContext().getSelf(),
-                    new PongHealthCheckTimeout(userId)
-            );
-
-            Cancellable oldSchedule = healthCheckTimeouts.put(userId, timeoutSchedule);
-
-            if (oldSchedule != null) {
-                oldSchedule.cancel();
-            }
-        }
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -4,7 +4,6 @@ import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromRegistry;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
@@ -14,7 +13,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol;
@@ -47,6 +45,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
             Long channelId,
             ChatMessages messages,
             EntityRef<ChannelEntityCommand> channelEntity,
+            ActorRef<ClientSessionCommand> clientSession,
             ActorRef<ChannelReaderRegistryCommand> replyTo
     ) {
         return Behaviors.setup(
@@ -56,7 +55,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                     String readerName = context.getSelf().path().address().toString() + "/"
                             + context.getSelf().path().name();
 
-                    replyTo.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName));
+                    replyTo.tell(new SpawnedChannelReaderActor(channelId, context.getSelf(), readerName, clientSession));
 
                     return Behaviors.withTimers(
                             timers -> {
@@ -104,7 +103,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(SyncMessageHeartBeat.class, this::onHeartBeat)
                                   .onMessage(DeliverSyncMessages.class, this::onDeliverSyncMessages)
                                   .onMessage(GetHistory.class, this::onGetHistory)
-                                  .onMessage(PingHealthCheckFromRegistry.class, this::onPingHealthCheckFromRegistry)
                                   .onMessage(PingHealthCheckFromClientSession.class, this::onPingHealthCheckFromClientSession)
                                   .onMessage(ClientSessionHealthCheckHeartBeat.class, this::onClientSessionHealthCheckHeartBeat)
                                   .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
@@ -168,13 +166,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     private Behavior<ChannelReaderCommand> onDeliverSyncMessages(DeliverSyncMessages command) {
         this.messages.syncMessages(command.messages());
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onPingHealthCheckFromRegistry(PingHealthCheckFromRegistry command) {
-        command.replyTo()
-               .tell(new ChannelReaderRegistryProtocol.PongHealthCheck(channelId));
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
@@ -1,6 +1,5 @@
 package com.tok.pekko.domain.chat.port.in;
 
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
@@ -15,10 +14,7 @@ public interface ChannelReaderProtocol {
     record SyncDeletion(Long messageId) implements ChannelReaderCommand { }
     record SyncUpdate(Long messageId, String updatedMessage, LocalDateTime updatedAt) implements ChannelReaderCommand { }
     record GetHistory(long messageSequence, int size, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
-    record PingHealthCheckFromRegistry(ActorRef<ChannelReaderRegistryCommand> replyTo) implements ChannelReaderCommand { }
     record RegisterClientSession(Long userId, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderCommand { }
     record UnregisterClientSession(Long userId) implements ChannelReaderCommand { }
-    record PingHealthCheckFromClientSession(ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
     record PongHealthCheck(Long userId) implements ChannelReaderCommand { }
-    record Shutdown() implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
@@ -1,7 +1,6 @@
 package com.tok.pekko.domain.chat.port.out;
 
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import java.util.List;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -11,6 +10,7 @@ public interface ChannelReaderRegistryProtocol {
     interface ChannelReaderRegistryCommand extends CborSerializable { }
 
     record SpawnedChannelReaderActor(Long channelId, ActorRef<ChannelReaderCommand> reader, String readerName) implements ChannelReaderRegistryCommand { }
-    record ReleaseChannelReaderActor(List<Long> channelIds, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderRegistryCommand { }
+    record ReleaseChannelReaderActor(Long userId, List<Long> channelIds) implements ChannelReaderRegistryCommand { }
     record ReportUnhealthyChannelReader(List<Long> channelIds) implements ChannelReaderRegistryCommand { }
+    record ReportUnhealthyClientSession(Long userId, Long channelId) implements ChannelReaderRegistryCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
@@ -10,7 +10,7 @@ public interface ChannelReaderRegistryProtocol {
 
     interface ChannelReaderRegistryCommand extends CborSerializable { }
 
-    record SpawnedChannelReaderActor(Long channelId, ActorRef<ChannelReaderCommand> reader, String readerName, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderRegistryCommand { }
+    record SpawnedChannelReaderActor(Long channelId, ActorRef<ChannelReaderCommand> reader, String readerName) implements ChannelReaderRegistryCommand { }
     record ReleaseChannelReaderActor(List<Long> channelIds, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderRegistryCommand { }
     record ReportUnhealthyChannelReader(List<Long> channelIds) implements ChannelReaderRegistryCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelReaderRegistryProtocol.java
@@ -1,13 +1,16 @@
 package com.tok.pekko.domain.chat.port.out;
 
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
+import java.util.List;
 import org.apache.pekko.actor.typed.ActorRef;
 
 public interface ChannelReaderRegistryProtocol {
 
     interface ChannelReaderRegistryCommand extends CborSerializable { }
 
-    record SpawnedChannelReaderActor(Long channelId, ActorRef<ChannelReaderCommand> reader, String readerName) implements ChannelReaderRegistryCommand { }
-    record PongHealthCheck(Long channelId) implements ChannelReaderRegistryCommand { }
+    record SpawnedChannelReaderActor(Long channelId, ActorRef<ChannelReaderCommand> reader, String readerName, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderRegistryCommand { }
+    record ReleaseChannelReaderActor(List<Long> channelIds, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderRegistryCommand { }
+    record ReportUnhealthyChannelReader(List<Long> channelIds) implements ChannelReaderRegistryCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -22,7 +22,6 @@ public interface ClientSessionProtocol {
     record SyncJoinChannel(Long channelId) implements ClientSessionCommand { }
     record LeaveChannel(Long channelId) implements ClientSessionCommand { }
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
-    record PongHealthCheck(Long channelId) implements ClientSessionCommand { }
-    record PingHealthCheck(ActorRef<ChannelReaderCommand> replyTo) implements ClientSessionCommand { }
+    record PingHealthCheck(Long channelId, ActorRef<ChannelReaderCommand> replyTo) implements ClientSessionCommand { }
     record Shutdown() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -9,6 +9,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCom
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
 import com.tok.pekko.global.common.CborSerializable;
+import java.time.Duration;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
 import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
@@ -31,7 +32,7 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
         ClusterSharding clusterSharding = ClusterSharding.get(context.getSystem());
 
         this.readerRegistry = context.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding),
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(240L)),
                 "channel-reader-registry-actor"
         );
     }

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -9,6 +9,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCom
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
 import com.tok.pekko.global.common.CborSerializable;
+import java.time.Clock;
 import java.time.Duration;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
@@ -20,13 +21,14 @@ import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
 
 public class GuardianActor extends AbstractBehavior<GuardianCommand> {
 
-    private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
-
-    public static Behavior<GuardianCommand> create() {
-        return Behaviors.setup(GuardianActor::new);
+    public static Behavior<GuardianCommand> create(Clock clock) {
+        return Behaviors.setup(context -> new GuardianActor(context, clock));
     }
 
-    private GuardianActor(ActorContext<GuardianCommand> context) {
+    private final Clock clock;
+    private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
+
+    private GuardianActor(ActorContext<GuardianCommand> context, Clock clock) {
         super(context);
 
         ClusterSharding clusterSharding = ClusterSharding.get(context.getSystem());
@@ -35,6 +37,7 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(240L)),
                 "channel-reader-registry-actor"
         );
+        this.clock = clock;
     }
 
     @Override
@@ -46,6 +49,7 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
     private Behavior<GuardianCommand> onSpawnClientSession(SpawnClientSession command) {
         ActorRef<ClientSessionCommand> clientSession = getContext().spawn(
                 ClientSessionActor.create(
+                        clock,
                         command.userId(),
                         command.clientMessageSender(),
                         command.messageStoragePort(),

--- a/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
@@ -28,8 +28,8 @@ import org.springframework.core.env.Environment;
 @RequiredArgsConstructor
 public class ClusterConfig {
 
-    private final Environment environment;
     private final Clock clock;
+    private final Environment environment;
 
     @Bean
     public ClusterSharding clusterSharding(MessageStoragePort messageStoragePort) {
@@ -54,7 +54,7 @@ public class ClusterConfig {
     public ActorSystem<GuardianCommand> actorSystem() {
         Config config = buildConfig();
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(clock),
                 "ChatCluster",
                 config
         );

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -1,19 +1,19 @@
 package com.tok.pekko.adapter.out.websocket;
 
-import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActorRef;
+import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
 import com.tok.pekko.domain.chat.actor.ChatMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RegisterReader;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.PongHealthCheck;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
-import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
@@ -35,7 +35,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -51,8 +50,7 @@ class ChannelReaderRegistryActorTest {
 
     @BeforeAll
     static void setup() {
-        Config config = ConfigFactory.load();
-        testKit = ActorTestKit.create(config);
+        testKit = ActorTestKit.create(ConfigFactory.load());
 
         mockMessageStoragePort = mock(MessageStoragePort.class);
 
@@ -76,17 +74,17 @@ class ChannelReaderRegistryActorTest {
     }
 
     @Test
-    void GetChannelReaderActorRef_메시지를_받으면_새로운_ChatChannelReaderActor를_생성하고_ClientSession에_전달한다() {
+    void GetChannelReaderActor_메시지를_받으면_새로운_ChatChannelReaderActor를_생성하고_ClientSession에_전달한다() {
         // given
         ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         Long channelId = 1L;
 
         // when
         registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
+                new GetChannelReaderActor(
                         List.of(channelId),
                         clientSessionProbe.ref()
                 )
@@ -104,16 +102,16 @@ class ChannelReaderRegistryActorTest {
     }
 
     @Test
-    void GetChannelReaderActorRef_메시지로_같은_채널을_요청하면_이미_생성된_ChatChannelReaderActor를_반환한다() {
+    void GetChannelReaderActor_메시지로_같은_채널을_요청하면_이미_생성된_ChatChannelReaderActor를_반환한다() {
         // given
         ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         Long channelId = 2L;
 
         registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
+                new GetChannelReaderActor(
                         List.of(channelId),
                         clientSessionProbe.ref()
                 )
@@ -131,7 +129,7 @@ class ChannelReaderRegistryActorTest {
                   .pollInterval(java.time.Duration.ofMillis(100))
                   .untilAsserted(() -> {
                       registryActor.tell(
-                              new ChannelReaderRegistryActor.GetChannelReaderActorRef(
+                              new GetChannelReaderActor(
                                       List.of(channelId),
                                       clientSessionProbe.ref()
                               )
@@ -145,118 +143,16 @@ class ChannelReaderRegistryActorTest {
     }
 
     @Test
-    void GetChannelReaderActorRef_메시지로_여러_채널을_요청하면_각_채널별_ChatChannelReaderActor를_생성한다() {
+    void GetChannelReaderActor_메시지를_받았을_때_메시지의_채널_목록이_비어있으면_빈_Map을_반환한다() {
         // given
         ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
-        );
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        Long channelId1 = 3L;
-        Long channelId2 = 4L;
-        Long channelId3 = 5L;
-
-        // when
-        registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
-                        List.of(channelId1, channelId2, channelId3),
-                        clientSessionProbe.ref()
-                )
-        );
-
-        // then
-        FoundChannelReaders actual = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
-                ClientSessionCommand.class,
-                Duration.ofSeconds(5)
-        );
-        assertThat(actual.chatChannelReaderRefs()).containsKeys(channelId1, channelId2, channelId3)
-                                                  .hasSize(3);
-    }
-
-    @Test
-    void PongHealthCheck_메시지를_받으면_해당_채널의_타임아웃_스케줄을_취소한다() {
-        // given
-        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
-        );
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        Long channelId = 6L;
-
-        registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
-                        List.of(channelId),
-                        clientSessionProbe.ref()
-                )
-        );
-        clientSessionProbe.expectMessageClass(
-                ClientSessionCommand.class,
-                Duration.ofSeconds(5)
-        );
-
-        // when
-        registryActor.tell(new PongHealthCheck(channelId));
-
-        // then
-        testKit.createTestProbe().expectNoMessage(Duration.ofMillis(100));
-    }
-
-    @Test
-    void ChatChannelReaderActor가_종료되면_Terminated_신호를_받아_Registry에서_제거한다() {
-        // given
-        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
-        );
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        Long channelId = 7L;
-
-        registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
-                        List.of(channelId),
-                        clientSessionProbe.ref()
-                )
-        );
-        FoundChannelReaders foundReaders = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
-                ClientSessionCommand.class,
-                Duration.ofSeconds(5)
-        );
-        ActorRef<ChannelReaderCommand> readerRef = foundReaders.chatChannelReaderRefs().get(channelId);
-
-        TestProbe<Void> terminationProbe = testKit.createTestProbe();
-
-        // when
-        readerRef.tell(new ChannelReaderProtocol.Shutdown());
-
-        terminationProbe.expectTerminated(readerRef, Duration.ofSeconds(5));
-
-        // then
-        registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
-                        List.of(channelId),
-                        clientSessionProbe.ref()
-                )
-        );
-        FoundChannelReaders newFoundReaders = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
-                ClientSessionCommand.class,
-                Duration.ofSeconds(5)
-        );
-        ActorRef<ChannelReaderCommand> newReaderRef = newFoundReaders.chatChannelReaderRefs().get(channelId);
-
-        assertAll(
-                () -> assertThat(newReaderRef).isNotEqualTo(readerRef),
-                () -> assertThat(newReaderRef.path().name()).startsWith("chat-channel-reader-")
-        );
-    }
-
-    @Test
-    void GetChannelReaderActorRef_메시지를_받았을_때_채널_목록이_비어있으면_빈_Map을_반환한다() {
-        // given
-        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(clusterSharding)
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         // when
         registryActor.tell(
-                new ChannelReaderRegistryActor.GetChannelReaderActorRef(
+                new GetChannelReaderActor(
                         List.of(),
                         clientSessionProbe.ref()
                 )
@@ -271,7 +167,7 @@ class ChannelReaderRegistryActorTest {
     }
 
     @Test
-    void SpawnedChannelReaderActor_메시지를_받으면_readers_맵에_저장하고_RegisterReader_메시지를_ChatChannelEntity에_전송한다() {
+    void SpawnedChannelReaderActor_메시지를_받으면_readers_맵에_저장하고_RegisterReader_메시지를_ChannelEntity에_전송한다() {
         // given
         ClusterSharding mockClusterSharding = mock(ClusterSharding.class);
         @SuppressWarnings("unchecked")
@@ -283,7 +179,7 @@ class ChannelReaderRegistryActorTest {
         Mockito.doNothing().when(mockEntityRef).tell(any(ChannelEntityCommand.class));
 
         ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
-                ChannelReaderRegistryActor.create(mockClusterSharding)
+                ChannelReaderRegistryActor.create(mockClusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderCommand> readerActorProbe = testKit.createTestProbe(ChannelReaderCommand.class);
@@ -295,12 +191,13 @@ class ChannelReaderRegistryActorTest {
                 new SpawnedChannelReaderActor(
                         channelId,
                         readerActorProbe.ref(),
-                        readerName
+                        readerName,
+                        clientSessionProbe.ref()
                 )
         );
 
         // then
-        registryActor.tell(new GetChannelReaderActorRef(List.of(channelId), clientSessionProbe.ref()));
+        registryActor.tell(new GetChannelReaderActor(List.of(channelId), clientSessionProbe.ref()));
 
         FoundChannelReaders actual = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
                 ClientSessionCommand.class,
@@ -317,5 +214,96 @@ class ChannelReaderRegistryActorTest {
         assertThat(capturedCommand)
                 .extracting(RegisterReader::readerName, RegisterReader::reader)
                 .containsExactly(readerName, readerActorProbe.ref());
+    }
+
+    @Test
+    void ReleaseChannelReaderActor_메시지를_받으면_해당_clientSession을_reader의_clientSessions에서_제거한다() {
+        // given
+        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
+        );
+        TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+        Long channelId = 10L;
+
+        registryActor.tell(
+                new GetChannelReaderActor(
+                        List.of(channelId),
+                        clientSessionProbe1.ref()
+                )
+        );
+        clientSessionProbe1.expectMessageClass(ClientSessionCommand.class, Duration.ofSeconds(5));
+
+        registryActor.tell(
+                new GetChannelReaderActor(
+                        List.of(channelId),
+                        clientSessionProbe2.ref()
+                )
+        );
+        clientSessionProbe2.expectMessageClass(ClientSessionCommand.class, Duration.ofSeconds(5));
+
+        // when
+        registryActor.tell(
+                new ReleaseChannelReaderActor(
+                        List.of(channelId),
+                        clientSessionProbe1.ref()
+                )
+        );
+
+        // then
+        Awaitility.await()
+                  .atMost(java.time.Duration.ofSeconds(5))
+                  .pollInterval(java.time.Duration.ofMillis(100))
+                  .untilAsserted(() -> {
+                      TestProbe<ClientSessionCommand> newClientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+                      registryActor.tell(
+                              new GetChannelReaderActor(
+                                      List.of(channelId),
+                                      newClientSessionProbe.ref()
+                              )
+                      );
+                      FoundChannelReaders actual = (FoundChannelReaders) newClientSessionProbe.expectMessageClass(
+                              ClientSessionCommand.class,
+                              Duration.ofSeconds(1)
+                      );
+                      assertThat(actual.chatChannelReaderRefs()).containsKey(channelId);
+                  });
+    }
+
+    @Test
+    void ReportUnhealthyChannelReader_메시지를_받으면_unhealthy_reader를_정지하고_모든_clientSession에_UnregisterChannelReader_메시지를_전송한다() {
+        // given
+        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
+        );
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        Long channelId = 11L;
+
+        registryActor.tell(
+                new GetChannelReaderActor(
+                        List.of(channelId),
+                        clientSessionProbe.ref()
+                )
+        );
+        clientSessionProbe.expectMessageClass(
+                ClientSessionCommand.class,
+                Duration.ofSeconds(5)
+        );
+
+        Awaitility.await()
+                  .atMost(java.time.Duration.ofSeconds(1))
+                  .pollInterval(java.time.Duration.ofMillis(100))
+                  .untilAsserted(() -> {
+                      // when
+                      registryActor.tell(
+                              new ReportUnhealthyChannelReader(List.of(channelId))
+                      );
+
+                      // then
+                      clientSessionProbe.expectMessageClass(
+                              UnregisterChannelReader.class,
+                              Duration.ofSeconds(1)
+                      );
+                  });
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -10,7 +10,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderComm
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -32,12 +31,14 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -173,47 +174,38 @@ class ChannelReaderRegistryActorTest {
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> mockEntityRef = mock(EntityRef.class);
 
-        Mockito.doReturn(mockEntityRef)
-               .when(mockClusterSharding)
-               .entityRefFor(any(), anyString());
-        Mockito.doNothing().when(mockEntityRef).tell(any(ChannelEntityCommand.class));
+        doReturn(mockEntityRef).when(mockClusterSharding).entityRefFor(any(), anyString());
+        doNothing().when(mockEntityRef).tell(any(ChannelEntityCommand.class));
 
         ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
                 ChannelReaderRegistryActor.create(mockClusterSharding, Duration.ofSeconds(30L))
         );
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        TestProbe<ChannelReaderCommand> readerActorProbe = testKit.createTestProbe(ChannelReaderCommand.class);
+
         Long channelId = 100L;
-        String readerName = "test-reader-name";
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         // when
-        registryActor.tell(
-                new SpawnedChannelReaderActor(
-                        channelId,
-                        readerActorProbe.ref(),
-                        readerName,
-                        clientSessionProbe.ref()
-                )
-        );
-
-        // then
         registryActor.tell(new GetChannelReaderActor(List.of(channelId), clientSessionProbe.ref()));
 
-        FoundChannelReaders actual = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
+        FoundChannelReaders foundReaders = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
                 ClientSessionCommand.class,
                 Duration.ofSeconds(5)
         );
-        assertThat(actual.chatChannelReaderRefs()).containsEntry(channelId, readerActorProbe.ref());
+
+        ActorRef<ChannelReaderCommand> actualReaderRef = foundReaders.chatChannelReaderRefs().get(channelId);
+
+        // then
+        assertThat(actualReaderRef).isNotNull();
 
         ArgumentCaptor<ChannelEntityCommand> captor = ArgumentCaptor.forClass(ChannelEntityCommand.class);
 
-        verify(mockEntityRef).tell(captor.capture());
+        verify(mockEntityRef, times(2)).tell(captor.capture());
 
         RegisterReader capturedCommand = (RegisterReader) captor.getValue();
 
         assertThat(capturedCommand)
-                .extracting(RegisterReader::readerName, RegisterReader::reader)
-                .containsExactly(readerName, readerActorProbe.ref());
+                .extracting(RegisterReader::reader)
+                .isEqualTo(actualReaderRef);
     }
 
     @Test

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -10,6 +10,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderComm
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -81,11 +82,13 @@ class ChannelReaderRegistryActorTest {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId = 100L;
         Long channelId = 1L;
 
         // when
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId,
                         List.of(channelId),
                         clientSessionProbe.ref()
                 )
@@ -109,10 +112,12 @@ class ChannelReaderRegistryActorTest {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId = 101L;
         Long channelId = 2L;
 
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId,
                         List.of(channelId),
                         clientSessionProbe.ref()
                 )
@@ -126,11 +131,12 @@ class ChannelReaderRegistryActorTest {
 
         // when & then
         Awaitility.await()
-                  .atMost(java.time.Duration.ofSeconds(5))
-                  .pollInterval(java.time.Duration.ofMillis(100))
+                  .atMost(Duration.ofSeconds(5))
+                  .pollInterval(Duration.ofMillis(100))
                   .untilAsserted(() -> {
                       registryActor.tell(
                               new GetChannelReaderActor(
+                                      userId,
                                       List.of(channelId),
                                       clientSessionProbe.ref()
                               )
@@ -150,10 +156,12 @@ class ChannelReaderRegistryActorTest {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId = 102L;
 
         // when
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId,
                         List.of(),
                         clientSessionProbe.ref()
                 )
@@ -181,11 +189,12 @@ class ChannelReaderRegistryActorTest {
                 ChannelReaderRegistryActor.create(mockClusterSharding, Duration.ofSeconds(30L))
         );
 
+        Long userId = 103L;
         Long channelId = 100L;
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         // when
-        registryActor.tell(new GetChannelReaderActor(List.of(channelId), clientSessionProbe.ref()));
+        registryActor.tell(new GetChannelReaderActor(userId, List.of(channelId), clientSessionProbe.ref()));
 
         FoundChannelReaders foundReaders = (FoundChannelReaders) clientSessionProbe.expectMessageClass(
                 ClientSessionCommand.class,
@@ -216,10 +225,13 @@ class ChannelReaderRegistryActorTest {
         );
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId1 = 104L;
+        Long userId2 = 105L;
         Long channelId = 10L;
 
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId1,
                         List.of(channelId),
                         clientSessionProbe1.ref()
                 )
@@ -228,6 +240,7 @@ class ChannelReaderRegistryActorTest {
 
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId2,
                         List.of(channelId),
                         clientSessionProbe2.ref()
                 )
@@ -237,19 +250,20 @@ class ChannelReaderRegistryActorTest {
         // when
         registryActor.tell(
                 new ReleaseChannelReaderActor(
-                        List.of(channelId),
-                        clientSessionProbe1.ref()
+                        userId1,
+                        List.of(channelId)
                 )
         );
 
         // then
         Awaitility.await()
-                  .atMost(java.time.Duration.ofSeconds(5))
-                  .pollInterval(java.time.Duration.ofMillis(100))
+                  .atMost(Duration.ofSeconds(5))
+                  .pollInterval(Duration.ofMillis(100))
                   .untilAsserted(() -> {
                       TestProbe<ClientSessionCommand> newClientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
                       registryActor.tell(
                               new GetChannelReaderActor(
+                                      userId1,
                                       List.of(channelId),
                                       newClientSessionProbe.ref()
                               )
@@ -269,10 +283,12 @@ class ChannelReaderRegistryActorTest {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
         );
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId = 106L;
         Long channelId = 11L;
 
         registryActor.tell(
                 new GetChannelReaderActor(
+                        userId,
                         List.of(channelId),
                         clientSessionProbe.ref()
                 )
@@ -283,8 +299,8 @@ class ChannelReaderRegistryActorTest {
         );
 
         Awaitility.await()
-                  .atMost(java.time.Duration.ofSeconds(1))
-                  .pollInterval(java.time.Duration.ofMillis(100))
+                  .atMost(Duration.ofSeconds(1))
+                  .pollInterval(Duration.ofMillis(100))
                   .untilAsserted(() -> {
                       // when
                       registryActor.tell(
@@ -298,4 +314,61 @@ class ChannelReaderRegistryActorTest {
                       );
                   });
     }
+
+    @Test
+    void ReportUnhealthyClientSession_메시지를_받으면_해당_userId_clientSession을_reader의_clientSessions에서_제거한다() {
+        // given
+        ActorRef<ChannelReaderRegistryCommand> registryActor = testKit.spawn(
+                ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(30L))
+        );
+        TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+        Long userId1 = 107L;
+        Long userId2 = 108L;
+        Long channelId = 12L;
+
+        registryActor.tell(
+                new GetChannelReaderActor(
+                        userId1,
+                        List.of(channelId),
+                        clientSessionProbe1.ref()
+                )
+        );
+        clientSessionProbe1.expectMessageClass(ClientSessionCommand.class, Duration.ofSeconds(5));
+
+        registryActor.tell(
+                new GetChannelReaderActor(
+                        userId2,
+                        List.of(channelId),
+                        clientSessionProbe2.ref()
+                )
+        );
+        clientSessionProbe2.expectMessageClass(ClientSessionCommand.class, Duration.ofSeconds(5));
+
+        // when
+        registryActor.tell(
+                new ReportUnhealthyClientSession(userId1, channelId)
+        );
+
+        // then
+        Awaitility.await()
+                  .atMost(Duration.ofSeconds(5))
+                  .pollInterval(Duration.ofMillis(100))
+                  .untilAsserted(() -> {
+                      TestProbe<ClientSessionCommand> newClientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+                      registryActor.tell(
+                              new GetChannelReaderActor(
+                                      userId1,
+                                      List.of(channelId),
+                                      newClientSessionProbe.ref()
+                              )
+                      );
+                      FoundChannelReaders actual = (FoundChannelReaders) newClientSessionProbe.expectMessageClass(
+                              ClientSessionCommand.class,
+                              Duration.ofSeconds(1)
+                      );
+                      assertThat(actual.chatChannelReaderRefs()).containsKey(channelId);
+                  });
+    }
+
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -1,6 +1,6 @@
 package com.tok.pekko.adapter.out.websocket;
 
-import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActorRef;
+import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
@@ -192,12 +192,12 @@ class ClientSessionActorTest {
     }
 
     @Test
-    void RequestHistory_메시지를_받을_때_해당_채널_reader가_없으면_아무것도_하지_않는다() {
+    void RequestHistory_메시지를_받을_때_해당_채널_reader가_없으면_readerRegistry에_요청한다() {
         // given
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
-        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
                 ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
@@ -207,7 +207,11 @@ class ClientSessionActorTest {
         clientSessionActor.tell(new RequestHistory(1L, 10L, 5));
 
         // then
-        readerRegistryProbe.expectNoMessage(Duration.ofSeconds(1));
+        GetChannelReaderActor message = readerRegistryProbe.expectMessageClass(
+                GetChannelReaderActor.class,
+                Duration.ofSeconds(1)
+        );
+        assertThat(message.channelIds()).containsExactly(1L);
     }
 
     @Test
@@ -324,7 +328,7 @@ class ClientSessionActorTest {
         clientSessionActor.tell(new FoundRegisteredChannelIds(channelIds));
 
         // then
-        GetChannelReaderActorRef actual = readerRegistryProbe.expectMessageClass(GetChannelReaderActorRef.class);
+        GetChannelReaderActor actual = readerRegistryProbe.expectMessageClass(GetChannelReaderActor.class);
 
         assertThat(actual.channelIds()).containsAll(channelIds);
     }
@@ -395,7 +399,7 @@ class ClientSessionActorTest {
         clientSessionActor.tell(new SyncJoinChannel(7L));
 
         // then
-        GetChannelReaderActorRef actual = readerRegistryProbe.expectMessageClass(GetChannelReaderActorRef.class);
+        GetChannelReaderActor actual = readerRegistryProbe.expectMessageClass(GetChannelReaderActor.class);
 
         assertThat(actual.channelIds()).contains(7L);
     }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -5,6 +5,7 @@ import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReader
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
@@ -18,11 +19,18 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.JoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.LeaveChannel;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
@@ -31,11 +39,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -59,13 +62,14 @@ class ClientSessionActorTest {
     @Test
     void DeliverNewMessage_메시지를_받으면_ClientMessageSender로_채팅_메시지를_전송한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -88,13 +92,14 @@ class ClientSessionActorTest {
     @Test
     void DeliverHistory_메시지를_받으면_ClientMessageSender로_히스토리_메시지들을_전송한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -116,13 +121,14 @@ class ClientSessionActorTest {
     @Test
     void DeliverHistory_메시지로_빈_리스트를_받으면_MessageStoragePort로_히스토리를_조회한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         List<ChatMessage> emptyMessages = List.of();
@@ -139,13 +145,14 @@ class ClientSessionActorTest {
     @Test
     void FoundHistory_메시지를_받으면_ClientMessageSender로_조회된_히스토리를_전송한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -165,13 +172,14 @@ class ClientSessionActorTest {
     @Test
     void RequestHistory_메시지를_받으면_해당_채널의_reader에_GetHistory가_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -194,13 +202,14 @@ class ClientSessionActorTest {
     @Test
     void RequestHistory_메시지를_받을_때_해당_채널_reader가_없으면_readerRegistry에_요청한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -208,8 +217,7 @@ class ClientSessionActorTest {
 
         // then
         GetChannelReaderActor message = readerRegistryProbe.expectMessageClass(
-                GetChannelReaderActor.class,
-                Duration.ofSeconds(1)
+                GetChannelReaderActor.class
         );
         assertThat(message.channelIds()).containsExactly(1L);
     }
@@ -217,33 +225,36 @@ class ClientSessionActorTest {
     @Test
     void Shutdown_메시지를_받으면_액터가_종료된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
+
         TestProbe<Void> terminationProbe = testKit.createTestProbe();
 
         // when
         clientSessionActor.tell(new Shutdown());
 
         // then
-        terminationProbe.expectTerminated(clientSessionActor, Duration.ofSeconds(3));
+        terminationProbe.expectTerminated(clientSessionActor);
     }
 
     @Test
     void 여러_DeliverNewMessage_메시지를_연속으로_받으면_모두_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -269,13 +280,14 @@ class ClientSessionActorTest {
     @Test
     void DeliverDeletedMessage_메시지를_받으면_ClientMessageSender로_삭제된_메시지를_전송한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -291,13 +303,14 @@ class ClientSessionActorTest {
     @Test
     void DeliverUpdatedMessage_메시지를_받으면_ClientMessageSender로_수정된_메시지를_전송한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -313,13 +326,14 @@ class ClientSessionActorTest {
     @Test
     void FoundRegisteredChannelIds_메시지를_받으면_readerRegistry에_GetChannelReaderActorRef가_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         List<Long> channelIds = List.of(1L, 2L, 3L);
@@ -336,13 +350,14 @@ class ClientSessionActorTest {
     @Test
     void FoundChannelReaders_메시지를_받으면_readers에_등록되고_각_reader에_RegisterClientSession이_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
@@ -365,13 +380,14 @@ class ClientSessionActorTest {
     @Test
     void JoinChannel_메시지를_받으면_channelMembershipPort로_채널_가입을_전달한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -386,13 +402,14 @@ class ClientSessionActorTest {
     @Test
     void SyncJoinChannel_메시지를_받으면_readerRegistry에_GetChannelReaderActorRef가_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -407,13 +424,14 @@ class ClientSessionActorTest {
     @Test
     void LeaveChannel_메시지를_받으면_channelMembershipPort에_채널_탈퇴를_전달한다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -428,13 +446,14 @@ class ClientSessionActorTest {
     @Test
     void SyncLeaveChannel_메시지를_받으면_reader에서_제거되고_ChatChannelReaderActor에_UnregisterClientSession이_전송된다() {
         // given
+        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -448,5 +467,56 @@ class ClientSessionActorTest {
 
         // then
         readerProbe.expectMessageClass(UnregisterClientSession.class);
+    }
+
+    @Test
+    void PingHealthCheck_메시지를_받으면_해당_채널의_pingCount가_증가한다() {
+        // given
+        Clock clock = Clock.fixed(Instant.parse("2025-11-04T10:00:00Z"), ZoneId.systemDefault());
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        Map<Long, ActorRef<ChannelReaderCommand>> readers = Map.of(1L, readerProbe.ref());
+
+        clientSessionActor.tell(new FoundChannelReaders(readers));
+        readerProbe.expectMessageClass(RegisterClientSession.class);
+
+        // when
+        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
+        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
+
+        // then
+        readerRegistryProbe.expectNoMessage();
+    }
+
+    @Test
+    void PingHealthCheck_메시지를_받으면_replyTo에게_PongHealthCheck_메시지를_전달한다() {
+        // given
+        Clock clock = Clock.fixed(Instant.parse("2025-11-04T10:00:00Z"), ZoneId.systemDefault());
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+
+        // when
+        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
+
+        // then
+        PongHealthCheck pongMessage = readerProbe.expectMessageClass(PongHealthCheck.class);
+
+        assertThat(pongMessage.userId()).isEqualTo(100L);
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
@@ -7,6 +7,7 @@ import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
@@ -37,7 +38,7 @@ class ClientSessionActorManagementServiceTest {
         config = ConfigFactory.load();
         testKit = ActorTestKit.create(config);
         actorSystem = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(Clock.systemDefaultZone()),
                 "test-system",
                 config
         );

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -64,13 +64,12 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.now();
@@ -113,12 +112,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         long messageSequence = 100L;
@@ -159,12 +157,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         long messageSequence = 10L;
@@ -199,11 +196,10 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         // when
@@ -220,13 +216,12 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         Long messageId = 1L;
@@ -273,13 +268,12 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         Long messageId = 1L;
@@ -327,12 +321,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         Long userId = 100L;
@@ -366,12 +359,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         Long userId = 100L;
@@ -402,12 +394,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
         );
 
         Long userId = 100L;

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -5,7 +5,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromRegistry;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
@@ -14,7 +13,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
@@ -68,12 +66,13 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.now();
@@ -116,11 +115,12 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         long messageSequence = 100L;
@@ -137,12 +137,12 @@ class ChannelReaderActorTest {
         given(mockMessages.getHistory(messageSequence, size)).willReturn(historyMessages);
 
         // when
-        readerActor.tell(new GetHistory(messageSequence, size, clientSessionProbe.ref()));
+        readerActor.tell(new GetHistory(messageSequence, size, replyToProbe.ref()));
 
         // then
         verify(mockMessages, timeout(1000)).getHistory(messageSequence, size);
 
-        DeliverHistory deliveredHistory = clientSessionProbe.expectMessageClass(
+        DeliverHistory deliveredHistory = replyToProbe.expectMessageClass(
                 DeliverHistory.class,
                 Duration.ofSeconds(3)
         );
@@ -161,11 +161,12 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         long messageSequence = 10L;
@@ -173,7 +174,7 @@ class ChannelReaderActorTest {
         given(mockMessages.getHistory(messageSequence, size)).willReturn(List.of());
 
         // when
-        readerActor.tell(new GetHistory(messageSequence, size, clientSessionProbe.ref()));
+        readerActor.tell(new GetHistory(messageSequence, size, replyToProbe.ref()));
 
         // then
         verify(mockMessages, timeout(1000)).getHistory(messageSequence, size);
@@ -200,10 +201,11 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         // when
@@ -220,12 +222,13 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         Long messageId = 1L;
@@ -272,12 +275,13 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         Long messageId = 1L;
@@ -325,17 +329,18 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         Long userId = 100L;
 
         // when
-        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+        readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
         // then
         LocalDateTime timestamp = LocalDateTime.now();
@@ -350,7 +355,7 @@ class ChannelReaderActorTest {
 
         readerActor.tell(new SyncNewMessage(newMessage));
 
-        DeliverNewMessage deliveredMessage = clientSessionProbe.expectMessageClass(
+        DeliverNewMessage deliveredMessage = registeredSessionProbe.expectMessageClass(
                 DeliverNewMessage.class,
                 Duration.ofSeconds(3)
         );
@@ -363,15 +368,16 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         Long userId = 100L;
-        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+        readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
         // when
         readerActor.tell(new UnregisterClientSession(userId));
@@ -389,34 +395,7 @@ class ChannelReaderActorTest {
 
         readerActor.tell(new SyncNewMessage(newMessage));
 
-        clientSessionProbe.expectNoMessage(Duration.ofSeconds(1));
-    }
-
-    @Test
-    void PingHealthCheckFromRegistry_메시지를_받으면_Registry에_PongHealthCheck을_반환한다() {
-        // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
-        @SuppressWarnings("unchecked")
-        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
-
-        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
-        );
-
-        registryProbe.expectMessageClass(
-                ChannelReaderRegistryProtocol.SpawnedChannelReaderActor.class,
-                Duration.ofSeconds(3)
-        );
-
-        // when
-        readerActor.tell(new PingHealthCheckFromRegistry(registryProbe.ref()));
-
-        // then
-        registryProbe.expectMessageClass(
-                ChannelReaderRegistryProtocol.PongHealthCheck.class,
-                Duration.ofSeconds(3)
-        );
+        registeredSessionProbe.expectNoMessage(Duration.ofSeconds(1));
     }
 
     @Test
@@ -425,18 +404,19 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         // when
-        readerActor.tell(new PingHealthCheckFromClientSession(clientSessionProbe.ref()));
+        readerActor.tell(new PingHealthCheckFromClientSession(replyToProbe.ref()));
 
         // then
-        clientSessionProbe.expectMessageClass(
+        replyToProbe.expectMessageClass(
                 ClientSessionProtocol.PongHealthCheck.class,
                 Duration.ofSeconds(3)
         );
@@ -448,15 +428,16 @@ class ChannelReaderActorTest {
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
         TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
 
         ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
         );
 
         Long userId = 100L;
-        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+        readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage newMessage = ChatMessage.create(
@@ -474,7 +455,7 @@ class ChannelReaderActorTest {
         // then
         readerActor.tell(new SyncNewMessage(newMessage));
 
-        DeliverNewMessage actual = clientSessionProbe.expectMessageClass(
+        DeliverNewMessage actual = registeredSessionProbe.expectMessageClass(
                 DeliverNewMessage.class,
                 Duration.ofSeconds(3)
         );

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -7,7 +7,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderComm
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
@@ -191,26 +190,6 @@ class ChannelReaderActorTest {
     }
 
     @Test
-    void Shutdown_메시지를_받으면_ChatChannelReaderActor가_종료된다() {
-        // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
-        @SuppressWarnings("unchecked")
-        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
-
-        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
-        );
-
-        // when
-        readerActor.tell(new Shutdown());
-
-        // then
-        TestProbe<Void> terminationProbe = testKit.createTestProbe();
-        terminationProbe.expectTerminated(readerActor, Duration.ofSeconds(3));
-    }
-
-    @Test
     void SyncDeletion_메시지를_받으면_ChatMessages에서_메시지를_삭제하고_모든_ClientSessionActor에_전달한다() {
         // given
         ChatMessages mockMessages = mock(ChatMessages.class);
@@ -389,7 +368,7 @@ class ChannelReaderActorTest {
     }
 
     @Test
-    void PongHealthCheck_메시지를_받으면_헬스체크_타임아웃이_발생하지_않는다() {
+    void PongHealthCheck_메시지를_받으면_Health_Check_타임아웃이_발생하지_않는다() {
         // given
         ChatMessages mockMessages = mock(ChatMessages.class);
         @SuppressWarnings("unchecked")

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -5,7 +5,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PingHealthCheckFromClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.Shutdown;
@@ -14,7 +13,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
@@ -396,30 +394,6 @@ class ChannelReaderActorTest {
         readerActor.tell(new SyncNewMessage(newMessage));
 
         registeredSessionProbe.expectNoMessage(Duration.ofSeconds(1));
-    }
-
-    @Test
-    void PingHealthCheckFromClientSession_메시지를_받으면_ClientSession에_PongHealthCheck을_반환한다() {
-        // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
-        @SuppressWarnings("unchecked")
-        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
-        TestProbe<ClientSessionCommand> replyToProbe = testKit.createTestProbe(ClientSessionCommand.class);
-
-        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, clientSessionProbe.ref(), registryProbe.ref())
-        );
-
-        // when
-        readerActor.tell(new PingHealthCheckFromClientSession(replyToProbe.ref()));
-
-        // then
-        replyToProbe.expectMessageClass(
-                ClientSessionProtocol.PongHealthCheck.class,
-                Duration.ofSeconds(3)
-        );
     }
 
     @Test

--- a/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
@@ -8,6 +8,7 @@ import com.tok.pekko.global.actor.GuardianActor.SpawnClientSession;
 import com.tok.pekko.global.actor.GuardianActor.SpawnedClientSession;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Clock;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -42,7 +43,7 @@ class GuardianActorTest {
     @BeforeEach
     void beforeEach() {
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(Clock.systemDefaultZone()),
                 "test-system",
                 config
         );
@@ -50,7 +51,7 @@ class GuardianActorTest {
         Cluster cluster = Cluster.get(system);
         cluster.manager().tell(new Join(cluster.selfMember().address()));
 
-        guardianActor = testKit.spawn(GuardianActor.create());
+        guardianActor = testKit.spawn(GuardianActor.create(Clock.systemDefaultZone()));
         responseProbe = testKit.createTestProbe();
     }
 


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #13 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->

- ChannelReaderActor에서만 Health Check를 단방향으로 수행하도록 변경 

### 변경 내용 

#### ChannelReaderActor
- Ping-Pong과 Death Watch로 해당 채널에 참여한 ClientSessionActor 관리
- Unhealthy한 ClientSessionActor를 ChannelReaderRegistryActor에 보고

#### ClientSessionActor
- 직접 Ping-Pong과 Death Watch로 Health Check를 하던 로직 삭제
- 일정 주기마다 ChannelReaderActor의 Ping-Pong 횟수를 카운팅해 기준 이하 횟수라면 Unhealthy 상태로 판단

#### ChannelReaderRegistryActor
- 직접 Ping-Pong과 Death Watch로 ChannelReaderActor에 대한 Health Check를 하던 로직 삭제
- ClientSessionActor에게 Unhealthy한 ChannelReaderActor를 보고하도록 변경
- Unhealthy한 ChannelReaderActor를 ClientSessionActor에게 전파하기 위해 어떤 ClientSessionActor가 ChannelReaderActor를 사용하고 있는지 관리
- Supervisor를 통해 특정 조건을 만족하지 않았다면 반드시 ChannelReaderActor를 유효한 상태로 유지할 수 있도록 변경
- 일정 주기마다 ChannelReaderActor를 사용하는 ClientSessionActor의 수를 카운팅해 사용하고 있는 ClientSessionActor가 없다면 ChannelReaderActor를 종료하도록 변경