### PR TITLE
사용자 및 채널 도메인 기능 추가

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
@@ -1,0 +1,303 @@
+package com.tok.pekko.domain.channel.model;
+
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(of = "channelId")
+public class Channel {
+
+    private final ChannelId channelId;
+    private final String name;
+    private final UserId creatorId;
+    private final ChannelPolicy channelPolicy;
+    private final Map<UserId, ChannelMembership> memberships;
+    private final LocalDateTime createdAt;
+
+    public static Channel create(String name, Long creatorId, ChannelPolicy channelPolicy, LocalDateTime createdAt) {
+        validateName(name);
+
+        return new Channel(
+                ChannelId.EMPTY_CHANNEL_ID,
+                name,
+                UserId.create(creatorId),
+                channelPolicy,
+                new HashMap<>(),
+                createdAt
+        );
+    }
+
+    public static Channel create(
+            Long channelId,
+            String name,
+            Long creatorId,
+            ChannelPolicy channelPolicy,
+            Map<UserId, ChannelMembership> memberships,
+            LocalDateTime createdAt
+    ) {
+        validateName(name);
+
+        return new Channel(
+                ChannelId.create(channelId),
+                name,
+                UserId.create(creatorId),
+                channelPolicy,
+                memberships,
+                createdAt
+        );
+    }
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("채널 이름은 필수입니다.");
+        }
+    }
+
+    private Channel(
+            ChannelId channelId,
+            String name,
+            UserId creatorId,
+            ChannelPolicy channelPolicy,
+            Map<UserId, ChannelMembership> memberships,
+            LocalDateTime createdAt
+    ) {
+        this.channelId = channelId;
+        this.name = name;
+        this.creatorId = creatorId;
+        this.channelPolicy = channelPolicy;
+        this.memberships = memberships;
+        this.createdAt = createdAt;
+    }
+
+    public void joinMember(UserId userId, ChannelRole role, LocalDateTime joinedAt) {
+        if (!channelPolicy.isPublic()) {
+            throw new IllegalArgumentException("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
+        }
+        if (memberships.containsKey(userId)) {
+            throw new IllegalArgumentException("이미 채널에 참여한 사용자입니다.");
+        }
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        memberships.put(userId, membership);
+    }
+
+    public void inviteMember(UserId userId, ChannelRole role, LocalDateTime joinedAt) {
+        if (memberships.containsKey(userId)) {
+            throw new IllegalArgumentException("이미 채널에 참여한 사용자입니다.");
+        }
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+        memberships.put(userId, membership);
+    }
+
+    public void promoteToManager(UserId userId, ChannelManagePermissions permissions) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new IllegalArgumentException("채널 멤버를 찾을 수 없습니다.");
+        }
+
+        ChannelMembership managerChannelMembership = channelMembership.promoteToManager(permissions);
+
+        memberships.put(userId, managerChannelMembership);
+    }
+
+    public void demoteToMember(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (channelMembership.isMember()) {
+            throw new IllegalArgumentException("이미 멤버입니다.");
+        }
+        if (channelMembership.isOwner()) {
+            throw new IllegalArgumentException("오너는 강등할 수 없습니다.");
+        }
+
+        ChannelMembership memberChannelMembership = channelMembership.demoteToMember();
+
+        memberships.put(userId, memberChannelMembership);
+    }
+
+    public void updateManagerPermissions(UserId managerId, ChannelManagePermissions newPermissions) {
+        ChannelMembership channelMembership = memberships.get(managerId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (!channelMembership.isManager()) {
+            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
+        }
+
+        ChannelMembership updatedChannelMembership = channelMembership.updatePermissions(newPermissions);
+
+        memberships.put(managerId, updatedChannelMembership);
+    }
+
+    public void addPermissionToManager(UserId managerId, ChannelPermissionType permission) {
+        ChannelMembership channelMembership = memberships.get(managerId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (!channelMembership.isManager()) {
+            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
+        }
+
+        ChannelMembership updatedChannelMembership = channelMembership.addPermission(permission);
+
+        memberships.put(managerId, updatedChannelMembership);
+    }
+
+    public void removePermissionFromManager(UserId managerId, ChannelPermissionType permission) {
+        ChannelMembership channelMembership = memberships.get(managerId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (!channelMembership.isManager()) {
+            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
+        }
+
+        ChannelMembership updatedChannelMembership = channelMembership.removePermission(permission);
+
+        memberships.put(managerId, updatedChannelMembership);
+    }
+
+    public void leaveMember(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (channelMembership.isOwner()) {
+            throw new IllegalArgumentException("오너는 채널에서 나갈 수 없습니다.");
+        }
+
+        memberships.remove(userId);
+    }
+
+    public boolean canMemberEditMessage(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canEditMessage(channelPolicy);
+    }
+
+    public boolean canMemberDeleteMessage(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canDeleteMessage(channelPolicy);
+    }
+
+    public boolean canUserEditChannelName(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canEditChannelName();
+    }
+
+    public boolean canUserKickMember(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canKickMember();
+    }
+
+    public boolean canUserInviteMember(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canInviteMember();
+    }
+
+    public boolean canUserMemberRoleManagement(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canMemberRoleManagement();
+    }
+
+    public boolean canUserPermissionManagement(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canPermissionManagement();
+    }
+
+    public boolean canUserDeleteChannel(UserId userId) {
+        ChannelMembership channelMembership = memberships.get(userId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        return channelMembership.canDeleteChannel();
+    }
+
+    public Channel changeName(String newName) {
+        validateName(newName);
+
+        return new Channel(
+                this.channelId,
+                newName,
+                this.creatorId,
+                this.channelPolicy,
+                this.memberships,
+                this.createdAt
+        );
+    }
+
+    public Channel changeChannelPolicy(ChannelPolicy channelPolicy) {
+        return new Channel(
+                this.channelId,
+                this.name,
+                this.creatorId,
+                channelPolicy,
+                this.memberships,
+                this.createdAt
+        );
+    }
+
+    public boolean isPublic() {
+        return channelPolicy.isPublic();
+    }
+
+    public static class ChannelMembershipNotFoundException extends IllegalArgumentException {
+
+        public ChannelMembershipNotFoundException() {
+            super("채널 멤버를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
@@ -1,0 +1,264 @@
+package com.tok.pekko.domain.channel.model;
+
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(of = "id")
+public class ChannelMembership {
+
+    private final ChannelMembershipId id;
+    private final UserId userId;
+    private final ChannelRole role;
+    private final ChannelManagePermissions permissions;
+    private final LocalDateTime joinedAt;
+
+    public static ChannelMembership create(UserId userId, ChannelRole role, LocalDateTime joinedAt) {
+        validateUserId(userId);
+
+        return new ChannelMembership(
+                ChannelMembershipId.EMPTY_CHANNEL_MEMBERSHIP_ID,
+                userId,
+                role,
+                createChannelManagePermissions(role),
+                joinedAt
+        );
+    }
+
+    public static ChannelMembership createManager(UserId userId, ChannelManagePermissions permissions, LocalDateTime joinedAt) {
+        validateUserId(userId);
+
+        return new ChannelMembership(
+                ChannelMembershipId.EMPTY_CHANNEL_MEMBERSHIP_ID,
+                userId,
+                ChannelRole.MANAGER,
+                permissions,
+                joinedAt
+        );
+    }
+
+    private static ChannelManagePermissions createChannelManagePermissions(ChannelRole role) {
+        if (role.isMember()) {
+            return ChannelManagePermissions.ofMember();
+        }
+        if (role.isOwner()) {
+            return ChannelManagePermissions.ofOwner();
+        }
+
+        return ChannelManagePermissions.ofManager();
+    }
+
+    public static ChannelMembership create(
+            Long id,
+            Long userId,
+            ChannelRole role,
+            ChannelManagePermissions channelManagePermissions,
+            LocalDateTime joinedAt
+    ) {
+        return new ChannelMembership(
+                ChannelMembershipId.create(id),
+                UserId.create(userId),
+                role,
+                channelManagePermissions,
+                joinedAt
+        );
+    }
+
+    private static void validateUserId(UserId userId) {
+        if (userId == null || userId == UserId.EMPTY_USER_ID) {
+            throw new IllegalArgumentException("사용자 ID는 필수입니다.");
+        }
+    }
+
+    private ChannelMembership(
+            ChannelMembershipId id,
+            UserId userId,
+            ChannelRole role,
+            ChannelManagePermissions permissions,
+            LocalDateTime joinedAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.role = role;
+        this.permissions = permissions;
+        this.joinedAt = joinedAt;
+    }
+
+    public ChannelMembership withAssignedId(Long id) {
+        return new ChannelMembership(
+                ChannelMembershipId.create(id),
+                this.userId,
+                this.role,
+                this.permissions,
+                this.joinedAt
+        );
+    }
+
+    public ChannelMembership updatePermissions(ChannelManagePermissions newPermissions) {
+        validateRole(this.role);
+
+        return new ChannelMembership(this.id, this.userId, this.role, newPermissions, this.joinedAt);
+    }
+
+    public ChannelMembership promoteToManager(ChannelManagePermissions permissions) {
+        return new ChannelMembership(this.id, this.userId, ChannelRole.MANAGER, permissions, this.joinedAt);
+    }
+
+    public ChannelMembership demoteToMember() {
+        return new ChannelMembership(
+                this.id,
+                this.userId,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                this.joinedAt
+        );
+    }
+
+    public ChannelMembership addPermission(ChannelPermissionType permission) {
+        validateRole(this.role);
+
+        return new ChannelMembership(this.id, this.userId, this.role, this.permissions.add(permission), this.joinedAt);
+    }
+
+    public ChannelMembership removePermission(ChannelPermissionType permission) {
+        validateRole(this.role);
+
+        return new ChannelMembership(
+                this.id,
+                this.userId,
+                this.role,
+                this.permissions.remove(permission),
+                this.joinedAt
+        );
+    }
+
+    public ChannelMembership changeRole(ChannelRole newRole, Set<ChannelPermissionType> newPermissions) {
+        return new ChannelMembership(
+                this.id,
+                this.userId,
+                newRole,
+                createChannelManagePermissions(newRole, newPermissions),
+                this.joinedAt
+        );
+    }
+
+    private ChannelManagePermissions createChannelManagePermissions(
+            ChannelRole newRole,
+            Set<ChannelPermissionType> newPermissions
+    ) {
+        if (newRole.isMember()) {
+            return ChannelManagePermissions.ofMember();
+        }
+        if (newRole.isOwner()) {
+            return ChannelManagePermissions.ofOwner();
+        }
+        if (newPermissions.isEmpty()) {
+            return ChannelManagePermissions.ofManager();
+        }
+
+        return ChannelManagePermissions.ofManager(newPermissions);
+    }
+
+    public boolean hasPermission(ChannelPermissionType permission) {
+        if (this.role.isOwner()) {
+            return true;
+        }
+        if (this.role.isManager()) {
+            return permissions.has(permission);
+        }
+
+        return false;
+    }
+
+    public boolean canEditChannelName() {
+        if (this.role.isOwner()) {
+            return true;
+        }
+
+        return this.role.isManager() && permissions.has(ChannelPermissionType.EDIT_CHANNEL_NAME);
+    }
+
+    public boolean canKickMember() {
+        if (this.role.isOwner()) {
+            return true;
+        }
+
+        return this.role.isManager() && permissions.has(ChannelPermissionType.MEMBER_KICK);
+    }
+
+    public boolean canDeleteMessage(ChannelPolicy policy) {
+        if (this.role.isOwner()) {
+            return true;
+        }
+        if (this.role.isManager()) {
+            return permissions.has(ChannelPermissionType.MESSAGE_DELETE);
+        }
+        if (this.role.isMember()) {
+            return policy.canDeleteOwnMessage();
+        }
+
+        return false;
+    }
+
+    public boolean canEditMessage(ChannelPolicy policy) {
+        if (this.role.isOwner()) {
+            return true;
+        }
+        if (this.role.isManager()) {
+            return permissions.has(ChannelPermissionType.MESSAGE_EDIT);
+        }
+        if (this.role.isMember()) {
+            return policy.canEditOwnMessage();
+        }
+
+        return false;
+    }
+
+    public boolean canInviteMember() {
+        if (this.role.isOwner()) {
+            return true;
+        }
+
+        return this.role.isManager() && permissions.has(ChannelPermissionType.MEMBER_INVITE);
+    }
+
+    public boolean canMemberRoleManagement() {
+        return this.role.isOwner();
+    }
+
+    public boolean canPermissionManagement() {
+        return this.role.isOwner();
+    }
+
+    public boolean canDeleteChannel() {
+        return this.role.isOwner();
+    }
+
+    public boolean canChangeChannelPolicy() {
+        return this.role.isOwner();
+    }
+
+    public boolean isManager() {
+        return this.role.isManager();
+    }
+
+    public boolean isMember() {
+        return this.role.isMember();
+    }
+
+    public boolean isOwner() {
+        return this.role.isOwner();
+    }
+
+    private void validateRole(ChannelRole role) {
+        if (role.isOwner() || role.isMember()) {
+            throw new IllegalArgumentException("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
+        }
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelPermissionType.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelPermissionType.java
@@ -1,0 +1,21 @@
+package com.tok.pekko.domain.channel.model;
+
+import lombok.Getter;
+
+@Getter
+public enum ChannelPermissionType {
+
+    EDIT_CHANNEL_NAME("채널 이름 변경"),
+
+    MESSAGE_EDIT("메시지 수정"),
+    MESSAGE_DELETE("메시지 삭제"),
+
+    MEMBER_INVITE("멤버 초대"),
+    MEMBER_KICK("멤버 강퇴");
+
+    private final String description;
+
+    ChannelPermissionType(String description) {
+        this.description = description;
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelRole.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelRole.java
@@ -1,0 +1,26 @@
+package com.tok.pekko.domain.channel.model;
+
+import java.util.Arrays;
+
+public enum ChannelRole {
+    OWNER, MANAGER, MEMBER;
+
+    public static ChannelRole find(String name) {
+        return Arrays.stream(ChannelRole.values())
+                     .filter(role -> role.name().equalsIgnoreCase(name))
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할 입니다."));
+    }
+
+    public boolean isOwner() {
+        return this == ChannelRole.OWNER;
+    }
+
+    public boolean isManager() {
+        return this == ChannelRole.MANAGER;
+    }
+
+    public boolean isMember() {
+        return this == ChannelRole.MEMBER;
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelId.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelId.java
@@ -1,0 +1,33 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class ChannelId {
+
+    public static final ChannelId EMPTY_CHANNEL_ID = new ChannelId(null);
+
+    private final Long value;
+
+    public static ChannelId create(Long value) {
+        validateValue(value);
+
+        return new ChannelId(value);
+    }
+
+    private static void validateValue(Long value) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("채널 ID는 양수여야 합니다.");
+        }
+    }
+
+    private ChannelId(Long value) {
+        this.value = value;
+    }
+
+    public boolean isEqualId(Long id) {
+        return this.value.equals(id);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissions.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissions.java
@@ -1,0 +1,75 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public class ChannelManagePermissions {
+
+    private final Set<ChannelPermissionType> permissions;
+
+    public static ChannelManagePermissions ofOwner() {
+        return new ChannelManagePermissions(EnumSet.noneOf(ChannelPermissionType.class));
+    }
+
+    public static ChannelManagePermissions ofManager() {
+        return new ChannelManagePermissions(EnumSet.of(ChannelPermissionType.MESSAGE_EDIT));
+    }
+
+    public static ChannelManagePermissions ofManager(Set<ChannelPermissionType> permissions) {
+        if (permissions.isEmpty()) {
+            return ChannelManagePermissions.ofManager();
+        }
+
+        return new ChannelManagePermissions(permissions);
+    }
+
+    public static ChannelManagePermissions ofMember() {
+        return new ChannelManagePermissions(EnumSet.noneOf(ChannelPermissionType.class));
+    }
+
+    private ChannelManagePermissions(Set<ChannelPermissionType> permissions) {
+        this.permissions = permissions;
+    }
+
+    public boolean has(ChannelPermissionType permission) {
+        return permissions.contains(permission);
+    }
+
+    public boolean hasAll(Set<ChannelPermissionType> perms) {
+        return permissions.containsAll(perms);
+    }
+
+    public boolean hasAny(Set<ChannelPermissionType> perms) {
+        return perms.stream().anyMatch(permissions::contains);
+    }
+
+    public ChannelManagePermissions add(ChannelPermissionType permission) {
+        Set<ChannelPermissionType> newPermissions = EnumSet.copyOf(permissions);
+
+        newPermissions.add(permission);
+        return new ChannelManagePermissions(newPermissions);
+    }
+
+    public ChannelManagePermissions remove(ChannelPermissionType permission) {
+        Set<ChannelPermissionType> newPermissions = EnumSet.copyOf(permissions);
+
+        newPermissions.remove(permission);
+        return new ChannelManagePermissions(newPermissions);
+    }
+
+    public Set<ChannelPermissionType> getAll() {
+        return Collections.unmodifiableSet(EnumSet.copyOf(permissions));
+    }
+
+    public int size() {
+        return permissions.size();
+    }
+
+    public boolean isEmpty() {
+        return permissions.isEmpty();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelMembershipId.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelMembershipId.java
@@ -1,0 +1,33 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class ChannelMembershipId {
+
+    public static final ChannelMembershipId EMPTY_CHANNEL_MEMBERSHIP_ID = new ChannelMembershipId(null);
+
+    private final Long value;
+
+    public static ChannelMembershipId create(Long value) {
+        validateValue(value);
+
+        return new ChannelMembershipId(value);
+    }
+
+    private static void validateValue(Long value) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("채널 참여자 ID는 양수여야 합니다.");
+        }
+    }
+
+    private ChannelMembershipId(Long value) {
+        this.value = value;
+    }
+
+    public boolean isEqualId(Long id) {
+        return this.value.equals(id);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
@@ -1,16 +1,20 @@
 package com.tok.pekko.domain.channel.model.vo;
 
-public record ChannelPolicy(boolean canEditOwnMessage, boolean canDeleteOwnMessage) {
+public record ChannelPolicy(boolean canEditOwnMessage, boolean canDeleteOwnMessage, boolean isPublic) {
 
     public static ChannelPolicy defaultPolicy() {
-        return new ChannelPolicy(true, true);
+        return new ChannelPolicy(true, true, true);
     }
 
     public ChannelPolicy updateEditOwnMessage(boolean canEdit) {
-        return new ChannelPolicy(canEdit, this.canDeleteOwnMessage);
+        return new ChannelPolicy(canEdit, this.canDeleteOwnMessage, this.isPublic);
     }
 
     public ChannelPolicy updateDeleteOwnMessage(boolean canDelete) {
-        return new ChannelPolicy(this.canEditOwnMessage, canDelete);
+        return new ChannelPolicy(this.canEditOwnMessage, canDelete, this.isPublic);
+    }
+
+    public ChannelPolicy updatePublic(boolean isPublic) {
+        return new ChannelPolicy(this.canEditOwnMessage, this.canDeleteOwnMessage, isPublic);
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
@@ -1,0 +1,16 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+public record ChannelPolicy(boolean canEditOwnMessage, boolean canDeleteOwnMessage) {
+
+    public static ChannelPolicy defaultPolicy() {
+        return new ChannelPolicy(true, true);
+    }
+
+    public ChannelPolicy updateEditOwnMessage(boolean canEdit) {
+        return new ChannelPolicy(canEdit, this.canDeleteOwnMessage);
+    }
+
+    public ChannelPolicy updateDeleteOwnMessage(boolean canDelete) {
+        return new ChannelPolicy(this.canEditOwnMessage, canDelete);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/user/model/RegistrationId.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/user/model/RegistrationId.java
@@ -1,0 +1,21 @@
+package com.tok.pekko.domain.user.model;
+
+import java.util.Arrays;
+
+public enum RegistrationId {
+
+    KAKAO("kakao");
+
+    private final String name;
+
+    RegistrationId(String name) {
+        this.name = name;
+    }
+
+    public static RegistrationId findBy(String name) {
+        return Arrays.stream(RegistrationId.values())
+                     .filter(id -> id.name.equalsIgnoreCase(name))
+                     .findAny()
+                     .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 소셜 로그인 서비스입니다."));
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/user/model/User.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/user/model/User.java
@@ -1,0 +1,32 @@
+package com.tok.pekko.domain.user.model;
+
+import com.tok.pekko.domain.user.model.vo.UserId;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(of = "id")
+public class User {
+
+    private final UserId id;
+    private final RegistrationId registrationId;
+    private final String socialId;
+
+    public static User create(RegistrationId registrationId, String socialId) {
+        return new User(UserId.EMPTY_USER_ID, registrationId, socialId);
+    }
+
+    public static User create(Long id, RegistrationId registrationId, String socialId) {
+        return new User(UserId.create(id), registrationId, socialId);
+    }
+
+    private User(UserId id, RegistrationId registrationId, String socialId) {
+        this.id = id;
+        this.registrationId = registrationId;
+        this.socialId = socialId;
+    }
+
+    public User withAssignedId(Long id) {
+        return new User(UserId.create(id), this.registrationId, this.socialId);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/user/model/vo/UserId.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/user/model/vo/UserId.java
@@ -1,0 +1,33 @@
+package com.tok.pekko.domain.user.model.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class UserId {
+
+    public static final UserId EMPTY_USER_ID = new UserId(null);
+
+    private final Long value;
+
+    public static UserId create(Long value) {
+        validateValue(value);
+
+        return new UserId(value);
+    }
+
+    private static void validateValue(Long value) {
+        if (value == null || value <= 0) {
+            throw new IllegalArgumentException("사용자 ID는 양수여야 합니다.");
+        }
+    }
+
+    private UserId(Long value) {
+        this.value = value;
+    }
+
+    public boolean isEqualId(Long id) {
+        return this.value.equals(id);
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
@@ -356,7 +356,7 @@ class ChannelMembershipTest {
     @Test
     void 오너는_모든_권한을_가진다() {
         // given
-        ChannelPolicy channelPolicy = new ChannelPolicy(false, false);
+        ChannelPolicy channelPolicy = new ChannelPolicy(false, false, false);
 
         // when
         ChannelMembership membership = ChannelMembership.create(
@@ -408,7 +408,7 @@ class ChannelMembershipTest {
                 ChannelRole.MANAGER,
                 LocalDateTime.now()
         );
-        ChannelPolicy policy = new ChannelPolicy(true, true);
+        ChannelPolicy policy = new ChannelPolicy(true, true, true);
 
         // when & then
         assertThat(membership.canDeleteMessage(policy)).isFalse();
@@ -422,8 +422,8 @@ class ChannelMembershipTest {
                 ChannelRole.MEMBER,
                 LocalDateTime.now()
         );
-        ChannelPolicy allowPolicy = new ChannelPolicy(true, true);
-        ChannelPolicy denyPolicy = new ChannelPolicy(true, false);
+        ChannelPolicy allowPolicy = new ChannelPolicy(true, true, true);
+        ChannelPolicy denyPolicy = new ChannelPolicy(true, false, true);
 
         // when & then
         assertAll(
@@ -440,8 +440,8 @@ class ChannelMembershipTest {
                 ChannelRole.MEMBER,
                 LocalDateTime.now()
         );
-        ChannelPolicy allowPolicy = new ChannelPolicy(true, false);
-        ChannelPolicy denyPolicy = new ChannelPolicy(false, true);
+        ChannelPolicy allowPolicy = new ChannelPolicy(true, false, true);
+        ChannelPolicy denyPolicy = new ChannelPolicy(false, true, true);
 
         // when & then
         assertAll(

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
@@ -1,0 +1,667 @@
+package com.tok.pekko.domain.channel.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelMembershipTest {
+
+    @Test
+    void 유효한_값으로_채널_참여자를_초기화할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(membership).isNotNull(),
+                () -> assertThat(membership.getId()).isEqualTo(ChannelMembershipId.EMPTY_CHANNEL_MEMBERSHIP_ID),
+                () -> assertThat(membership.getUserId()).isEqualTo(userId),
+                () -> assertThat(membership.getRole()).isEqualTo(role),
+                () -> assertThat(membership.getJoinedAt()).isEqualTo(joinedAt)
+        );
+    }
+
+    @Test
+    void null_사용자_ID로는_채널_참여자를_초기화할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> ChannelMembership.create(null, ChannelRole.MEMBER, LocalDateTime.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자 ID는 필수입니다.");
+    }
+
+    @Test
+    void 비어_있는_사용자_ID로는_채널_참여자를_초기화할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> ChannelMembership.create(UserId.EMPTY_USER_ID, ChannelRole.MEMBER, LocalDateTime.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자 ID는 필수입니다.");
+    }
+
+    @Test
+    void 멤버_역할로_초기화하면_아무_권한도_가지지_못한다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.getPermissions().isEmpty()).isTrue();
+    }
+
+    @Test
+    void 오너_역할로_초기화하면_모든_권한이_기본적으로_부여되므로_아무_권한도_가지지_않는다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.OWNER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.getPermissions().isEmpty()).isTrue();
+    }
+
+    @Test
+    void 매니저_역할로_초기화하면_메시지_수정_권한을_가진다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue();
+    }
+
+    @Test
+    void 매니저_역할로_명시적_권한을_지정해_초기화할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+        Set<ChannelPermissionType> perms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+
+        // when
+        ChannelMembership membership = ChannelMembership.createManager(userId, permissions, joinedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(membership.getRole()).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
+    }
+
+    @Test
+    void 영속화된_채널_참여자를_초기화할_수_있다() {
+        // given
+        Long memberId = 100L;
+        Long userId = 1L;
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        Set<ChannelPermissionType> perms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+
+        // when
+        ChannelMembership membership = ChannelMembership.create(memberId, userId, role, permissions, joinedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(membership.getId()).isEqualTo(ChannelMembershipId.create(memberId)),
+                () -> assertThat(membership.getUserId()).isEqualTo(UserId.create(userId)),
+                () -> assertThat(membership.getRole()).isEqualTo(role),
+                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue()
+        );
+    }
+
+    @Test
+    void 같은_채널_참여자_ID를_가진_채널_참여자는_동등하다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership1 = ChannelMembership.create(1L, userId.getValue(), ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(), joinedAt);
+        ChannelMembership membership2 = ChannelMembership.create(1L, userId.getValue(), ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(), joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(membership1).isEqualTo(membership2),
+                () -> assertThat(membership1).hasSameHashCodeAs(membership2)
+        );
+    }
+
+    @Test
+    void 다른_채널_참여자_ID를_가진_채널_참여자는_동등하지_않다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership1 = ChannelMembership.create(1L, userId.getValue(), role,
+                ChannelManagePermissions.ofMember(), joinedAt);
+        ChannelMembership membership2 = ChannelMembership.create(2L, userId.getValue(), role,
+                ChannelManagePermissions.ofMember(), joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(membership1).isNotEqualTo(membership2),
+                () -> assertThat(membership1).doesNotHaveSameHashCodeAs(membership2)
+        );
+    }
+
+    @Test
+    void 채널_참여자에게_ID를_할당할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+        Long assignedId = 100L;
+
+        // when
+        ChannelMembership actual = membership.withAssignedId(assignedId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getId()).isEqualTo(ChannelMembershipId.create(assignedId)),
+                () -> assertThat(actual.getUserId()).isEqualTo(userId),
+                () -> assertThat(actual.getRole()).isEqualTo(role),
+                () -> assertThat(actual.getJoinedAt()).isEqualTo(joinedAt)
+        );
+    }
+
+    @Test
+    void 매니저에게는_권한을_업데이트할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+        Set<ChannelPermissionType> newPerms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager(newPerms);
+
+        // when
+        ChannelMembership updatedMembership = membership.updatePermissions(newPermissions);
+
+        // then
+        assertThat(updatedMembership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue();
+    }
+
+    @Test
+    void 멤버에게는_권한을_업데이트할_수_없다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager();
+
+        // when & then
+        assertThatThrownBy(() -> membership.updatePermissions(newPermissions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
+    }
+
+    @Test
+    void 오너에게는_권한을_업데이트할_수_없다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager();
+
+        // when & then
+        assertThatThrownBy(() -> membership.updatePermissions(newPermissions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
+    }
+
+    @Test
+    void 매니저에게는_권한을_추가할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        // when
+        ChannelMembership addedMembership = membership.addPermission(ChannelPermissionType.MEMBER_KICK);
+
+        // then
+        assertThat(addedMembership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue();
+    }
+
+    @Test
+    void 멤버에게는_권한을_추가할_수_없다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> membership.addPermission(ChannelPermissionType.MESSAGE_EDIT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
+    }
+
+    @Test
+    void 매니저에게는_권한을_제거할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        // when
+        ChannelMembership removedMembership = membership.removePermission(ChannelPermissionType.MESSAGE_EDIT);
+
+        // then
+        assertThat(removedMembership.getPermissions().isEmpty()).isTrue();
+    }
+
+    @Test
+    void 멤버는_권한을_제거할_수_없다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> membership.removePermission(ChannelPermissionType.MESSAGE_EDIT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
+    }
+
+    @Test
+    void 매니저_역할을_멤버_역할로_변경할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole oldRole = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, oldRole, joinedAt);
+
+        // when
+        ChannelMembership changedMembership = membership.changeRole(ChannelRole.MEMBER, EnumSet.noneOf(ChannelPermissionType.class));
+
+        // then
+        assertThat(changedMembership.getRole()).isEqualTo(ChannelRole.MEMBER);
+    }
+
+    @Test
+    void 멤버_역할을_매니저_역할로_변경하면서_권한을_지정할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        ChannelRole oldRole = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership membership = ChannelMembership.create(userId, oldRole, joinedAt);
+        Set<ChannelPermissionType> newPermissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+
+        // when
+        ChannelMembership changedMembership = membership.changeRole(ChannelRole.MANAGER, newPermissions);
+
+        // then
+        assertAll(
+                () -> assertThat(changedMembership.getRole()).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(changedMembership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_모든_권한을_가진다() {
+        // given
+        ChannelPolicy channelPolicy = new ChannelPolicy(false, false);
+
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.OWNER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.EDIT_CHANNEL_NAME)).isTrue(),
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MESSAGE_DELETE)).isTrue(),
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MEMBER_INVITE)).isTrue(),
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue(),
+                () -> assertThat(membership.canEditChannelName()).isTrue(),
+                () -> assertThat(membership.canKickMember()).isTrue(),
+                () -> assertThat(membership.canDeleteMessage(channelPolicy)).isTrue(),
+                () -> assertThat(membership.canEditMessage(channelPolicy)).isTrue(),
+                () -> assertThat(membership.canInviteMember()).isTrue(),
+                () -> assertThat(membership.canMemberRoleManagement()).isTrue(),
+                () -> assertThat(membership.canPermissionManagement()).isTrue(),
+                () -> assertThat(membership.canDeleteChannel()).isTrue(),
+                () -> assertThat(membership.canChangeChannelPolicy()).isTrue()
+        );
+    }
+
+    @Test
+    void 매니저는_가진_권한만_반영된다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(membership.hasPermission(ChannelPermissionType.MESSAGE_DELETE)).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_메시지_삭제_권한이_있어야_메시지_삭제가_가능하다() {
+        // given
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+        ChannelPolicy policy = new ChannelPolicy(true, true);
+
+        // when & then
+        assertThat(membership.canDeleteMessage(policy)).isFalse();
+    }
+
+    @Test
+    void 멤버는_채널_정책에_따라_자신의_메시지만_삭제할_수_있다() {
+        // given
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        ChannelPolicy allowPolicy = new ChannelPolicy(true, true);
+        ChannelPolicy denyPolicy = new ChannelPolicy(true, false);
+
+        // when & then
+        assertAll(
+                () -> assertThat(membership.canDeleteMessage(allowPolicy)).isTrue(),
+                () -> assertThat(membership.canDeleteMessage(denyPolicy)).isFalse()
+        );
+    }
+
+    @Test
+    void 멤버는_채널_정책에_따라_자신의_메시지만_수정할_수_있다() {
+        // given
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        ChannelPolicy allowPolicy = new ChannelPolicy(true, false);
+        ChannelPolicy denyPolicy = new ChannelPolicy(false, true);
+
+        // when & then
+        assertAll(
+                () -> assertThat(membership.canEditMessage(allowPolicy)).isTrue(),
+                () -> assertThat(membership.canEditMessage(denyPolicy)).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_멤버_초대_권한이_있어야_멤버_초대가_가능하다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canInviteMember()).isFalse();
+    }
+
+    @Test
+    void 매니저는_멤버_역할을_관리할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canMemberRoleManagement()).isFalse();
+    }
+
+    @Test
+    void 해당_채널_참여자가_매니저_역할인지_확인한다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership managerMembership = ChannelMembership.create(userId, ChannelRole.MANAGER, joinedAt);
+        ChannelMembership memberMembership = ChannelMembership.create(userId, ChannelRole.MEMBER, joinedAt);
+        ChannelMembership ownerMembership = ChannelMembership.create(userId, ChannelRole.OWNER, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.isManager()).isTrue(),
+                () -> assertThat(memberMembership.isManager()).isFalse(),
+                () -> assertThat(ownerMembership.isManager()).isFalse()
+        );
+    }
+
+    @Test
+    void 해당_채널_참여자가_멤버_역할인지_확인한다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership memberMembership = ChannelMembership.create(userId, ChannelRole.MEMBER, joinedAt);
+        ChannelMembership managerMembership = ChannelMembership.create(userId, ChannelRole.MANAGER, joinedAt);
+        ChannelMembership ownerMembership = ChannelMembership.create(userId, ChannelRole.OWNER, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.isMember()).isTrue(),
+                () -> assertThat(managerMembership.isMember()).isFalse(),
+                () -> assertThat(ownerMembership.isMember()).isFalse()
+        );
+    }
+
+    @Test
+    void 해당_채널_참여자가_오너_역할인지_확인한다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership ownerMembership = ChannelMembership.create(userId, ChannelRole.OWNER, joinedAt);
+        ChannelMembership memberMembership = ChannelMembership.create(userId, ChannelRole.MEMBER, joinedAt);
+        ChannelMembership managerMembership = ChannelMembership.create(userId, ChannelRole.MANAGER, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.isOwner()).isTrue(),
+                () -> assertThat(memberMembership.isOwner()).isFalse(),
+                () -> assertThat(managerMembership.isOwner()).isFalse()
+        );
+    }
+
+    @Test
+    void 멤버를_매니저로_승격할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+        ChannelMembership memberMembership = ChannelMembership.create(userId, ChannelRole.MEMBER, joinedAt);
+        Set<ChannelPermissionType> perms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions promotionPermissions = ChannelManagePermissions.ofManager(perms);
+
+        // when
+        ChannelMembership promotedMembership = memberMembership.promoteToManager(promotionPermissions);
+
+        // then
+        assertAll(
+                () -> assertThat(promotedMembership.getRole()).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(promotedMembership.getUserId()).isEqualTo(userId),
+                () -> assertThat(promotedMembership.getJoinedAt()).isEqualTo(joinedAt),
+                () -> assertThat(promotedMembership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(promotedMembership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
+    }
+
+    @Test
+    void 매니저를_멤버로_강등할_수_있다() {
+        // given
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+        ChannelMembership managerMembership = ChannelMembership.create(userId, ChannelRole.MANAGER, joinedAt);
+
+        // when
+        ChannelMembership demotedMembership = managerMembership.demoteToMember();
+
+        // then
+        assertAll(
+                () -> assertThat(demotedMembership.getRole()).isEqualTo(ChannelRole.MEMBER),
+                () -> assertThat(demotedMembership.getUserId()).isEqualTo(userId),
+                () -> assertThat(demotedMembership.getJoinedAt()).isEqualTo(joinedAt),
+                () -> assertThat(demotedMembership.getPermissions().isEmpty()).isTrue()
+        );
+    }
+
+    @Test
+    void 매니저는_멤버_강퇴_권한이_있어야_멤버_강퇴가_가능하다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canKickMember()).isFalse();
+    }
+
+    @Test
+    void 매니저는_권한을_관리할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canPermissionManagement()).isFalse();
+    }
+
+    @Test
+    void 멤버는_권한을_관리할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canPermissionManagement()).isFalse();
+    }
+
+    @Test
+    void 매니저는_채널을_삭제할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canDeleteChannel()).isFalse();
+    }
+
+    @Test
+    void 멤버는_채널을_삭제할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canDeleteChannel()).isFalse();
+    }
+
+    @Test
+    void 매니저는_채널_정책을_변경할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canChangeChannelPolicy()).isFalse();
+    }
+
+    @Test
+    void 멤버는_채널_정책을_변경할_수_없다() {
+        // when
+        ChannelMembership membership = ChannelMembership.create(
+                UserId.create(1L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+
+        // then
+        assertThat(membership.canChangeChannelPolicy()).isFalse();
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelRoleTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelRoleTest.java
@@ -1,0 +1,67 @@
+package com.tok.pekko.domain.channel.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelRoleTest {
+
+    @Test
+    void 역할_이름으로_특정_역할을_찾을_수_있다() {
+        // when
+        ChannelRole ownerRole = ChannelRole.find("OWNER");
+        ChannelRole managerRole = ChannelRole.find("MANAGER");
+        ChannelRole memberRole = ChannelRole.find("MEMBER");
+
+        // then
+        assertAll(
+                () -> assertThat(ownerRole).isEqualTo(ChannelRole.OWNER),
+                () -> assertThat(managerRole).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(memberRole).isEqualTo(ChannelRole.MEMBER)
+        );
+    }
+
+    @Test
+    void 존재하지_않는_역할_이름으로는_역할을_찾을_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> ChannelRole.find("INVALID_ROLE"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 역할 입니다.");
+    }
+
+    @Test
+    void 오너_역할인지_확인한다() {
+        // when & then
+        assertAll(
+                () -> assertThat(ChannelRole.OWNER.isOwner()).isTrue(),
+                () -> assertThat(ChannelRole.MANAGER.isOwner()).isFalse(),
+                () -> assertThat(ChannelRole.MEMBER.isOwner()).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저_역할인지_확인한다() {
+        // when & then
+        assertAll(
+                () -> assertThat(ChannelRole.MANAGER.isManager()).isTrue(),
+                () -> assertThat(ChannelRole.OWNER.isManager()).isFalse(),
+                () -> assertThat(ChannelRole.MEMBER.isManager()).isFalse()
+        );
+    }
+
+    @Test
+    void 멤버_역할인지_확인한다() {
+        // when & then
+        assertAll(
+                () -> assertThat(ChannelRole.MEMBER.isMember()).isTrue(),
+                () -> assertThat(ChannelRole.OWNER.isMember()).isFalse(),
+                () -> assertThat(ChannelRole.MANAGER.isMember()).isFalse()
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
@@ -1,0 +1,589 @@
+package com.tok.pekko.domain.channel.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelTest {
+
+    @Test
+    void 유효한_값으로_채널을_초기화할_수_있다() {
+        // given
+        String name = "general";
+        Long creatorId = 1L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy();
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // when
+        Channel channel = Channel.create(name, creatorId, channelPolicy, createdAt);
+
+        // then
+        assertAll(
+                () -> assertThat(channel).isNotNull(),
+                () -> assertThat(channel.getName()).isEqualTo(name),
+                () -> assertThat(channel.getCreatorId()).isEqualTo(UserId.create(creatorId)),
+                () -> assertThat(channel.getChannelPolicy()).isEqualTo(channelPolicy),
+                () -> assertThat(channel.getCreatedAt()).isEqualTo(createdAt),
+                () -> assertThat(channel.getMemberships()).isEmpty()
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullAndEmptySource
+    void 유효하지_않은_채널_이름으로는_초기화할_수_없다(String name) {
+        // when & then
+        assertThatThrownBy(() -> Channel.create(name, 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("채널 이름은 필수입니다.");
+    }
+
+    @Test
+    void 명시적_값으로_채널을_초기화할_수_있다() {
+        // given
+        Long channelId = 1L;
+        String name = "general";
+        Long creatorId = 1L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // when
+        Channel channel = Channel.create(channelId, name, creatorId, channelPolicy, memberships, createdAt);
+
+        // then
+        assertAll(
+                () -> assertThat(channel).isNotNull(),
+                () -> assertThat(channel.getChannelId()).isEqualTo(ChannelId.create(channelId)),
+                () -> assertThat(channel.getName()).isEqualTo(name),
+                () -> assertThat(channel.getCreatorId()).isEqualTo(UserId.create(creatorId))
+        );
+    }
+
+    @Test
+    void 채널의_공개_여부를_확인할_수_있다() {
+        // given
+        Channel publicChannel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
+        Channel privateChannel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(publicChannel.isPublic()).isTrue(),
+                () -> assertThat(privateChannel.isPublic()).isFalse()
+        );
+    }
+
+    @Test
+    void 공개_채널에_멤버가_참여할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when
+        channel.joinMember(userId, role, joinedAt);
+
+        // then
+        assertThat(channel.getMemberships()).containsKey(userId);
+    }
+
+    @Test
+    void 비공개_채널에는_직접_참여할_수_없다() {
+        // given
+        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
+        Channel channel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when & then
+        assertThatThrownBy(() -> channel.joinMember(userId, role, joinedAt))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
+    }
+
+    @Test
+    void 이미_참여한_멤버는_다시_참여할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.joinMember(userId, role, joinedAt))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 채널에 참여한 사용자입니다.");
+    }
+
+    @Test
+    void 채널에_멤버를_초대할_수_있다() {
+        // given
+        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
+        Channel channel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when
+        channel.inviteMember(userId, role, joinedAt);
+
+        // then
+        assertThat(channel.getMemberships()).containsKey(userId);
+    }
+
+    @Test
+    void 초대된_멤버도_중복으로_초대할_수_없다() {
+        // given
+        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
+        Channel channel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.inviteMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.inviteMember(userId, role, joinedAt))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 채널에 참여한 사용자입니다.");
+    }
+
+    @Test
+    void 멤버를_매니저로_승격할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        Set<ChannelPermissionType> perms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+
+        // when
+        channel.promoteToManager(userId, permissions);
+
+        // then
+        ChannelMembership membership = channel.getMemberships().get(userId);
+        assertAll(
+                () -> assertThat(membership.isManager()).isTrue(),
+                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue()
+        );
+    }
+
+    @Test
+    void 존재하지_않는_멤버를_승격할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+
+        // when & then
+        assertThatThrownBy(() -> channel.promoteToManager(userId, permissions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("채널 멤버를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 매니저를_멤버로_강등할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when
+        channel.demoteToMember(userId);
+
+        // then
+        ChannelMembership membership = channel.getMemberships().get(userId);
+        assertThat(membership.isMember()).isTrue();
+    }
+
+    @Test
+    void 이미_멤버인_경우_강등할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.demoteToMember(userId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 멤버입니다.");
+    }
+
+    @Test
+    void 오너는_강등할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.demoteToMember(userId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("오너는 강등할 수 없습니다.");
+    }
+
+    @Test
+    void 존재하지_않는_멤버를_강등할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+
+        // when & then
+        assertThatThrownBy(() -> channel.demoteToMember(userId))
+                .isInstanceOf(Channel.ChannelMembershipNotFoundException.class)
+                .hasMessage("채널 멤버를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 매니저의_권한을_업데이트할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        Set<ChannelPermissionType> newPerms = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK,
+                ChannelPermissionType.MEMBER_INVITE
+        );
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager(newPerms);
+
+        // when
+        channel.updateManagerPermissions(managerId, newPermissions);
+
+        // then
+        ChannelMembership membership = channel.getMemberships().get(managerId);
+        assertThat(membership.getPermissions().has(ChannelPermissionType.MEMBER_INVITE)).isTrue();
+    }
+
+    @Test
+    void 매니저가_아닌_사용자의_권한은_업데이트할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        Set<ChannelPermissionType> newPerms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager(newPerms);
+
+        // when & then
+        assertThatThrownBy(() -> channel.updateManagerPermissions(userId, newPermissions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 멤버는 매니저가 아닙니다.");
+    }
+
+    @Test
+    void 매니저에게_권한을_추가할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when
+        channel.addPermissionToManager(managerId, ChannelPermissionType.MEMBER_KICK);
+
+        // then
+        ChannelMembership membership = channel.getMemberships().get(managerId);
+        assertThat(membership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue();
+    }
+
+    @Test
+    void 멤버에게_권한을_추가할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.addPermissionToManager(userId, ChannelPermissionType.MESSAGE_EDIT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 멤버는 매니저가 아닙니다.");
+    }
+
+    @Test
+    void 매니저에게서_권한을_제거할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when
+        channel.removePermissionFromManager(managerId, ChannelPermissionType.MESSAGE_EDIT);
+
+        // then
+        ChannelMembership membership = channel.getMemberships().get(managerId);
+        assertThat(membership.getPermissions().isEmpty()).isTrue();
+    }
+
+    @Test
+    void 멤버를_채널에서_제거할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when
+        channel.leaveMember(userId);
+
+        // then
+        assertThat(channel.getMemberships()).doesNotContainKey(userId);
+    }
+
+    @Test
+    void 오너는_채널에서_나갈_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.leaveMember(userId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("오너는 채널에서 나갈 수 없습니다.");
+    }
+
+    @Test
+    void 멤버는_채널정책에_따라_자신의_메시지를_수정할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canMemberEditMessage(userId)).isTrue();
+    }
+
+    @Test
+    void 멤버는_채널정책에_따라_자신의_메시지를_삭제할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canMemberDeleteMessage(userId)).isTrue();
+    }
+
+    @Test
+    void 오너는_채널명을_변경할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserEditChannelName(userId)).isTrue();
+    }
+
+    @Test
+    void 매니저는_EDIT_CHANNEL_NAME_권한으로만_채널명_변경이_가능하다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserEditChannelName(managerId)).isFalse();
+    }
+
+    @Test
+    void 오너는_멤버를_강퇴할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserKickMember(userId)).isTrue();
+    }
+
+    @Test
+    void 오너는_멤버를_초대할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserInviteMember(userId)).isTrue();
+    }
+
+    @Test
+    void 매니저는_MEMBER_INVITE_권한으로만_멤버_초대가_가능하다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserInviteMember(managerId)).isFalse();
+    }
+
+    @Test
+    void 오너는_멤버_역할을_관리할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserMemberRoleManagement(userId)).isTrue();
+    }
+
+    @Test
+    void 매니저는_멤버_역할을_관리할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserMemberRoleManagement(managerId)).isFalse();
+    }
+
+    @Test
+    void 오너는_권한을_관리할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserPermissionManagement(userId)).isTrue();
+    }
+
+    @Test
+    void 매니저는_권한을_관리할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserPermissionManagement(managerId)).isFalse();
+    }
+
+    @Test
+    void 오너는_채널을_삭제할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(userId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserDeleteChannel(userId)).isTrue();
+    }
+
+    @Test
+    void 매니저는_채널을_삭제할_수_없다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId managerId = UserId.create(2L);
+        ChannelRole role = ChannelRole.MANAGER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+        channel.joinMember(managerId, role, joinedAt);
+
+        // when & then
+        assertThat(channel.canUserDeleteChannel(managerId)).isFalse();
+    }
+
+    @Test
+    void 채널_이름을_변경할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        String newName = "random";
+
+        // when
+        Channel changedChannel = channel.changeName(newName);
+
+        // then
+        assertAll(
+                () -> assertThat(changedChannel.getName()).isEqualTo(newName),
+                () -> assertThat(changedChannel.getCreatorId()).isEqualTo(channel.getCreatorId()),
+                () -> assertThat(changedChannel.getChannelPolicy()).isEqualTo(channel.getChannelPolicy())
+        );
+    }
+
+    @Test
+    void 채널_정책을_변경할_수_있다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        ChannelPolicy newPolicy = new ChannelPolicy(false, false, false);
+
+        // when
+        Channel actual = channel.changeChannelPolicy(newPolicy);
+
+        // then
+        assertThat(actual.getChannelPolicy()).isEqualTo(newPolicy);
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelIdTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelIdTest.java
@@ -1,0 +1,77 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelIdTest {
+
+    @Test
+    void 양수_값을_가진_ID로_초기화한다() {
+        // when
+        ChannelId channelId = ChannelId.create(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(channelId).isNotNull(),
+                () -> assertThat(channelId.getValue()).isEqualTo(1L)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullSource
+    @ValueSource(longs = {0, -1})
+    void 유효하지_않은_ID로는_초기화할_수_없다(Long id) {
+        // when & then
+        assertThatThrownBy(() -> ChannelId.create(id))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("채널 ID는 양수여야 합니다.");
+    }
+
+    @Test
+    void 같은_값의_ID를_가진_ChannelId는_동등하다() {
+        // given
+        ChannelId channelId1 = ChannelId.create(1L);
+        ChannelId channelId2 = ChannelId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelId1).isEqualTo(channelId2),
+                () -> assertThat(channelId1).hasSameHashCodeAs(channelId2)
+        );
+    }
+
+    @Test
+    void 다른_값의_ID를_가진_ChannelId는_동등하지_않다() {
+        // given
+        ChannelId channelId1 = ChannelId.create(1L);
+        ChannelId channelId2 = ChannelId.create(2L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelId1).isNotEqualTo(channelId2),
+                () -> assertThat(channelId1).doesNotHaveSameHashCodeAs(channelId2)
+        );
+    }
+
+    @Test
+    void 동일한_ID인지_확인한다() {
+        // given
+        ChannelId channelId = ChannelId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelId.isEqualId(1L)).isTrue(),
+                () -> assertThat(channelId.isEqualId(2L)).isFalse()
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissionsTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissionsTest.java
@@ -1,0 +1,250 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelManagePermissionsTest {
+
+    @Test
+    void 채널_오너의_채널_관리_권한을_초기화한다() {
+        // when
+        ChannelManagePermissions actual = ChannelManagePermissions.ofOwner();
+
+        // then
+        assertAll(
+                () -> assertThat(actual.isEmpty()).isTrue(),
+                () -> assertThat(actual.size()).isZero()
+        );
+    }
+
+    @Test
+    void 채널_매니저의_기본_권한인_메시지_수정을_가진_채널_관리_권한을_초기화한다() {
+        // when
+        ChannelManagePermissions actual = ChannelManagePermissions.ofManager();
+
+        // then
+        assertAll(
+                () -> assertThat(actual.has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.size()).isEqualTo(1),
+                () -> assertThat(actual.isEmpty()).isFalse()
+        );
+    }
+
+    @Test
+    void 여러_권한을_지정해_채널_매니저의_채널_관리_권한을_초기화한다() {
+        // when
+        ChannelManagePermissions actual = ChannelManagePermissions.ofManager(
+                Set.of(
+                        ChannelPermissionType.MESSAGE_EDIT,
+                        ChannelPermissionType.MESSAGE_DELETE,
+                        ChannelPermissionType.MEMBER_INVITE
+                )
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(actual.has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.has(ChannelPermissionType.MESSAGE_DELETE)).isTrue(),
+                () -> assertThat(actual.has(ChannelPermissionType.MEMBER_INVITE)).isTrue(),
+                () -> assertThat(actual.size()).isEqualTo(3)
+        );
+    }
+
+    @Test
+    void 채널에_참여한_사용자의_채널_관리_권한을_초기화한다() {
+        // when
+        ChannelManagePermissions actual = ChannelManagePermissions.ofMember();
+
+        // then
+        assertAll(
+                () -> assertThat(actual.isEmpty()).isTrue(),
+                () -> assertThat(actual.size()).isZero()
+        );
+    }
+
+    @Test
+    void 특정_권한을_가졌는지_확인한다() {
+        // given
+        ChannelManagePermissions actual = ChannelManagePermissions.ofManager();
+
+        // when & then
+        assertAll(
+                () -> assertThat(actual.has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.has(ChannelPermissionType.MESSAGE_DELETE)).isFalse()
+        );
+    }
+
+    @Test
+    void 지정한_여러_권한을_모두_가졌는지_확인한다() {
+        // given
+        ChannelPermissionType perm1 = ChannelPermissionType.MESSAGE_EDIT;
+        ChannelPermissionType perm2 = ChannelPermissionType.MESSAGE_DELETE;
+        ChannelPermissionType perm3 = ChannelPermissionType.MEMBER_INVITE;
+
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(Set.of(perm1, perm2));
+
+        Set<ChannelPermissionType> allExistingPerms = EnumSet.of(perm1, perm2);
+        Set<ChannelPermissionType> partialPerms = EnumSet.of(perm1);
+        Set<ChannelPermissionType> notExistingPerms = EnumSet.of(perm3);
+
+        // when & then
+        assertAll(
+                () -> assertThat(permissions.hasAll(allExistingPerms)).isTrue(),
+                () -> assertThat(permissions.hasAll(partialPerms)).isTrue(),
+                () -> assertThat(permissions.hasAll(notExistingPerms)).isFalse()
+        );
+    }
+
+    @Test
+    void 지정한_여러_권한_중_하나라도_가졌는지_확인한다() {
+        // given
+        ChannelPermissionType perm1 = ChannelPermissionType.MESSAGE_EDIT;
+        ChannelPermissionType perm2 = ChannelPermissionType.MESSAGE_DELETE;
+        ChannelPermissionType perm3 = ChannelPermissionType.MEMBER_INVITE;
+
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(Set.of(perm1));
+
+        Set<ChannelPermissionType> withExisting = EnumSet.of(perm1, perm2);
+        Set<ChannelPermissionType> allNotExisting = EnumSet.of(perm2, perm3);
+
+        // when & then
+        assertAll(
+                () -> assertThat(permissions.hasAny(withExisting)).isTrue(),
+                () -> assertThat(permissions.hasAny(allNotExisting)).isFalse()
+        );
+    }
+
+    @Test
+    void 권한을_추가한다() {
+        // given
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager();
+
+        // when
+        ChannelManagePermissions addedPermissions = permissions.add(ChannelPermissionType.MESSAGE_DELETE);
+
+        // then
+        assertAll(
+                () -> assertThat(addedPermissions.has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(addedPermissions.has(ChannelPermissionType.MESSAGE_DELETE)).isTrue(),
+                () -> assertThat(addedPermissions.size()).isEqualTo(2),
+                () -> assertThat(permissions.has(ChannelPermissionType.MESSAGE_DELETE)).isFalse(),
+                () -> assertThat(permissions.size()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 권한을_제거한다() {
+        // given
+        ChannelPermissionType perm1 = ChannelPermissionType.MESSAGE_EDIT;
+        ChannelPermissionType perm2 = ChannelPermissionType.MESSAGE_DELETE;
+
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(Set.of(perm1, perm2));
+
+        // when
+        ChannelManagePermissions removedPermissions = permissions.remove(perm1);
+
+        // then
+        assertAll(
+                () -> assertThat(removedPermissions.has(perm1)).isFalse(),
+                () -> assertThat(removedPermissions.has(perm2)).isTrue(),
+                () -> assertThat(removedPermissions.size()).isEqualTo(1),
+                () -> assertThat(permissions.has(perm1)).isTrue(),
+                () -> assertThat(permissions.size()).isEqualTo(2)
+        );
+    }
+
+    @Test
+    void 모든_권한을_조회한다() {
+        // given
+        ChannelPermissionType perm1 = ChannelPermissionType.MESSAGE_EDIT;
+        ChannelPermissionType perm2 = ChannelPermissionType.MESSAGE_DELETE;
+
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(Set.of(perm1, perm2));
+
+        // when
+        Set<ChannelPermissionType> allPermissions = permissions.getAll();
+
+        // then
+        assertAll(
+                () -> assertThat(allPermissions).contains(perm1, perm2),
+                () -> assertThat(allPermissions).hasSize(2)
+        );
+    }
+
+    @Test
+    void 권한_개수를_확인한다() {
+        // given
+        ChannelManagePermissions emptyPermissions = ChannelManagePermissions.ofMember();
+        ChannelManagePermissions singlePermissions = ChannelManagePermissions.ofManager();
+        ChannelManagePermissions multiplePermissions = ChannelManagePermissions.ofManager(
+                Set.of(
+                        ChannelPermissionType.MESSAGE_EDIT,
+                        ChannelPermissionType.MESSAGE_DELETE,
+                        ChannelPermissionType.MEMBER_INVITE
+                )
+        );
+
+        // when & then
+        assertAll(
+                () -> assertThat(emptyPermissions.size()).isZero(),
+                () -> assertThat(singlePermissions.size()).isEqualTo(1),
+                () -> assertThat(multiplePermissions.size()).isEqualTo(3)
+        );
+    }
+
+    @Test
+    void 권한이_비어있는지_확인한다() {
+        // given
+        ChannelManagePermissions emptyPermissions = ChannelManagePermissions.ofMember();
+        ChannelManagePermissions nonEmptyPermissions = ChannelManagePermissions.ofManager();
+
+        // when & then
+        assertAll(
+                () -> assertThat(emptyPermissions.isEmpty()).isTrue(),
+                () -> assertThat(nonEmptyPermissions.isEmpty()).isFalse()
+        );
+    }
+
+    @Test
+    void 같은_권한을_가진_채널_관리_권한은_동등하다() {
+        // given
+        ChannelPermissionType perm1 = ChannelPermissionType.MESSAGE_EDIT;
+        ChannelPermissionType perm2 = ChannelPermissionType.MESSAGE_DELETE;
+
+        ChannelManagePermissions permissions1 = ChannelManagePermissions.ofManager(Set.of(perm1, perm2));
+        ChannelManagePermissions permissions2 = ChannelManagePermissions.ofManager(Set.of(perm1, perm2));
+
+        // when & then
+        assertAll(
+                () -> assertThat(permissions1).isEqualTo(permissions2),
+                () -> assertThat(permissions1).hasSameHashCodeAs(permissions2)
+        );
+    }
+
+    @Test
+    void 다른_권한을_가진_채널_관리_권한은_동등하지_않다() {
+        // given
+        ChannelManagePermissions permissions1 = ChannelManagePermissions.ofManager(Set.of(ChannelPermissionType.MESSAGE_EDIT));
+        ChannelManagePermissions permissions2 = ChannelManagePermissions.ofManager(
+                Set.of(
+                        ChannelPermissionType.MESSAGE_EDIT,
+                        ChannelPermissionType.MESSAGE_DELETE
+                )
+        );
+
+        // when & then
+        assertAll(
+                () -> assertThat(permissions1).isNotEqualTo(permissions2),
+                () -> assertThat(permissions1).doesNotHaveSameHashCodeAs(permissions2)
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelMembershipIdTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelMembershipIdTest.java
@@ -1,0 +1,77 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelMembershipIdTest {
+
+    @Test
+    void 양수_값을_가진_ID로_초기화한다() {
+        // when
+        ChannelMembershipId channelMembershipId = ChannelMembershipId.create(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(channelMembershipId).isNotNull(),
+                () -> assertThat(channelMembershipId.getValue()).isEqualTo(1L)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullSource
+    @ValueSource(longs = {0, -1})
+    void 유효하지_않은_ID로는_초기화할_수_없다(Long id) {
+        // when & then
+        assertThatThrownBy(() -> ChannelMembershipId.create(id))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("채널 참여자 ID는 양수여야 합니다.");
+    }
+
+    @Test
+    void 같은_값의_ID를_가진_ChannelMembershipId는_동등하다() {
+        // given
+        ChannelMembershipId channelMembershipId1 = ChannelMembershipId.create(1L);
+        ChannelMembershipId channelMembershipId2 = ChannelMembershipId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelMembershipId1).isEqualTo(channelMembershipId2),
+                () -> assertThat(channelMembershipId1).hasSameHashCodeAs(channelMembershipId2)
+        );
+    }
+
+    @Test
+    void 다른_값의_ID를_가진_ChannelMembershipId는_동등하지_않다() {
+        // given
+        ChannelMembershipId channelMembershipId1 = ChannelMembershipId.create(1L);
+        ChannelMembershipId channelMembershipId2 = ChannelMembershipId.create(2L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelMembershipId1).isNotEqualTo(channelMembershipId2),
+                () -> assertThat(channelMembershipId1).doesNotHaveSameHashCodeAs(channelMembershipId2)
+        );
+    }
+
+    @Test
+    void 동일한_ID인지_확인한다() {
+        // given
+        ChannelMembershipId channelMembershipId = ChannelMembershipId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(channelMembershipId.isEqualId(1L)).isTrue(),
+                () -> assertThat(channelMembershipId.isEqualId(2L)).isFalse()
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicyTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicyTest.java
@@ -1,0 +1,94 @@
+package com.tok.pekko.domain.channel.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelPolicyTest {
+
+    @Test
+    void 채널_정책을_초기화한다() {
+        // when
+        ChannelPolicy policy = new ChannelPolicy(true, false);
+
+        // then
+        assertAll(
+                () -> assertThat(policy).isNotNull(),
+                () -> assertThat(policy.canEditOwnMessage()).isTrue(),
+                () -> assertThat(policy.canDeleteOwnMessage()).isFalse()
+        );
+    }
+
+    @Test
+    void 기본_채널_정책을_초기화한다() {
+        // when
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+
+        // then
+        assertAll(
+                () -> assertThat(policy.canEditOwnMessage()).isTrue(),
+                () -> assertThat(policy.canDeleteOwnMessage()).isTrue()
+        );
+    }
+
+    @Test
+    void 자신이_작성한_메시지_수정_가능_여부를_변경한다() {
+        // given
+        ChannelPolicy policy = new ChannelPolicy(false, true);
+
+        // when
+        ChannelPolicy updatedPolicy = policy.updateEditOwnMessage(true);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedPolicy.canEditOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue()
+        );
+    }
+
+    @Test
+    void 자신이_작성한_메시지_삭제_가능_여부를_변경한다() {
+        // given
+        ChannelPolicy policy = new ChannelPolicy(true, false);
+
+        // when
+        ChannelPolicy updatedPolicy = policy.updateDeleteOwnMessage(true);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedPolicy.canEditOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue()
+        );
+    }
+
+    @Test
+    void 같은_값을_가진_채널_정책은_동등하다() {
+        // given
+        ChannelPolicy policy1 = new ChannelPolicy(true, false);
+        ChannelPolicy policy2 = new ChannelPolicy(true, false);
+
+        // when & then
+        assertAll(
+                () -> assertThat(policy1).isEqualTo(policy2),
+                () -> assertThat(policy1).hasSameHashCodeAs(policy2)
+        );
+    }
+
+    @Test
+    void 값이_다른_채널_정책은_동등하지_않다() {
+        // given
+        ChannelPolicy policy1 = new ChannelPolicy(true, true);
+        ChannelPolicy policy2 = new ChannelPolicy(false, false);
+
+        // when & then
+        assertAll(
+                () -> assertThat(policy1).isNotEqualTo(policy2),
+                () -> assertThat(policy1).doesNotHaveSameHashCodeAs(policy2)
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicyTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicyTest.java
@@ -14,13 +14,14 @@ class ChannelPolicyTest {
     @Test
     void 채널_정책을_초기화한다() {
         // when
-        ChannelPolicy policy = new ChannelPolicy(true, false);
+        ChannelPolicy policy = new ChannelPolicy(true, false, false);
 
         // then
         assertAll(
                 () -> assertThat(policy).isNotNull(),
                 () -> assertThat(policy.canEditOwnMessage()).isTrue(),
-                () -> assertThat(policy.canDeleteOwnMessage()).isFalse()
+                () -> assertThat(policy.canDeleteOwnMessage()).isFalse(),
+                () -> assertThat(policy.isPublic()).isFalse()
         );
     }
 
@@ -32,14 +33,15 @@ class ChannelPolicyTest {
         // then
         assertAll(
                 () -> assertThat(policy.canEditOwnMessage()).isTrue(),
-                () -> assertThat(policy.canDeleteOwnMessage()).isTrue()
+                () -> assertThat(policy.canDeleteOwnMessage()).isTrue(),
+                () -> assertThat(policy.isPublic()).isTrue()
         );
     }
 
     @Test
     void 자신이_작성한_메시지_수정_가능_여부를_변경한다() {
         // given
-        ChannelPolicy policy = new ChannelPolicy(false, true);
+        ChannelPolicy policy = new ChannelPolicy(false, true, true);
 
         // when
         ChannelPolicy updatedPolicy = policy.updateEditOwnMessage(true);
@@ -47,14 +49,15 @@ class ChannelPolicyTest {
         // then
         assertAll(
                 () -> assertThat(updatedPolicy.canEditOwnMessage()).isTrue(),
-                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue()
+                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.isPublic()).isTrue()
         );
     }
 
     @Test
     void 자신이_작성한_메시지_삭제_가능_여부를_변경한다() {
         // given
-        ChannelPolicy policy = new ChannelPolicy(true, false);
+        ChannelPolicy policy = new ChannelPolicy(true, false, false);
 
         // when
         ChannelPolicy updatedPolicy = policy.updateDeleteOwnMessage(true);
@@ -62,15 +65,32 @@ class ChannelPolicyTest {
         // then
         assertAll(
                 () -> assertThat(updatedPolicy.canEditOwnMessage()).isTrue(),
-                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue()
+                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.isPublic()).isFalse()
+        );
+    }
+
+    @Test
+    void 채널_공개_여부를_변경한다() {
+        // given
+        ChannelPolicy policy = new ChannelPolicy(true, true, false);
+
+        // when
+        ChannelPolicy updatedPolicy = policy.updatePublic(true);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedPolicy.canEditOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.canDeleteOwnMessage()).isTrue(),
+                () -> assertThat(updatedPolicy.isPublic()).isTrue()
         );
     }
 
     @Test
     void 같은_값을_가진_채널_정책은_동등하다() {
         // given
-        ChannelPolicy policy1 = new ChannelPolicy(true, false);
-        ChannelPolicy policy2 = new ChannelPolicy(true, false);
+        ChannelPolicy policy1 = new ChannelPolicy(true, false, true);
+        ChannelPolicy policy2 = new ChannelPolicy(true, false, true);
 
         // when & then
         assertAll(
@@ -82,8 +102,8 @@ class ChannelPolicyTest {
     @Test
     void 값이_다른_채널_정책은_동등하지_않다() {
         // given
-        ChannelPolicy policy1 = new ChannelPolicy(true, true);
-        ChannelPolicy policy2 = new ChannelPolicy(false, false);
+        ChannelPolicy policy1 = new ChannelPolicy(true, true, true);
+        ChannelPolicy policy2 = new ChannelPolicy(false, false, false);
 
         // when & then
         assertAll(

--- a/pekko/src/test/java/com/tok/pekko/domain/user/model/RegistrationIdTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/user/model/RegistrationIdTest.java
@@ -1,0 +1,30 @@
+package com.tok.pekko.domain.user.model;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RegistrationIdTest {
+
+    @Test
+    void 소셜_서비스_이름으로_RegistrationId를_찾을_수_있다() {
+        // when
+        RegistrationId actual = RegistrationId.findBy("kakao");
+
+        // then
+        assertThat(actual).isEqualTo(RegistrationId.KAKAO);
+    }
+
+    @Test
+    void 유효하지_않은_이름으로_조회할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> RegistrationId.findBy("invalid_service"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 소셜 로그인 서비스입니다.");
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/user/model/UserTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/user/model/UserTest.java
@@ -1,0 +1,68 @@
+package com.tok.pekko.domain.user.model;
+
+import com.tok.pekko.domain.user.model.vo.UserId;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UserTest {
+
+    @Test
+    void 소셜_로그인_정보로_User를_초기화할_수_있다() {
+        // given
+        RegistrationId registrationId = RegistrationId.KAKAO;
+        String socialId = "kakao12345";
+
+        // when
+        User actual = User.create(registrationId, socialId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getId()).isEqualTo(UserId.EMPTY_USER_ID),
+                () -> assertThat(actual.getRegistrationId()).isEqualTo(RegistrationId.KAKAO),
+                () -> assertThat(actual.getSocialId()).isEqualTo(socialId)
+        );
+    }
+
+    @Test
+    void 모든_필드를_포함한_User를_초기화할_수_있다() {
+        // given
+        Long userId = 100L;
+        RegistrationId registrationId = RegistrationId.KAKAO;
+        String socialId = "kakao12345";
+
+        // when
+        User actual = User.create(userId, registrationId, socialId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getId()).isEqualTo(UserId.create(userId)),
+                () -> assertThat(actual.getRegistrationId()).isEqualTo(RegistrationId.KAKAO),
+                () -> assertThat(actual.getSocialId()).isEqualTo(socialId)
+        );
+    }
+
+    @Test
+    void 기존_User에_id를_할당할_수_있다() {
+        // given
+        RegistrationId registrationId = RegistrationId.KAKAO;
+        String socialId = "kakao12345";
+        User existingUser = User.create(registrationId, socialId);
+        Long assignedId = 100L;
+
+        // when
+        User actual = existingUser.withAssignedId(assignedId);
+
+        // then
+        assertAll(
+                () -> assertThat(actual.getId()).isEqualTo(UserId.create(assignedId)),
+                () -> assertThat(actual.getRegistrationId()).isEqualTo(RegistrationId.KAKAO),
+                () -> assertThat(actual.getSocialId()).isEqualTo(socialId)
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/user/model/vo/UserIdTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/user/model/vo/UserIdTest.java
@@ -1,0 +1,77 @@
+package com.tok.pekko.domain.user.model.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UserIdTest {
+
+    @Test
+    void 양수_값을_가진_ID로_초기화한다() {
+        // when
+        UserId userId = UserId.create(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(userId).isNotNull(),
+                () -> assertThat(userId.getValue()).isEqualTo(1L)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
+    @NullSource
+    @ValueSource(longs = {0, -1})
+    void 유효하지_않은_ID로는_초기화할_수_없다(Long id) {
+        // when & then
+        assertThatThrownBy(() -> UserId.create(id))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자 ID는 양수여야 합니다.");
+    }
+
+    @Test
+    void 같은_값의_ID를_가진_UserId는_동등하다() {
+        // given
+        UserId userId1 = UserId.create(1L);
+        UserId userId2 = UserId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(userId1).isEqualTo(userId2),
+                () -> assertThat(userId1).hasSameHashCodeAs(userId2)
+        );
+    }
+
+    @Test
+    void 다른_값의_ID를_가진_UserId는_동등하지_않다() {
+        // given
+        UserId userId1 = UserId.create(1L);
+        UserId userId2 = UserId.create(2L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(userId1).isNotEqualTo(userId2),
+                () -> assertThat(userId1).doesNotHaveSameHashCodeAs(userId2)
+        );
+    }
+
+    @Test
+    void 동일한_ID인지_확인한다() {
+        // given
+        UserId userId = UserId.create(1L);
+
+        // when & then
+        assertAll(
+                () -> assertThat(userId.isEqualId(1L)).isTrue(),
+                () -> assertThat(userId.isEqualId(2L)).isFalse()
+        );
+    }
+}


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #8 

## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->

- 사용자 및 채널 도메인 기능 추가

### 사용자 (User)
- 소셜 로그인을 고려한 User 도메인 추가 
- 영속화 이전 ID null을 표현하기 위해 Null Object 패턴을 적용한 UserId VO 추가 
- 소셜 서비스 식별을 위한 RegistrationId enum 추가 

### 채널 

#### 도메인
- Channel : 채널 이름 및 정책, 참여자 정보를 관리하는 도메인
- ChannelMembership : 해당 채널에 참여한 사용자가 가진 역할 및 권한을 관리하는 도메인 

#### VO 
- ChannelId, ChannelMembershipId : 영속화 이전 ID null을 표현하기 위해 Null Object 패턴을 적용한 VO
- ChannelManagePermissions : 해당 채널을 관리하기 위한 권한을 표현한 일급 컬렉션 VO 
- ChannelPolicy : 채널 정책(자신이 작성한 메시지 수정 가능 여부, 자신이 작성한 메시지 삭제 가능 여부, 채널 공개 여부) 관리 VO 

#### 권한 (enum, ChannelPermissionType)
- ChannelPermissionType.EDIT_CHANNEL_NAME : 채널 이름 변경
- ChannelPermissionType.MESSAGE_EDIT : 메시지 수정
- ChannelPermissionType.MESSAGE_DELETE : 메시지 삭제 
- ChannelPermissionType.MEMBER_INVITE : 멤버 초대 
- ChannelPermissionType.MEMBER_KICK : 멤버 강퇴 

#### 역할 (enum, ChannelRole)

- ChannelRole.OWNER
  - 반드시 한 채널에 존재해야 함 
  - 채널 탈퇴 불가능 
  - 모든 권한 부여 
- ChannelRole.MANAGER
  - OWNER가 역할 및 권한 부여
  - 기본적으로 MESSAGE_EDIT 권한만 가지고 있음 
  - 권한 추가 / 삭제 가능 
  - MEMBER로 강등 가능 
- ChannelRole.MEMBER
  - 채널 참여자의 기본 역할 
  - MANAGER로 승격 가능
  - 기본적으로 허용된 권한이 없음 
  - 채널 정책에 따라 자신이 작성한 메시지를 수정 / 삭제할 수도 있음