### PR TITLE
Actor 생명주기 관리 로직 개선

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
@@ -38,6 +38,11 @@ import reactor.core.publisher.Sinks;
 @RequiredArgsConstructor
 public class DevChatWebSocketHandler implements WebSocketHandler {
 
+    private static final String HEARTBEAT_PING_MESSAGE_TYPE = "PING";
+    private static final String HEARTBEAT_PONG_MESSAGE_TYPE = "PONG";
+    private static final String SESSION_HEALTH_PONG_MESSAGE_TYPE = "WS_PONG";
+    private static final String MESSAGE_SCHEMA_TYPE = "type";
+
     private final ObjectMapper objectMapper;
     private final ClusterSharding clusterSharding;
     private final ClientSessionActorManagementService managementService;
@@ -135,8 +140,8 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
             JsonNode node = objectMapper.readTree(payload);
             String type = node.path("type").asText();
 
-            if ("PING".equalsIgnoreCase(type)) {
-                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload("PONG", null));
+            if (HEARTBEAT_PING_MESSAGE_TYPE.equalsIgnoreCase(type)) {
+                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload(HEARTBEAT_PONG_MESSAGE_TYPE, null));
                 return true;
             }
         } catch (Exception ignored) {
@@ -151,9 +156,9 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     ) {
         try {
             JsonNode node = objectMapper.readTree(payload);
-            String type = node.path("type").asText();
+            String type = node.path(MESSAGE_SCHEMA_TYPE).asText();
 
-            if ("WS_PONG".equalsIgnoreCase(type)) {
+            if (SESSION_HEALTH_PONG_MESSAGE_TYPE.equalsIgnoreCase(type)) {
                 clientSession.thenAccept(actorRef -> actorRef.tell(new SessionPongReceived()));
                 return true;
             }

--- a/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
@@ -1,20 +1,23 @@
 package com.tok.pekko.adapter.in.websocket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
 import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender;
 import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
-import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SessionPongReceived;
 import java.net.URI;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
@@ -29,6 +32,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
+@Slf4j
 @Profile("dev")
 @Component
 @RequiredArgsConstructor
@@ -37,67 +41,152 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     private final ObjectMapper objectMapper;
     private final ClusterSharding clusterSharding;
     private final ClientSessionActorManagementService managementService;
+    private final Map<Long, WebSocketMessageSender> clientMessageSenders = new ConcurrentHashMap<>();
 
     @Override
     public Mono<Void> handle(WebSocketSession session) {
         WebSocketConnectionContext context = extractConnectionContext(session);
-        Sinks.Many<ChatMessage> messageSink = createMessageSink();
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> messageSink = createMessageSink();
+        WebSocketMessageSender messageSender = getOrCreateMessageSender(context, messageSink);
 
-        CompletionStage<ActorRef<ClientSessionCommand>> clientSession = createClientSessionActor(context, messageSink);
+        CompletionStage<ActorRef<ClientSessionCommand>> clientSession =
+                getOrCreateClientSessionActor(context, messageSender);
 
-        Flux<WebSocketMessage> inbound = handleInboundMessages(session, context);
+        Mono<Void> inbound = handleInboundMessages(session, context, messageSink, clientSession);
         Flux<WebSocketMessage> outbound = handleOutboundMessages(session, messageSink);
 
         return session.send(outbound)
                       .and(inbound)
-                      .doFinally(signal -> cleanupConnection(messageSink, clientSession));
+                      .doFinally(signal -> cleanupConnection(messageSender, messageSink));
     }
 
     private WebSocketConnectionContext extractConnectionContext(WebSocketSession session) {
         return WebSocketConnectionContext.from(session);
     }
 
-    private Sinks.Many<ChatMessage> createMessageSink() {
+    private Sinks.Many<WebSocketMessageSender.WebSocketPayload> createMessageSink() {
         return Sinks.many()
                     .unicast()
                     .onBackpressureBuffer();
     }
 
-    private CompletionStage<ActorRef<ClientSessionCommand>> createClientSessionActor(WebSocketConnectionContext context, Sinks.Many<ChatMessage> sink) {
-        ClientMessageSender sender = new WebSocketMessageSender(sink);
-
-        return managementService.createClientSessionActor(sender, context.userId());
+    private WebSocketMessageSender getOrCreateMessageSender(
+            WebSocketConnectionContext context,
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+    ) {
+        return clientMessageSenders.compute(
+                context.userId(),
+                (userId, sender) -> {
+                    WebSocketMessageSender actualSender = sender != null ? sender : new WebSocketMessageSender();
+                    actualSender.attachSink(sink);
+                    return actualSender;
+                }
+        );
     }
 
-    private Flux<WebSocketMessage> handleInboundMessages(
+    private CompletionStage<ActorRef<ClientSessionCommand>> getOrCreateClientSessionActor(
+            WebSocketConnectionContext context,
+            WebSocketMessageSender messageSender
+    ) {
+        try {
+            ActorRef<ClientSessionCommand> existing = managementService.findClientSession(context.userId());
+
+            return CompletableFuture.completedFuture(existing);
+        } catch (ClientSessionActorManagementService.ClientSessionNotFoundException ignored) {
+            return managementService.createClientSessionActor(messageSender, context.userId());
+        }
+    }
+
+    private Mono<Void> handleInboundMessages(
             WebSocketSession session,
-            WebSocketConnectionContext context
+            WebSocketConnectionContext context,
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink,
+            CompletionStage<ActorRef<ClientSessionCommand>> clientSession
     ) {
         return session.receive()
-                      .doOnNext(message -> forwardMessageToActor(context, message));
+                      .flatMap(message -> processInboundMessage(context, sink, clientSession, message))
+                      .then();
     }
 
-    private void forwardMessageToActor(WebSocketConnectionContext context, WebSocketMessage message) {
-        EntityRef<ChannelEntityCommand> entityRef = getEntityRef(context.channelId());
+    private Mono<Void> processInboundMessage(
+            WebSocketConnectionContext context,
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink,
+            CompletionStage<ActorRef<ClientSessionCommand>> clientSession,
+            WebSocketMessage message
+    ) {
+        String payload = message.getPayloadAsText();
+
+        if (handleClientHealthPong(payload, clientSession)) {
+            return Mono.empty();
+        }
+        if (handlePingMessage(payload, sink)) {
+            return Mono.empty();
+        }
+
+        forwardMessageToActor(context, payload);
+        return Mono.empty();
+    }
+
+    private boolean handlePingMessage(
+            String payload,
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+    ) {
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            String type = node.path("type").asText();
+
+            if ("PING".equalsIgnoreCase(type)) {
+                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload("PONG", null));
+                return true;
+            }
+        } catch (Exception ignored) {
+        }
+
+        return false;
+    }
+
+    private boolean handleClientHealthPong(
+            String payload,
+            CompletionStage<ActorRef<ClientSessionCommand>> clientSession
+    ) {
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            String type = node.path("type").asText();
+
+            if ("WS_PONG".equalsIgnoreCase(type)) {
+                clientSession.thenAccept(actorRef -> actorRef.tell(new SessionPongReceived()));
+                return true;
+            }
+        } catch (Exception ignored) {
+        }
+
+        return false;
+    }
+
+    private void forwardMessageToActor(WebSocketConnectionContext context, String messagePayload) {
+        EntityRef<ChannelEntityCommand> channelEntity = getEntity(context.channelId());
         SendMessage command = new SendMessage(
                 context.userId(),
-                message.getPayloadAsText()
+                messagePayload
         );
 
-        entityRef.tell(command);
+        channelEntity.tell(command);
     }
 
     private Flux<WebSocketMessage> handleOutboundMessages(
             WebSocketSession session,
-            Sinks.Many<ChatMessage> sink
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
     ) {
         return sink.asFlux()
-                   .flatMap(message -> serializeMessage(session, message));
+                   .flatMap(payload -> serializeMessage(session, payload));
     }
 
-    private Mono<WebSocketMessage> serializeMessage(WebSocketSession session, ChatMessage message) {
+    private Mono<WebSocketMessage> serializeMessage(
+            WebSocketSession session,
+            WebSocketMessageSender.WebSocketPayload payload
+    ) {
         try {
-            String json = objectMapper.writeValueAsString(message);
+            String json = objectMapper.writeValueAsString(payload);
 
             return Mono.just(session.textMessage(json));
         } catch (JsonProcessingException ignored) {
@@ -106,14 +195,14 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     }
 
     private void cleanupConnection(
-            Sinks.Many<ChatMessage> sink,
-            CompletionStage<ActorRef<ClientSessionCommand>> clientSession
+            WebSocketMessageSender messageSender,
+            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
     ) {
-        clientSession.thenAccept(actorRef -> actorRef.tell(new Shutdown()));
+        messageSender.detachSink(sink);
         sink.tryEmitComplete();
     }
 
-    private EntityRef<ChannelEntityCommand> getEntityRef(Long channelId) {
+    private EntityRef<ChannelEntityCommand> getEntity(Long channelId) {
         return clusterSharding.entityRefFor(
                 ChannelEntity.ENTITY_TYPE_KEY,
                 String.valueOf(channelId)

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipAdapter.java
@@ -3,8 +3,6 @@ package com.tok.pekko.adapter.out.persistence;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import lombok.RequiredArgsConstructor;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.springframework.stereotype.Component;
@@ -22,22 +20,6 @@ public class ChannelMembershipAdapter implements ChannelMembershipPort {
         Mono.fromCallable(() -> channelMembershipRepository.findAllIChannelIds(userId))
             .subscribeOn(Schedulers.boundedElastic())
             .doOnNext(channelIds -> replyTo.tell(new FoundRegisteredChannelIds(channelIds)))
-            .subscribe();
-    }
-
-    @Override
-    public void joinChannel(Long userId, Long channelId, ActorRef<ClientSessionCommand> replyTo) {
-        Mono.fromRunnable(() -> channelMembershipRepository.save(userId, channelId))
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnSuccess(ignored -> replyTo.tell(new SyncJoinChannel(channelId)))
-            .subscribe();
-    }
-
-    @Override
-    public void leaveChannel(Long userId, Long channelId, ActorRef<ClientSessionCommand> replyTo) {
-        Mono.fromRunnable(() -> channelMembershipRepository.save(userId, channelId))
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnSuccess(ignored -> replyTo.tell(new SyncLeaveChannel(channelId)))
             .subscribe();
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
@@ -14,7 +14,7 @@ import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUn
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -131,7 +131,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
                 getContext().stop(unHealthyReaderNode.reader);
                 unHealthyReaderNode.clientSessions
                         .values()
-                        .forEach(clientSession -> clientSession.tell(new UnregisterChannelReader(channelId)));
+                        .forEach(clientSession -> clientSession.tell(new RefreshChannelReader(channelId)));
             }
         }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
@@ -12,4 +12,8 @@ public interface ClientMessageSender {
     void sendUpdatedMessage(ChatMessage updatedMessage);
 
     void sendDeletedMessage(ChatMessage deletedMessage);
+
+    void sendWebSocketPing();
+
+    void requestSessionReconnect();
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -1,6 +1,7 @@
 package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
+import com.tok.pekko.domain.chat.actor.HealthCheckConst;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
@@ -44,8 +45,9 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
-    private static final long TIMER_DURATION = 190L;
     private static final int MINIMUM_PING_COUNT = 3;
+    private static final long CHANNEL_READER_PING_INTERVAL_SECONDS = HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS;
+    private static final long TIMER_DURATION = CHANNEL_READER_PING_INTERVAL_SECONDS * MINIMUM_PING_COUNT;
 
     public static Behavior<ClientSessionCommand> create(
             Clock clock,
@@ -199,15 +201,9 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     }
 
     private Behavior<ClientSessionCommand> onPingHealthCheck(PingHealthCheck command) {
-        CounterNode counterNode = pingCounter.get(command.channelId());
+        CounterNode counterNode = pingCounter.computeIfAbsent(command.channelId(), channelId -> new CounterNode(clock));
 
-        if (counterNode != null) {
-            counterNode.pingCount++;
-
-            return this;
-        }
-
-        pingCounter.put(command.channelId(), new CounterNode(clock));
+        counterNode.recordPing(clock);
         command.replyTo()
                .tell(new PongHealthCheck(userId));
         return this;
@@ -275,6 +271,9 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             readers.remove(channelId);
             pingCounter.remove(channelId);
         });
+        if (!unHealthChannelIds.isEmpty()) {
+            readerRegistry.tell(new GetChannelReaderActor(userId, unHealthChannelIds, getContext().getSelf()));
+        }
         pingCounter.values().forEach(counterNode -> counterNode.reset(clock));
 
         return this;
@@ -295,22 +294,58 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
     private static class CounterNode {
 
-        private LocalDateTime readerSpawnedAt;
+        private LocalDateTime lastResetAt;
+        private LocalDateTime lastPingAt;
         private int pingCount;
 
         private CounterNode(Clock clock) {
-            this.readerSpawnedAt = LocalDateTime.now(clock);
+            this.lastResetAt = LocalDateTime.now(clock);
+            this.lastPingAt = null;
             this.pingCount = 0;
         }
 
-        private boolean isUnHealthy(LocalDateTime now) {
-            long elapsedSeconds = ChronoUnit.SECONDS.between(readerSpawnedAt, now);
+        private void recordPing(Clock clock) {
+            this.pingCount++;
+            this.lastPingAt = LocalDateTime.now(clock);
+        }
 
-            return elapsedSeconds >= TIMER_DURATION && pingCount < MINIMUM_PING_COUNT;
+        private boolean isUnHealthy(LocalDateTime now) {
+            long elapsedSinceReset = ChronoUnit.SECONDS.between(lastResetAt, now);
+
+            if (hasNotReachedFirstPingInterval(elapsedSinceReset)) {
+                return false;
+            }
+
+            return hasPingCountDeficit(elapsedSinceReset) || isPingStalled(now, elapsedSinceReset);
+        }
+
+        private boolean hasNotReachedFirstPingInterval(long elapsedSeconds) {
+            return elapsedSeconds < CHANNEL_READER_PING_INTERVAL_SECONDS;
+        }
+
+        private boolean hasPingCountDeficit(long elapsedSinceReset) {
+            long expectedCount = calculateExpectedPingCount(elapsedSinceReset);
+
+            return pingCount < expectedCount;
+        }
+
+        private boolean isPingStalled(LocalDateTime now, long elapsedSinceReset) {
+            long elapsedSincePing = lastPingAt == null
+                    ? elapsedSinceReset
+                    : ChronoUnit.SECONDS.between(lastPingAt, now);
+
+            return elapsedSincePing >= CHANNEL_READER_PING_INTERVAL_SECONDS * MINIMUM_PING_COUNT;
+        }
+
+        private long calculateExpectedPingCount(long elapsedSeconds) {
+            long countBasedOnInterval = elapsedSeconds / CHANNEL_READER_PING_INTERVAL_SECONDS;
+
+            return Math.min(MINIMUM_PING_COUNT, Math.max(1, countBasedOnInterval));
         }
 
         private void reset(Clock clock) {
-            this.readerSpawnedAt = LocalDateTime.now(clock);
+            this.lastResetAt = LocalDateTime.now(clock);
+            this.lastPingAt = null;
             this.pingCount = 0;
         }
     }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -18,8 +18,6 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.JoinChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.LeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
@@ -72,7 +70,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                         userId,
                                         clientMessageSender,
                                         messageStoragePort,
-                                        channelMembershipPort,
                                         readerRegistry
                                 );
                             }
@@ -85,7 +82,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     private final Long userId;
     private final ClientMessageSender clientMessageSender;
     private final MessageStoragePort messageStoragePort;
-    private final ChannelMembershipPort channelMembershipPort;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
     private final Map<Long, CounterNode> pingCounter;
@@ -97,7 +93,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
-            ChannelMembershipPort channelMembershipPort,
             ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
         super(context);
@@ -106,7 +101,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         this.userId = userId;
         this.messageStoragePort = messageStoragePort;
         this.clientMessageSender = clientMessageSender;
-        this.channelMembershipPort = channelMembershipPort;
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
         this.pingCounter = new HashMap<>();
@@ -124,9 +118,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(FoundRegisteredChannelIds.class, this::onFoundRegisteredChannelIds)
                                   .onMessage(UnregisterChannelReader.class, this::onUnregisterChannelReader)
                                   .onMessage(FoundChannelReaders.class, this::onFoundChannelReaders)
-                                  .onMessage(JoinChannel.class, this::onJoinChannel)
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
-                                  .onMessage(LeaveChannel.class, this::onLeaveChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
                                   .onMessage(PingHealthCheck.class, this::onPingHealthCheck)
                                   .onMessage(HeartBeat.class, this::onHeartBeat)
@@ -241,18 +233,8 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         return this;
     }
 
-    private Behavior<ClientSessionCommand> onJoinChannel(JoinChannel command) {
-        channelMembershipPort.joinChannel(userId, command.channelId(), getContext().getSelf());
-        return this;
-    }
-
     private Behavior<ClientSessionCommand> onSyncJoinChannel(SyncJoinChannel command) {
         readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
-        return this;
-    }
-
-    private Behavior<ClientSessionCommand> onLeaveChannel(LeaveChannel command) {
-        channelMembershipPort.leaveChannel(userId, command.channelId(), getContext().getSelf());
         return this;
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -262,10 +262,8 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             readers.remove(channelId);
             pingCounter.remove(channelId);
         });
-        if (!unHealthChannelIds.isEmpty()) {
-            readerRegistry.tell(new GetChannelReaderActor(userId, unHealthChannelIds, getContext().getSelf()));
-        }
-        pingCounter.values().forEach(counterNode -> counterNode.reset(clock));
+        pingCounter.values()
+                   .forEach(counterNode -> counterNode.reset(clock));
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -45,6 +45,7 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
+    private static final int INIT_HISTORY_SIZE = 50;
     private static final int MINIMUM_PING_COUNT = 3;
     private static final long CHANNEL_READER_PING_INTERVAL_SECONDS = HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS;
     private static final long TIMER_DURATION = CHANNEL_READER_PING_INTERVAL_SECONDS * MINIMUM_PING_COUNT;
@@ -217,6 +218,13 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             readers.put(channelId, reader);
             pingCounter.put(channelId, new CounterNode(clock));
             reader.tell(new RegisterClientSession(userId, getContext().getSelf()));
+
+            messageStoragePort.findHistory(
+                    channelId,
+                    Long.MAX_VALUE,
+                    INIT_HISTORY_SIZE,
+                    getContext().getSelf()
+            );
 
             RequestHistory requestHistoryCommand = this.pendingRequestHistory.remove(channelId);
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -21,7 +21,9 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SessionPongReceived;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +38,9 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
+    private static final long WEBSOCKET_HEALTHCHECK_INTERVAL_SECONDS = 30L;
+    private static final int MAX_MISSED_SESSION_PONGS = 2;
+
     public static Behavior<ClientSessionCommand> create(
             Long userId,
             ClientMessageSender clientMessageSender,
@@ -47,12 +52,21 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                 context -> {
                     channelMembershipPort.findParticipatingChannels(userId, context.getSelf());
 
-                    return new ClientSessionActor(
-                            context,
-                            userId,
-                            clientMessageSender,
-                            messageStoragePort,
-                            readerRegistry
+                    return Behaviors.withTimers(
+                            timers -> {
+                                timers.startTimerAtFixedRate(
+                                        new SessionHealthCheck(),
+                                        Duration.ofSeconds(WEBSOCKET_HEALTHCHECK_INTERVAL_SECONDS)
+                                );
+
+                                return new ClientSessionActor(
+                                        context,
+                                        userId,
+                                        clientMessageSender,
+                                        messageStoragePort,
+                                        readerRegistry
+                                );
+                            }
                     );
                 }
         );
@@ -64,6 +78,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
     private final Map<Long, RequestHistory> pendingRequestHistory;
+    private int missedSessionPongs;
 
     private ClientSessionActor(
             ActorContext<ClientSessionCommand> context,
@@ -80,6 +95,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
         this.pendingRequestHistory = new HashMap<>();
+        this.missedSessionPongs = 0;
     }
 
     @Override
@@ -96,6 +112,8 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
                                   .onMessage(Shutdown.class, this::onShutdown)
+                                  .onMessage(SessionPongReceived.class, this::onSessionPongReceived)
+                                  .onMessage(SessionHealthCheck.class, this::onSessionHealthCheck)
                                   .build();
     }
 
@@ -218,5 +236,24 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         return Behaviors.stopped();
     }
 
+    private Behavior<ClientSessionCommand> onSessionPongReceived(SessionPongReceived command) {
+        missedSessionPongs = 0;
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onSessionHealthCheck(SessionHealthCheck command) {
+        clientMessageSender.sendWebSocketPing();
+        missedSessionPongs++;
+
+        if (missedSessionPongs >= MAX_MISSED_SESSION_PONGS) {
+            clientMessageSender.requestSessionReconnect();
+            missedSessionPongs = 0;
+        }
+
+        return this;
+    }
+
     public record FoundChannelReaders(Map<Long, ActorRef<ChannelReaderCommand>> chatChannelReaderRefs) implements ClientSessionCommand { }
+    private record SessionHealthCheck() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -4,6 +4,7 @@ import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannel
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
@@ -34,8 +35,6 @@ import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.actor.typed.javadsl.Receive;
 
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
-
-    private static final int INIT_HISTORY_SIZE = 50;
 
     public static Behavior<ClientSessionCommand> create(
             Long userId,
@@ -174,13 +173,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
             readers.put(channelId, reader);
             reader.tell(new RegisterClientSession(userId, getContext().getSelf()));
-
-            messageStoragePort.findHistory(
-                    channelId,
-                    Long.MAX_VALUE,
-                    INIT_HISTORY_SIZE,
-                    getContext().getSelf()
-            );
+            reader.tell(new RequestInitialHistory(getContext().getSelf()));
 
             RequestHistory requestHistoryCommand = this.pendingRequestHistory.remove(channelId);
 
@@ -188,7 +181,8 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                 reader.tell(
                         new GetHistory(
                                 requestHistoryCommand.messageSequence(),
-                                requestHistoryCommand.size(), getContext().getSelf()
+                                requestHistoryCommand.size(),
+                                getContext().getSelf()
                         )
                 );
             }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -23,7 +23,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import java.time.Clock;
 import java.time.Duration;
@@ -116,7 +116,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(DeliverHistory.class, this::onDeliverHistory)
                                   .onMessage(FoundHistory.class, this::onFoundHistory)
                                   .onMessage(FoundRegisteredChannelIds.class, this::onFoundRegisteredChannelIds)
-                                  .onMessage(UnregisterChannelReader.class, this::onUnregisterChannelReader)
+                                  .onMessage(RefreshChannelReader.class, this::onRefreshChannelReader)
                                   .onMessage(FoundChannelReaders.class, this::onFoundChannelReaders)
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
@@ -187,9 +187,10 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         return this;
     }
 
-    private Behavior<ClientSessionCommand> onUnregisterChannelReader(UnregisterChannelReader command) {
+    private Behavior<ClientSessionCommand> onRefreshChannelReader(RefreshChannelReader command) {
         readers.remove(command.channelId());
         pingCounter.remove(command.channelId());
+        readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
         return this;
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -1,16 +1,13 @@
 package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
-import com.tok.pekko.domain.chat.actor.HealthCheckConst;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseChannelReaderActor;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
@@ -18,17 +15,12 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
-import java.time.Clock;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,12 +36,8 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
     private static final int INIT_HISTORY_SIZE = 50;
-    private static final int MINIMUM_PING_COUNT = 3;
-    private static final long CHANNEL_READER_PING_INTERVAL_SECONDS = HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS;
-    private static final long TIMER_DURATION = CHANNEL_READER_PING_INTERVAL_SECONDS * MINIMUM_PING_COUNT;
 
     public static Behavior<ClientSessionCommand> create(
-            Clock clock,
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
@@ -60,36 +48,26 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                 context -> {
                     channelMembershipPort.findParticipatingChannels(userId, context.getSelf());
 
-                    return Behaviors.withTimers(
-                            timers -> {
-                                timers.startTimerAtFixedRate(new HeartBeat(), Duration.ofSeconds(TIMER_DURATION));
-
-                                return new ClientSessionActor(
-                                        context,
-                                        clock,
-                                        userId,
-                                        clientMessageSender,
-                                        messageStoragePort,
-                                        readerRegistry
-                                );
-                            }
+                    return new ClientSessionActor(
+                            context,
+                            userId,
+                            clientMessageSender,
+                            messageStoragePort,
+                            readerRegistry
                     );
                 }
         );
     }
 
-    private final Clock clock;
     private final Long userId;
     private final ClientMessageSender clientMessageSender;
     private final MessageStoragePort messageStoragePort;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
-    private final Map<Long, CounterNode> pingCounter;
     private final Map<Long, RequestHistory> pendingRequestHistory;
 
     private ClientSessionActor(
             ActorContext<ClientSessionCommand> context,
-            Clock clock,
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
@@ -97,13 +75,11 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     ) {
         super(context);
 
-        this.clock = clock;
         this.userId = userId;
         this.messageStoragePort = messageStoragePort;
         this.clientMessageSender = clientMessageSender;
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
-        this.pingCounter = new HashMap<>();
         this.pendingRequestHistory = new HashMap<>();
     }
 
@@ -120,8 +96,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(FoundChannelReaders.class, this::onFoundChannelReaders)
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
-                                  .onMessage(PingHealthCheck.class, this::onPingHealthCheck)
-                                  .onMessage(HeartBeat.class, this::onHeartBeat)
                                   .onMessage(Shutdown.class, this::onShutdown)
                                   .build();
     }
@@ -189,17 +163,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
     private Behavior<ClientSessionCommand> onRefreshChannelReader(RefreshChannelReader command) {
         readers.remove(command.channelId());
-        pingCounter.remove(command.channelId());
         readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
-        return this;
-    }
-
-    private Behavior<ClientSessionCommand> onPingHealthCheck(PingHealthCheck command) {
-        CounterNode counterNode = pingCounter.computeIfAbsent(command.channelId(), channelId -> new CounterNode(clock));
-
-        counterNode.recordPing(clock);
-        command.replyTo()
-               .tell(new PongHealthCheck(userId));
         return this;
     }
 
@@ -209,7 +173,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             ActorRef<ChannelReaderCommand> reader = readerEntry.getValue();
 
             readers.put(channelId, reader);
-            pingCounter.put(channelId, new CounterNode(clock));
             reader.tell(new RegisterClientSession(userId, getContext().getSelf()));
 
             messageStoragePort.findHistory(
@@ -249,25 +212,6 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         return this;
     }
 
-    private Behavior<ClientSessionCommand> onHeartBeat(HeartBeat command) {
-        LocalDateTime now = LocalDateTime.now(clock);
-        List<Long> unHealthChannelIds = pingCounter.entrySet()
-                                                   .stream()
-                                                   .filter(entry -> entry.getValue().isUnHealthy(now))
-                                                   .map(Entry::getKey)
-                                                   .toList();
-
-        readerRegistry.tell(new ReportUnhealthyChannelReader(unHealthChannelIds));
-        unHealthChannelIds.forEach(channelId -> {
-            readers.remove(channelId);
-            pingCounter.remove(channelId);
-        });
-        pingCounter.values()
-                   .forEach(counterNode -> counterNode.reset(clock));
-
-        return this;
-    }
-
     private Behavior<ClientSessionCommand> onShutdown(Shutdown command) {
         ArrayList<Long> channelIds = new ArrayList<>(readers.keySet());
 
@@ -275,70 +219,10 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
         readers.values()
                .forEach(reader -> reader.tell(new UnregisterClientSession(userId)));
         readers.clear();
-        pingCounter.clear();
         pendingRequestHistory.clear();
 
         return Behaviors.stopped();
     }
 
-    private static class CounterNode {
-
-        private LocalDateTime lastResetAt;
-        private LocalDateTime lastPingAt;
-        private int pingCount;
-
-        private CounterNode(Clock clock) {
-            this.lastResetAt = LocalDateTime.now(clock);
-            this.lastPingAt = null;
-            this.pingCount = 0;
-        }
-
-        private void recordPing(Clock clock) {
-            this.pingCount++;
-            this.lastPingAt = LocalDateTime.now(clock);
-        }
-
-        private boolean isUnHealthy(LocalDateTime now) {
-            long elapsedSinceReset = ChronoUnit.SECONDS.between(lastResetAt, now);
-
-            if (hasNotReachedFirstPingInterval(elapsedSinceReset)) {
-                return false;
-            }
-
-            return hasPingCountDeficit(elapsedSinceReset) || isPingStalled(now, elapsedSinceReset);
-        }
-
-        private boolean hasNotReachedFirstPingInterval(long elapsedSeconds) {
-            return elapsedSeconds < CHANNEL_READER_PING_INTERVAL_SECONDS;
-        }
-
-        private boolean hasPingCountDeficit(long elapsedSinceReset) {
-            long expectedCount = calculateExpectedPingCount(elapsedSinceReset);
-
-            return pingCount < expectedCount;
-        }
-
-        private boolean isPingStalled(LocalDateTime now, long elapsedSinceReset) {
-            long elapsedSincePing = lastPingAt == null
-                    ? elapsedSinceReset
-                    : ChronoUnit.SECONDS.between(lastPingAt, now);
-
-            return elapsedSincePing >= CHANNEL_READER_PING_INTERVAL_SECONDS * MINIMUM_PING_COUNT;
-        }
-
-        private long calculateExpectedPingCount(long elapsedSeconds) {
-            long countBasedOnInterval = elapsedSeconds / CHANNEL_READER_PING_INTERVAL_SECONDS;
-
-            return Math.min(MINIMUM_PING_COUNT, Math.max(1, countBasedOnInterval));
-        }
-
-        private void reset(Clock clock) {
-            this.lastResetAt = LocalDateTime.now(clock);
-            this.lastPingAt = null;
-            this.pingCount = 0;
-        }
-    }
-
     public record FoundChannelReaders(Map<Long, ActorRef<ChannelReaderCommand>> chatChannelReaderRefs) implements ClientSessionCommand { }
-    private record HeartBeat() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
@@ -2,31 +2,72 @@ package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.atomic.AtomicReference;
 import reactor.core.publisher.Sinks;
 
-@RequiredArgsConstructor
 public class WebSocketMessageSender implements ClientMessageSender {
 
-    private final Sinks.Many<ChatMessage> sink;
+    public static final String EVENT_NEW = "NEW";
+    public static final String EVENT_UPDATED = "UPDATED";
+    public static final String EVENT_DELETED = "DELETED";
+    public static final String EVENT_WS_PING = "WS_HEALTH_PING";
+    public static final String EVENT_WS_RECONNECT = "WS_RECONNECT";
+
+    private final AtomicReference<Sinks.Many<WebSocketPayload>> sinkHolder;
+
+    public WebSocketMessageSender() {
+        this(null);
+    }
+
+    public WebSocketMessageSender(Sinks.Many<WebSocketPayload> sink) {
+        this.sinkHolder = new AtomicReference<>(sink);
+    }
+
+    public void attachSink(Sinks.Many<WebSocketPayload> sink) {
+        sinkHolder.set(sink);
+    }
+
+    public void detachSink(Sinks.Many<WebSocketPayload> sink) {
+        sinkHolder.compareAndSet(sink, null);
+    }
 
     @Override
     public void sendMessage(ChatMessage message) {
-        sink.tryEmitNext(message);
+        emit(new WebSocketPayload(EVENT_NEW, message));
     }
 
     @Override
     public void sendMessages(List<ChatMessage> messages) {
-        messages.forEach(sink::tryEmitNext);
+        messages.forEach(this::sendMessage);
     }
 
     @Override
     public void sendDeletedMessage(ChatMessage deletedMessage) {
-        sink.tryEmitNext(deletedMessage);
+        emit(new WebSocketPayload(EVENT_DELETED, deletedMessage));
     }
 
     @Override
     public void sendUpdatedMessage(ChatMessage updatedMessage) {
-        sink.tryEmitNext(updatedMessage);
+        emit(new WebSocketPayload(EVENT_UPDATED, updatedMessage));
     }
+
+    @Override
+    public void sendWebSocketPing() {
+        emit(new WebSocketPayload(EVENT_WS_PING, null));
+    }
+
+    @Override
+    public void requestSessionReconnect() {
+        emit(new WebSocketPayload(EVENT_WS_RECONNECT, null));
+    }
+
+    private void emit(WebSocketPayload payload) {
+        Sinks.Many<WebSocketPayload> sink = sinkHolder.get();
+
+        if (sink != null) {
+            sink.tryEmitNext(payload);
+        }
+    }
+
+    public record WebSocketPayload(String type, ChatMessage message) { }
 }

--- a/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
@@ -3,6 +3,8 @@ package com.tok.pekko.application.actor;
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
@@ -58,6 +60,22 @@ public class ClientSessionActorManagementService {
         }
 
         return clientSession;
+    }
+
+    public void syncJoinChannel(Long channelId, Long userId) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(userId);
+
+        if (clientSession != null) {
+            clientSession.tell(new SyncJoinChannel(channelId));
+        }
+    }
+
+    public void syncLeaveChannel(Long channelId, Long userId) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(userId);
+
+        if (clientSession != null) {
+            clientSession.tell(new SyncLeaveChannel(channelId));
+        }
     }
 
     public static class ClientSessionNotFoundException extends IllegalStateException {

--- a/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
@@ -1,5 +1,6 @@
 package com.tok.pekko.application.channel;
 
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.ChannelRole;
@@ -19,11 +20,13 @@ public class ChannelMembershipService {
 
     private final Clock clock;
     private final ChannelStoragePort channelStoragePort;
+    private final ClientSessionActorManagementService clientSessionActorManagementService;
 
     public void joinChannel(Long channelId, Long userId) {
         Channel channel = channelStoragePort.findChannel(channelId);
 
         channel.joinMember(UserId.create(userId), ChannelRole.MEMBER, LocalDateTime.now(clock));
+        clientSessionActorManagementService.syncJoinChannel(channelId, userId);
     }
 
     public void inviteMember(Long channelId, Long inviterId, Long inviteeId) {
@@ -34,12 +37,14 @@ public class ChannelMembershipService {
         }
 
         channel.inviteMember(UserId.create(inviteeId), ChannelRole.MEMBER, LocalDateTime.now(clock));
+        clientSessionActorManagementService.syncJoinChannel(channelId, inviteeId);
     }
 
     public void leaveChannel(Long channelId, Long userId) {
         Channel channel = channelStoragePort.findChannel(channelId);
 
         channel.leaveMember(UserId.create(userId));
+        clientSessionActorManagementService.syncLeaveChannel(channelId, userId);
     }
 
     public void managedMemberRole(Long channelId, Long executorId, Long targetUserId, ChannelRole channelRole) {

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -20,7 +20,6 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessag
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -235,8 +234,10 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     }
 
     private Behavior<ChannelReaderCommand> onPostStop(PostStop signal) {
-        clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new RefreshChannelReader(channelId)));
+        healthCheckTimeouts.values()
+                           .forEach(Cancellable::cancel);
+        healthCheckTimeouts.clear();
+        clientSessions.clear();
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -19,6 +19,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
 import java.time.Duration;
 import java.util.HashMap;
@@ -36,6 +37,9 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 
 public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
+
+    private static final Duration HEALTH_CHECK_TIMEOUT =
+            Duration.ofSeconds(HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS * 2);
 
     public static Behavior<ChannelReaderCommand> create(
             Long channelId,
@@ -55,7 +59,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                     return Behaviors.withTimers(
                             timers -> {
                                 timers.startTimerAtFixedRate(new SyncMessageHeartBeat(), Duration.ofSeconds(30L));
-                                timers.startTimerAtFixedRate(new ClientSessionHealthCheckHeartBeat(), Duration.ofSeconds(60L));
+                                timers.startTimerAtFixedRate(new ClientSessionHealthCheckHeartBeat(), Duration.ofSeconds(HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS));
 
                                 return new ChannelReaderActor(
                                         context,
@@ -102,6 +106,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(SyncMessageHeartBeat.class, this::onSyncMessageHeartBeat)
                                   .onMessage(DeliverSyncMessages.class, this::onDeliverSyncMessages)
                                   .onMessage(GetHistory.class, this::onGetHistory)
+                                  .onMessage(ClientSessionHealthCheckHeartBeat.class, this::onClientSessionHealthCheckHeartBeat)
                                   .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
                                   .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
@@ -169,6 +174,19 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private Behavior<ChannelReaderCommand> onRegisterClientSession(RegisterClientSession command) {
         clientSessions.put(command.userId(), command.clientSession());
         getContext().watch(command.clientSession());
+        pingClientSession(command.userId());
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onClientSessionHealthCheckHeartBeat(
+            ClientSessionHealthCheckHeartBeat command
+    ) {
+        getContext().getLog()
+                    .debug("ChannelReaderActor.onClientSessionHealthCheckHeartBeat channelId={} sessionCount={}",
+                            channelId,
+                            clientSessions.size());
+        clientSessions.keySet().forEach(this::pingClientSession);
 
         return this;
     }
@@ -221,6 +239,28 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                       .forEach(clientSession -> clientSession.tell(new UnregisterChannelReader(channelId)));
 
         return this;
+    }
+
+    private void pingClientSession(Long userId) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(userId);
+
+        if (clientSession == null) {
+            return;
+        }
+
+        Cancellable existing = healthCheckTimeouts.remove(userId);
+        if (existing != null) {
+            existing.cancel();
+        }
+
+        Cancellable timeout = getContext().scheduleOnce(
+                HEALTH_CHECK_TIMEOUT,
+                getContext().getSelf(),
+                new PongHealthCheckTimeout(userId)
+        );
+        healthCheckTimeouts.put(userId, timeout);
+
+        clientSession.tell(new PingHealthCheck(channelId, getContext().getSelf()));
     }
 
     private record SyncMessageHeartBeat() implements ChannelReaderCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -6,6 +6,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
@@ -17,7 +18,9 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +71,9 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private final ChatMessages messages;
     private final EntityRef<ChannelEntityCommand> channelEntity;
     private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions;
+    private final List<RequestInitialHistory> requestInitialHistories;
+    private final List<Runnable> pendingSyncEvents;
+    private boolean initialHistorySynced;
 
     private ChannelReaderActor(
             ActorContext<ChannelReaderCommand> context,
@@ -81,6 +87,9 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         this.messages = messages;
         this.channelEntity = channelEntity;
         this.clientSessions = new HashMap<>();
+        this.requestInitialHistories = new ArrayList<>();
+        this.pendingSyncEvents = new ArrayList<>();
+        this.initialHistorySynced = false;
     }
 
     @Override
@@ -93,37 +102,41 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(GetHistory.class, this::onGetHistory)
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
                                   .onMessage(UnregisterClientSession.class, this::onUnregisterClientSession)
+                                  .onMessage(RequestInitialHistory.class, this::onRequestInitialHistory)
                                   .onSignal(Terminated.class, this::onTerminated)
                                   .onSignal(PostStop.class, this::onPostStop)
                                   .build();
     }
 
     private Behavior<ChannelReaderCommand> onSyncNewMessage(SyncNewMessage command) {
-        messages.add(command.message());
-        clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new DeliverNewMessage(command.message())));
+        if (!initialHistorySynced) {
+            pendingSyncEvents.add(() -> applySyncNewMessage(command));
+            return this;
+        }
+
+        applySyncNewMessage(command);
 
         return this;
     }
 
     private Behavior<ChannelReaderCommand> onSyncUpdate(SyncUpdate command) {
-        ChatMessage updatedMessage = messages.update(
-                command.messageId(),
-                command.updatedMessage(),
-                command.updatedAt()
-        );
+        if (!initialHistorySynced) {
+            pendingSyncEvents.add(() -> applySyncUpdate(command));
+            return this;
+        }
 
-        clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new DeliverUpdatedMessage(updatedMessage)));
+        applySyncUpdate(command);
 
         return this;
     }
 
     private Behavior<ChannelReaderCommand> onSyncDeletion(SyncDeletion command) {
-        ChatMessage deletedMessage = messages.delete(command.messageId());
+        if (!initialHistorySynced) {
+            pendingSyncEvents.add(() -> applySyncDeletion(command));
+            return this;
+        }
 
-        clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new DeliverDeletedMessage(deletedMessage)));
+        applySyncDeletion(command);
 
         return this;
     }
@@ -148,7 +161,10 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     }
 
     private Behavior<ChannelReaderCommand> onDeliverSyncMessages(DeliverSyncMessages command) {
-        this.messages.syncMessages(command.messages());
+        messages.syncMessages(command.messages());
+        initialHistorySynced = true;
+        applyPendingSyncEvents();
+        fulfillPendingInitialHistoryRequests();
 
         return this;
     }
@@ -163,6 +179,19 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private Behavior<ChannelReaderCommand> onUnregisterClientSession(UnregisterClientSession command) {
         clientSessions.remove(command.userId());
 
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onRequestInitialHistory(RequestInitialHistory command) {
+        if (!initialHistorySynced) {
+            requestInitialHistories.add(command);
+            return this;
+        }
+
+        List<ChatMessage> history = this.messages.getMessages();
+
+        command.replyTo()
+                .tell(new FoundHistory(history));
         return this;
     }
 
@@ -181,6 +210,52 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         clientSessions.clear();
 
         return this;
+    }
+
+    private void applySyncNewMessage(SyncNewMessage command) {
+        messages.add(command.message());
+        clientSessions.values()
+                      .forEach(clientSession -> clientSession.tell(new DeliverNewMessage(command.message())));
+    }
+
+    private void applySyncUpdate(SyncUpdate command) {
+        ChatMessage updatedMessage = messages.update(
+                command.messageId(),
+                command.updatedMessage(),
+                command.updatedAt()
+        );
+
+        clientSessions.values()
+                      .forEach(clientSession -> clientSession.tell(new DeliverUpdatedMessage(updatedMessage)));
+    }
+
+    private void applySyncDeletion(SyncDeletion command) {
+        ChatMessage deletedMessage = messages.delete(command.messageId());
+
+        clientSessions.values()
+                      .forEach(clientSession -> clientSession.tell(new DeliverDeletedMessage(deletedMessage)));
+    }
+
+    private void fulfillPendingInitialHistoryRequests() {
+        if (requestInitialHistories.isEmpty()) {
+            return;
+        }
+
+        List<ChatMessage> historySnapshot = messages.getMessages();
+
+        requestInitialHistories.forEach(
+                requestInitialHistory -> requestInitialHistory.replyTo().tell(new FoundHistory(historySnapshot))
+        );
+        requestInitialHistories.clear();
+    }
+
+    private void applyPendingSyncEvents() {
+        if (pendingSyncEvents.isEmpty()) {
+            return;
+        }
+
+        pendingSyncEvents.forEach(Runnable::run);
+        pendingSyncEvents.clear();
     }
 
     private record SyncMessageHeartBeat() implements ChannelReaderCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -4,7 +4,6 @@ import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
@@ -12,19 +11,16 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
-import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.pekko.actor.Cancellable;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
 import org.apache.pekko.actor.typed.PostStop;
@@ -36,9 +32,6 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 
 public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
-
-    private static final Duration HEALTH_CHECK_TIMEOUT =
-            Duration.ofSeconds(HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS * 2);
 
     public static Behavior<ChannelReaderCommand> create(
             Long channelId,
@@ -58,14 +51,12 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                     return Behaviors.withTimers(
                             timers -> {
                                 timers.startTimerAtFixedRate(new SyncMessageHeartBeat(), Duration.ofSeconds(30L));
-                                timers.startTimerAtFixedRate(new ClientSessionHealthCheckHeartBeat(), Duration.ofSeconds(HealthCheckConst.CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS));
 
                                 return new ChannelReaderActor(
                                         context,
                                         channelId,
                                         messages,
-                                        channelEntity,
-                                        readerRegistry
+                                        channelEntity
                                 );
                             }
                     );
@@ -76,25 +67,20 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private final Long channelId;
     private final ChatMessages messages;
     private final EntityRef<ChannelEntityCommand> channelEntity;
-    private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions;
-    private final Map<Long, Cancellable> healthCheckTimeouts;
 
     private ChannelReaderActor(
             ActorContext<ChannelReaderCommand> context,
             Long channelId,
             ChatMessages messages,
-            EntityRef<ChannelEntityCommand> channelEntity,
-            ActorRef<ChannelReaderRegistryCommand> readerRegistry
+            EntityRef<ChannelEntityCommand> channelEntity
     ) {
         super(context);
 
         this.channelId = channelId;
         this.messages = messages;
         this.channelEntity = channelEntity;
-        this.readerRegistry = readerRegistry;
         this.clientSessions = new HashMap<>();
-        this.healthCheckTimeouts = new HashMap<>();
     }
 
     @Override
@@ -105,9 +91,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(SyncMessageHeartBeat.class, this::onSyncMessageHeartBeat)
                                   .onMessage(DeliverSyncMessages.class, this::onDeliverSyncMessages)
                                   .onMessage(GetHistory.class, this::onGetHistory)
-                                  .onMessage(ClientSessionHealthCheckHeartBeat.class, this::onClientSessionHealthCheckHeartBeat)
-                                  .onMessage(PongHealthCheck.class, this::onPongHealthCheck)
-                                  .onMessage(PongHealthCheckTimeout.class, this::onPongHealthCheckTimeout)
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
                                   .onMessage(UnregisterClientSession.class, this::onUnregisterClientSession)
                                   .onSignal(Terminated.class, this::onTerminated)
@@ -173,42 +156,6 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private Behavior<ChannelReaderCommand> onRegisterClientSession(RegisterClientSession command) {
         clientSessions.put(command.userId(), command.clientSession());
         getContext().watch(command.clientSession());
-        pingClientSession(command.userId());
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onClientSessionHealthCheckHeartBeat(
-            ClientSessionHealthCheckHeartBeat command
-    ) {
-        getContext().getLog()
-                    .debug("ChannelReaderActor.onClientSessionHealthCheckHeartBeat channelId={} sessionCount={}",
-                            channelId,
-                            clientSessions.size());
-        clientSessions.keySet().forEach(this::pingClientSession);
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onPongHealthCheck(PongHealthCheck command) {
-        Cancellable schedule = healthCheckTimeouts.remove(command.userId());
-
-        if (schedule != null) {
-            schedule.cancel();
-        }
-
-        return this;
-    }
-
-    private Behavior<ChannelReaderCommand> onPongHealthCheckTimeout(PongHealthCheckTimeout command) {
-        healthCheckTimeouts.remove(command.userId());
-
-        ActorRef<ClientSessionCommand> clientSession = clientSessions.remove(command.userId());
-
-        if (clientSession != null) {
-            getContext().unwatch(clientSession);
-            readerRegistry.tell(new ReportUnhealthyClientSession(command.userId(), command.userId()));
-        }
 
         return this;
     }
@@ -225,47 +172,17 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                       .filter(entry -> entry.getValue().path().equals(signal.getRef().path()))
                       .map(Map.Entry::getKey)
                       .findFirst()
-                      .ifPresent(userId -> {
-                          healthCheckTimeouts.remove(userId);
-                          clientSessions.remove(userId);
-                      });
+                      .ifPresent(clientSessions::remove);
 
         return this;
     }
 
     private Behavior<ChannelReaderCommand> onPostStop(PostStop signal) {
-        healthCheckTimeouts.values()
-                           .forEach(Cancellable::cancel);
-        healthCheckTimeouts.clear();
         clientSessions.clear();
 
         return this;
     }
 
-    private void pingClientSession(Long userId) {
-        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(userId);
-
-        if (clientSession == null) {
-            return;
-        }
-
-        Cancellable existing = healthCheckTimeouts.remove(userId);
-        if (existing != null) {
-            existing.cancel();
-        }
-
-        Cancellable timeout = getContext().scheduleOnce(
-                HEALTH_CHECK_TIMEOUT,
-                getContext().getSelf(),
-                new PongHealthCheckTimeout(userId)
-        );
-        healthCheckTimeouts.put(userId, timeout);
-
-        clientSession.tell(new PingHealthCheck(channelId, getContext().getSelf()));
-    }
-
     private record SyncMessageHeartBeat() implements ChannelReaderCommand { }
-    private record ClientSessionHealthCheckHeartBeat() implements ChannelReaderCommand { }
-    private record PongHealthCheckTimeout(Long userId) implements ChannelReaderCommand { }
     record DeliverSyncMessages(List<ChatMessage> messages) implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -20,7 +20,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessag
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -236,7 +236,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     private Behavior<ChannelReaderCommand> onPostStop(PostStop signal) {
         clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new UnregisterChannelReader(channelId)));
+                      .forEach(clientSession -> clientSession.tell(new RefreshChannelReader(channelId)));
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/HealthCheckConst.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/HealthCheckConst.java
@@ -1,0 +1,9 @@
+package com.tok.pekko.domain.chat.actor;
+
+public final class HealthCheckConst {
+
+    public static final long CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS = 60L;
+
+    private HealthCheckConst() {
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/HealthCheckConst.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/HealthCheckConst.java
@@ -1,9 +1,0 @@
-package com.tok.pekko.domain.chat.actor;
-
-public final class HealthCheckConst {
-
-    public static final long CLIENT_SESSION_HEALTH_PING_INTERVAL_SECONDS = 60L;
-
-    private HealthCheckConst() {
-    }
-}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
@@ -16,5 +16,4 @@ public interface ChannelReaderProtocol {
     record GetHistory(long messageSequence, int size, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
     record RegisterClientSession(Long userId, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderCommand { }
     record UnregisterClientSession(Long userId) implements ChannelReaderCommand { }
-    record PongHealthCheck(Long userId) implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
@@ -16,4 +16,5 @@ public interface ChannelReaderProtocol {
     record GetHistory(long messageSequence, int size, ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
     record RegisterClientSession(Long userId, ActorRef<ClientSessionCommand> clientSession) implements ChannelReaderCommand { }
     record UnregisterClientSession(Long userId) implements ChannelReaderCommand { }
+    record RequestInitialHistory(ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipPort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipPort.java
@@ -6,8 +6,4 @@ import org.apache.pekko.actor.typed.ActorRef;
 public interface ChannelMembershipPort {
 
     void findParticipatingChannels(Long userId, ActorRef<ClientSessionCommand> replyTo);
-
-    void joinChannel(Long userId, Long channelId, ActorRef<ClientSessionCommand> replyTo);
-
-    void leaveChannel(Long userId, Long channelId, ActorRef<ClientSessionCommand> replyTo);
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -17,7 +17,7 @@ public interface ClientSessionProtocol {
     record FoundHistory(List<ChatMessage> history) implements ClientSessionCommand { }
     record DeliverHistory(Long channelId, long messageSequence, int size, List<ChatMessage> history) implements ClientSessionCommand { }
     record FoundRegisteredChannelIds(List<Long> channelIds) implements ClientSessionCommand { }
-    record UnregisterChannelReader(Long channelId) implements ClientSessionCommand { }
+    record RefreshChannelReader(Long channelId) implements ClientSessionCommand { }
     record SyncJoinChannel(Long channelId) implements ClientSessionCommand { }
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
     record PingHealthCheck(Long channelId, ActorRef<ChannelReaderCommand> replyTo) implements ClientSessionCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -19,4 +19,5 @@ public interface ClientSessionProtocol {
     record SyncJoinChannel(Long channelId) implements ClientSessionCommand { }
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
     record Shutdown() implements ClientSessionCommand { }
+    record SessionPongReceived() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -18,9 +18,7 @@ public interface ClientSessionProtocol {
     record DeliverHistory(Long channelId, long messageSequence, int size, List<ChatMessage> history) implements ClientSessionCommand { }
     record FoundRegisteredChannelIds(List<Long> channelIds) implements ClientSessionCommand { }
     record UnregisterChannelReader(Long channelId) implements ClientSessionCommand { }
-    record JoinChannel(Long channelId) implements ClientSessionCommand { }
     record SyncJoinChannel(Long channelId) implements ClientSessionCommand { }
-    record LeaveChannel(Long channelId) implements ClientSessionCommand { }
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
     record PingHealthCheck(Long channelId, ActorRef<ChannelReaderCommand> replyTo) implements ClientSessionCommand { }
     record Shutdown() implements ClientSessionCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -1,10 +1,8 @@
 package com.tok.pekko.domain.chat.port.out;
 
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
-import org.apache.pekko.actor.typed.ActorRef;
 
 public interface ClientSessionProtocol {
 
@@ -20,6 +18,5 @@ public interface ClientSessionProtocol {
     record RefreshChannelReader(Long channelId) implements ClientSessionCommand { }
     record SyncJoinChannel(Long channelId) implements ClientSessionCommand { }
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
-    record PingHealthCheck(Long channelId, ActorRef<ChannelReaderCommand> replyTo) implements ClientSessionCommand { }
     record Shutdown() implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -13,6 +13,7 @@ import java.time.Clock;
 import java.time.Duration;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.SupervisorStrategy;
 import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
@@ -48,14 +49,16 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
 
     private Behavior<GuardianCommand> onSpawnClientSession(SpawnClientSession command) {
         ActorRef<ClientSessionCommand> clientSession = getContext().spawn(
-                ClientSessionActor.create(
-                        clock,
-                        command.userId(),
-                        command.clientMessageSender(),
-                        command.messageStoragePort(),
-                        command.channelMembershipPort(),
-                        readerRegistry
-                ),
+                Behaviors.supervise(
+                        ClientSessionActor.create(
+                                clock,
+                                command.userId(),
+                                command.clientMessageSender(),
+                                command.messageStoragePort(),
+                                command.channelMembershipPort(),
+                                readerRegistry
+                        )
+                ).onFailure(SupervisorStrategy.restart()),
                 "client-session-" + System.nanoTime() + "-" + command.userId()
         );
 

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -9,7 +9,6 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCom
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
 import com.tok.pekko.global.common.CborSerializable;
-import java.time.Clock;
 import java.time.Duration;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
@@ -22,14 +21,13 @@ import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
 
 public class GuardianActor extends AbstractBehavior<GuardianCommand> {
 
-    public static Behavior<GuardianCommand> create(Clock clock) {
-        return Behaviors.setup(context -> new GuardianActor(context, clock));
+    public static Behavior<GuardianCommand> create() {
+        return Behaviors.setup(GuardianActor::new);
     }
 
-    private final Clock clock;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
 
-    private GuardianActor(ActorContext<GuardianCommand> context, Clock clock) {
+    private GuardianActor(ActorContext<GuardianCommand> context) {
         super(context);
 
         ClusterSharding clusterSharding = ClusterSharding.get(context.getSystem());
@@ -38,7 +36,6 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(240L)),
                 "channel-reader-registry-actor"
         );
-        this.clock = clock;
     }
 
     @Override
@@ -51,7 +48,6 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
         ActorRef<ClientSessionCommand> clientSession = getContext().spawn(
                 Behaviors.supervise(
                         ClientSessionActor.create(
-                                clock,
                                 command.userId(),
                                 command.clientMessageSender(),
                                 command.messageStoragePort(),

--- a/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
@@ -54,7 +54,7 @@ public class ClusterConfig {
     public ActorSystem<GuardianCommand> actorSystem() {
         Config config = buildConfig();
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(clock),
+                GuardianActor.create(),
                 "ChatCluster",
                 config
         );

--- a/pekko/src/test/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandlerTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandlerTest.java
@@ -7,7 +7,9 @@ import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SessionPongReceived;
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
@@ -24,6 +26,7 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -49,7 +52,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
@@ -58,7 +67,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         Mono<Void> result = handler.handle(session);
@@ -68,7 +76,6 @@ class DevChatWebSocketHandlerTest {
                     .verifyComplete();
 
         verify(managementService).createClientSessionActor(any(ClientMessageSender.class), eq(100L));
-        verify(clientSession).thenAccept(any());
     }
 
     @Test
@@ -86,7 +93,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
         String messageContent = "테스트 메시지";
@@ -98,7 +111,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         Mono<Void> result = handler.handle(session);
@@ -119,7 +131,13 @@ class DevChatWebSocketHandlerTest {
         WebSocketSession session = mock(WebSocketSession.class);
         HandshakeInfo handshakeInfo = mock(HandshakeInfo.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
@@ -140,7 +158,13 @@ class DevChatWebSocketHandlerTest {
         WebSocketSession session = mock(WebSocketSession.class);
         HandshakeInfo handshakeInfo = mock(HandshakeInfo.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
@@ -166,7 +190,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
 
@@ -176,7 +206,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
         given(objectMapper.writeValueAsString(any())).willThrow(JsonProcessingException.class);
 
         // when
@@ -201,7 +230,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
 
@@ -211,7 +246,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         Mono<Void> result = handler.handle(session);
@@ -220,7 +254,45 @@ class DevChatWebSocketHandlerTest {
         StepVerifier.create(result)
                     .verifyComplete();
 
-        verify(clientSession).thenAccept(any());
+    }
+
+    @Test
+    void 클라이언트로부터_WS_PONG_메시지를_받으면_Actor에_Pong을_전달한다() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
+        WebSocketSession session = mock(WebSocketSession.class);
+        HandshakeInfo handshakeInfo = mock(HandshakeInfo.class);
+        WebSocketMessage webSocketMessage = mock(WebSocketMessage.class);
+
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> entityRef = mock(EntityRef.class);
+        @SuppressWarnings("unchecked")
+        ActorRef<ClientSessionCommand> clientSessionActor = mock(ActorRef.class);
+
+        CompletionStage<ActorRef<ClientSessionCommand>> clientSession = CompletableFuture.completedFuture(clientSessionActor);
+
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
+
+        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+
+        given(session.getHandshakeInfo()).willReturn(handshakeInfo);
+        given(handshakeInfo.getUri()).willReturn(uri);
+        given(session.receive()).willReturn(Flux.just(webSocketMessage));
+        given(webSocketMessage.getPayloadAsText()).willReturn("{\"type\":\"WS_PONG\"}");
+        given(session.send(any())).willReturn(Mono.empty());
+        given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
+        given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
+
+        handler.handle(session).block();
+
+        verify(clientSessionActor).tell(any(SessionPongReceived.class));
     }
 
     @Test
@@ -239,7 +311,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
 
@@ -251,7 +329,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         Mono<Void> result = handler.handle(session);
@@ -277,7 +354,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=123&userId=456");
 
@@ -287,7 +370,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(456L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         handler.handle(session).subscribe();
@@ -311,7 +393,13 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(objectMapper, clusterSharding, managementService);
+        given(managementService.findClientSession(anyLong()))
+                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
+                objectMapper,
+                clusterSharding,
+                managementService
+        );
 
         URI uri = new URI("ws://localhost:8080/ws/chat?channelId=999&userId=100");
 
@@ -322,7 +410,6 @@ class DevChatWebSocketHandlerTest {
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
-        given(clientSession.thenAccept(any())).willReturn(null);
 
         // when
         Mono<Void> result = handler.handle(session);
@@ -333,4 +420,5 @@ class DevChatWebSocketHandlerTest {
 
         verify(clusterSharding).entityRefFor(any(), eq("999"));
     }
+
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipAdapterTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipAdapterTest.java
@@ -3,15 +3,10 @@ package com.tok.pekko.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
 
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.global.config.dev.BlockHoundTestInstallUtils;
 import java.time.Duration;
 import java.util.List;
@@ -105,86 +100,6 @@ class ChannelMembershipAdapterTest {
     }
 
     @Test
-    void 사용자가_새롭게_채널에_참여하면_SyncJoinChannel_메시지를_전달한다() {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willDoNothing().given(repository).save(eq(userId), eq(channelId));
-
-        // when
-        adapter.joinChannel(userId, channelId, replyProbe.ref());
-
-        // then
-        SyncJoinChannel actual = replyProbe.expectMessageClass(
-                SyncJoinChannel.class,
-                Duration.ofSeconds(3)
-        );
-        assertThat(actual.channelId()).isEqualTo(channelId);
-    }
-
-    @Test
-    void 사용자가_새롭게_채널에_참여하지_못했다면_아무_메시지도_전달하지_않는다() {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willThrow(new RuntimeException("Database error")).given(repository).save(anyLong(), anyLong());
-
-        // when
-        adapter.joinChannel(userId, channelId, replyProbe.ref());
-
-        // then
-        replyProbe.expectNoMessage(Duration.ofSeconds(1));
-    }
-
-    @Test
-    void 사용자가_채널을_탈퇴하면_SyncLeaveChannel_메시지를_전달한다() {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willDoNothing().given(repository).save(eq(userId), eq(channelId));
-
-        // when
-        adapter.leaveChannel(userId, channelId, replyProbe.ref());
-
-        // then
-        SyncLeaveChannel syncLeaveChannel = replyProbe.expectMessageClass(
-                SyncLeaveChannel.class,
-                Duration.ofSeconds(3)
-        );
-        assertThat(syncLeaveChannel.channelId()).isEqualTo(channelId);
-    }
-
-    @Test
-    void 사용자가_채널을_탈퇴하지_못하면_아무_메시지도_전달하지_않는다() {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willThrow(new RuntimeException("Database error")).given(repository).save(anyLong(), anyLong());
-
-        // when
-        adapter.leaveChannel(userId, channelId, replyProbe.ref());
-
-        // then
-        replyProbe.expectNoMessage(Duration.ofSeconds(1));
-    }
-
-    @Test
     void 사용자가_참여한_채널_ID_조회_시_호출자_스레드를_블로킹하지_않는다() throws InterruptedException {
         // given
         TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
@@ -210,64 +125,6 @@ class ChannelMembershipAdapterTest {
         assertAll(
                 () -> assertThat(errorHolder.get()).isNull(),
                 () -> replyProbe.expectMessageClass(FoundRegisteredChannelIds.class, Duration.ofSeconds(1))
-        );
-    }
-
-    @Test
-    void 사용자가_새롭게_채널에_참여할_때_호출자_스레드를_블로킹하지_않는다() throws InterruptedException {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willDoNothing().given(repository).save(anyLong(), anyLong());
-
-        // when
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Throwable> errorHolder = new AtomicReference<>();
-
-        Mono.fromRunnable(() -> adapter.joinChannel(userId, channelId, replyProbe.ref()))
-            .subscribeOn(Schedulers.parallel())
-            .doFinally(ignored -> latch.countDown())
-            .subscribe(null, errorHolder::set);
-
-        latch.await();
-
-        // then
-        assertAll(
-                () -> assertThat(errorHolder.get()).isNull(),
-                () -> replyProbe.expectMessageClass(SyncJoinChannel.class, Duration.ofSeconds(1))
-        );
-    }
-
-    @Test
-    void 사용자가_채널을_탈퇴할_때_호출자_스레드를_블로킹하지_않는다() throws InterruptedException {
-        // given
-        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
-        ChannelMembershipRepository repository = Mockito.mock(ChannelMembershipRepository.class);
-        ChannelMembershipAdapter adapter = new ChannelMembershipAdapter(repository);
-        Long userId = 1L;
-        Long channelId = 10L;
-
-        willDoNothing().given(repository).save(anyLong(), anyLong());
-
-        // when
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Throwable> errorHolder = new AtomicReference<>();
-
-        Mono.fromRunnable(() -> adapter.leaveChannel(userId, channelId, replyProbe.ref()))
-            .subscribeOn(Schedulers.parallel())
-            .doFinally(ignored -> latch.countDown())
-            .subscribe(null, errorHolder::set);
-
-        latch.await();
-
-        // then
-        assertAll(
-                () -> assertThat(errorHolder.get()).isNull(),
-                () -> replyProbe.expectMessageClass(SyncLeaveChannel.class, Duration.ofSeconds(1))
         );
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -12,7 +12,7 @@ import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseC
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyChannelReader;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReportUnhealthyClientSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.UnregisterChannelReader;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RefreshChannelReader;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
@@ -309,7 +309,7 @@ class ChannelReaderRegistryActorTest {
 
                       // then
                       clientSessionProbe.expectMessageClass(
-                              UnregisterChannelReader.class,
+                              RefreshChannelReader.class,
                               Duration.ofSeconds(1)
                       );
                   });

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -208,7 +208,7 @@ class ChannelReaderRegistryActorTest {
 
         ArgumentCaptor<ChannelEntityCommand> captor = ArgumentCaptor.forClass(ChannelEntityCommand.class);
 
-        verify(mockEntityRef, times(2)).tell(captor.capture());
+        verify(mockEntityRef, timeout(1000).times(2)).tell(captor.capture());
 
         RegisterReader capturedCommand = (RegisterReader) captor.getValue();
 

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -5,7 +5,6 @@ import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReader
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
@@ -17,16 +16,12 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -60,14 +55,13 @@ class ClientSessionActorTest {
     @Test
     void DeliverNewMessage_메시지를_받으면_ClientMessageSender로_채팅_메시지를_전송한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -90,14 +84,13 @@ class ClientSessionActorTest {
     @Test
     void DeliverHistory_메시지를_받으면_ClientMessageSender로_히스토리_메시지들을_전송한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -119,14 +112,13 @@ class ClientSessionActorTest {
     @Test
     void DeliverHistory_메시지로_빈_리스트를_받으면_MessageStoragePort로_히스토리를_조회한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         List<ChatMessage> emptyMessages = List.of();
@@ -143,14 +135,13 @@ class ClientSessionActorTest {
     @Test
     void FoundHistory_메시지를_받으면_ClientMessageSender로_조회된_히스토리를_전송한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -170,14 +161,13 @@ class ClientSessionActorTest {
     @Test
     void RequestHistory_메시지를_받으면_해당_채널의_reader에_GetHistory가_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -200,14 +190,13 @@ class ClientSessionActorTest {
     @Test
     void RequestHistory_메시지를_받을_때_해당_채널_reader가_없으면_readerRegistry에_요청한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -223,14 +212,13 @@ class ClientSessionActorTest {
     @Test
     void Shutdown_메시지를_받으면_액터가_종료된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<Void> terminationProbe = testKit.createTestProbe();
@@ -245,14 +233,13 @@ class ClientSessionActorTest {
     @Test
     void 여러_DeliverNewMessage_메시지를_연속으로_받으면_모두_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -278,14 +265,13 @@ class ClientSessionActorTest {
     @Test
     void DeliverDeletedMessage_메시지를_받으면_ClientMessageSender로_삭제된_메시지를_전송한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -301,14 +287,13 @@ class ClientSessionActorTest {
     @Test
     void DeliverUpdatedMessage_메시지를_받으면_ClientMessageSender로_수정된_메시지를_전송한다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 14, 0, 0);
@@ -324,14 +309,13 @@ class ClientSessionActorTest {
     @Test
     void FoundRegisteredChannelIds_메시지를_받으면_readerRegistry에_GetChannelReaderActorRef가_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         List<Long> channelIds = List.of(1L, 2L, 3L);
@@ -348,14 +332,13 @@ class ClientSessionActorTest {
     @Test
     void FoundChannelReaders_메시지를_받으면_readers에_등록되고_각_reader에_RegisterClientSession이_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
@@ -378,14 +361,13 @@ class ClientSessionActorTest {
     @Test
     void SyncJoinChannel_메시지를_받으면_readerRegistry에_GetChannelReaderActorRef가_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         // when
@@ -400,14 +382,13 @@ class ClientSessionActorTest {
     @Test
     void SyncLeaveChannel_메시지를_받으면_reader에서_제거되고_ChatChannelReaderActor에_UnregisterClientSession이_전송된다() {
         // given
-        Clock clock = Clock.systemDefaultZone();
         ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
         MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
         ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
         TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
 
         ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
         );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -421,56 +402,5 @@ class ClientSessionActorTest {
 
         // then
         readerProbe.expectMessageClass(UnregisterClientSession.class);
-    }
-
-    @Test
-    void PingHealthCheck_메시지를_받으면_해당_채널의_pingCount가_증가한다() {
-        // given
-        Clock clock = Clock.fixed(Instant.parse("2025-11-04T10:00:00Z"), ZoneId.systemDefault());
-        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
-        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
-        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
-        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
-
-        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
-        );
-
-        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
-        Map<Long, ActorRef<ChannelReaderCommand>> readers = Map.of(1L, readerProbe.ref());
-
-        clientSessionActor.tell(new FoundChannelReaders(readers));
-        readerProbe.expectMessageClass(RegisterClientSession.class);
-
-        // when
-        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
-        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
-
-        // then
-        readerRegistryProbe.expectNoMessage();
-    }
-
-    @Test
-    void PingHealthCheck_메시지를_받으면_replyTo에게_PongHealthCheck_메시지를_전달한다() {
-        // given
-        Clock clock = Clock.fixed(Instant.parse("2025-11-04T10:00:00Z"), ZoneId.systemDefault());
-        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
-        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
-        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
-        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
-
-        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
-        );
-
-        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
-
-        // when
-        clientSessionActor.tell(new PingHealthCheck(1L, readerProbe.ref()));
-
-        // then
-        PongHealthCheck pongMessage = readerProbe.expectMessageClass(PongHealthCheck.class);
-
-        assertThat(pongMessage.userId()).isEqualTo(100L);
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -17,8 +17,6 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.JoinChannel;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.LeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
@@ -378,28 +376,6 @@ class ClientSessionActorTest {
     }
 
     @Test
-    void JoinChannel_메시지를_받으면_channelMembershipPort로_채널_가입을_전달한다() {
-        // given
-        Clock clock = Clock.systemDefaultZone();
-        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
-        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
-        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
-        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
-
-        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
-        );
-
-        // when
-        clientSessionActor.tell(new JoinChannel(5L));
-
-        // then
-        verify(mockChannelMembershipPort, timeout(1000)).joinChannel(
-                eq(100L), eq(5L), any(ActorRef.class)
-        );
-    }
-
-    @Test
     void SyncJoinChannel_메시지를_받으면_readerRegistry에_GetChannelReaderActorRef가_전송된다() {
         // given
         Clock clock = Clock.systemDefaultZone();
@@ -419,28 +395,6 @@ class ClientSessionActorTest {
         GetChannelReaderActor actual = readerRegistryProbe.expectMessageClass(GetChannelReaderActor.class);
 
         assertThat(actual.channelIds()).contains(7L);
-    }
-
-    @Test
-    void LeaveChannel_메시지를_받으면_channelMembershipPort에_채널_탈퇴를_전달한다() {
-        // given
-        Clock clock = Clock.systemDefaultZone();
-        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
-        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
-        ChannelMembershipPort mockChannelMembershipPort = mock(ChannelMembershipPort.class);
-        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
-
-        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
-                ClientSessionActor.create(clock, 100L, mockClientMessageSender, mockMessageStoragePort, mockChannelMembershipPort, readerRegistryProbe.ref())
-        );
-
-        // when
-        clientSessionActor.tell(new LeaveChannel(3L));
-
-        // then
-        verify(mockChannelMembershipPort, timeout(1000)).leaveChannel(
-                eq(100L), eq(3L), any(ActorRef.class)
-        );
     }
 
     @Test

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -6,6 +6,7 @@ import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipPort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
@@ -175,6 +176,7 @@ class ClientSessionActorTest {
 
         clientSessionActor.tell(new FoundChannelReaders(readers));
         readerProbe.expectMessageClass(RegisterClientSession.class);
+        readerProbe.expectMessageClass(RequestInitialHistory.class);
 
         // when
         clientSessionActor.tell(new RequestHistory(1L, 10L, 5));
@@ -396,6 +398,7 @@ class ClientSessionActorTest {
 
         clientSessionActor.tell(new FoundChannelReaders(readers));
         readerProbe.expectMessageClass(RegisterClientSession.class);
+        readerProbe.expectMessageClass(RequestInitialHistory.class);
 
         // when
         clientSessionActor.tell(new SyncLeaveChannel(3L));

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
@@ -10,7 +10,9 @@ import reactor.core.publisher.Sinks;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -20,7 +22,7 @@ class WebSocketMessageSenderTest {
     void 단일_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<ChatMessage> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage message = createMessage(1L, "테스트 메시지");
 
@@ -28,14 +30,14 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(sink).tryEmitNext(message);
+        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
     }
 
     @Test
     void 여러_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<ChatMessage> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         List<ChatMessage> messages = List.of(
                 createMessage(1L, "메시지1"),
@@ -48,9 +50,9 @@ class WebSocketMessageSenderTest {
 
         // then
         assertAll(
-                () -> verify(sink).tryEmitNext(messages.get(0)),
-                () -> verify(sink).tryEmitNext(messages.get(1)),
-                () -> verify(sink).tryEmitNext(messages.get(2))
+                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
+                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
+                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
         );
     }
 
@@ -58,7 +60,7 @@ class WebSocketMessageSenderTest {
     void 삭제된_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<ChatMessage> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage deletedMessage = createMessage(1L, "삭제된 메시지");
 
@@ -66,14 +68,14 @@ class WebSocketMessageSenderTest {
         sender.sendDeletedMessage(deletedMessage);
 
         // then
-        verify(sink).tryEmitNext(deletedMessage);
+        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
     }
 
     @Test
     void 수정된_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<ChatMessage> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage updatedMessage = createMessage(1L, "수정된 메시지");
 
@@ -81,7 +83,58 @@ class WebSocketMessageSenderTest {
         sender.sendUpdatedMessage(updatedMessage);
 
         // then
-        verify(sink).tryEmitNext(updatedMessage);
+        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
+    }
+
+    @Test
+    void 웹소켓_헬스체크_핑을_전송한다() {
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+
+        sender.sendWebSocketPing();
+
+        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
+    }
+
+    @Test
+    void 재연결을_요청한다() {
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+
+        sender.requestSessionReconnect();
+
+        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
+    }
+
+    @Test
+    void sink를_교체하면_새로운_sink로_메시지를_전송한다() {
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> firstSink = mock(Sinks.Many.class);
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> secondSink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(firstSink);
+        ChatMessage message = createMessage(10L, "hello");
+
+        sender.sendMessage(message);
+        sender.attachSink(secondSink);
+        sender.sendMessage(message);
+
+        verify(firstSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(secondSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+    }
+
+    @Test
+    void sink를_detach하면_추가_메시지가_전송되지_않는다() {
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+
+        sender.detachSink(sink);
+        sender.requestSessionReconnect();
+
+        verifyNoInteractions(sink);
     }
 
     private ChatMessage createMessage(Long messageId, String content) {

--- a/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
@@ -7,7 +7,6 @@ import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
@@ -38,7 +37,7 @@ class ClientSessionActorManagementServiceTest {
         config = ConfigFactory.load();
         testKit = ActorTestKit.create(config);
         actorSystem = ActorSystem.create(
-                GuardianActor.create(Clock.systemDefaultZone()),
+                GuardianActor.create(),
                 "test-system",
                 config
         );

--- a/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.channel.model.ChannelPermissionType;
@@ -34,7 +35,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.fixed(Instant.parse("2024-03-01T12:30:00Z"), ZoneOffset.UTC);
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         Channel channel = Channel.create(
                 1L,
                 "general",
@@ -60,7 +62,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -90,7 +93,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -122,7 +126,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         ChannelMembership manager = ChannelMembership.create(
@@ -158,7 +163,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -187,7 +193,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -219,7 +226,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -257,7 +265,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -295,7 +304,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -327,7 +337,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -361,7 +372,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(
@@ -402,7 +414,8 @@ class ChannelMembershipServiceTest {
         // given
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
         Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort);
+        ClientSessionActorManagementService clientSessionService = mock(ClientSessionActorManagementService.class);
+        ChannelMembershipService service = new ChannelMembershipService(clock, channelStoragePort, clientSessionService);
         LocalDateTime createdAt = LocalDateTime.now(clock);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         memberships.put(

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -6,6 +6,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
@@ -15,6 +16,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessag
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -81,6 +83,8 @@ class ChannelReaderActorTest {
 
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
+
+        completeInitialSync(readerActor);
 
         // when
         readerActor.tell(new SyncNewMessage(newMessage));
@@ -218,6 +222,8 @@ class ChannelReaderActorTest {
 
         given(mockMessages.delete(messageId)).willReturn(deletedMessage);
 
+        completeInitialSync(readerActor);
+
         // when
         readerActor.tell(new SyncDeletion(messageId));
 
@@ -271,6 +277,8 @@ class ChannelReaderActorTest {
 
         given(mockMessages.update(eq(messageId), eq(updatedMessageContent), any(LocalDateTime.class))).willReturn(updatedMessage);
 
+        completeInitialSync(readerActor);
+
         // when
         readerActor.tell(new SyncUpdate(messageId, updatedMessageContent, timestamp));
 
@@ -310,6 +318,8 @@ class ChannelReaderActorTest {
         // when
         readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
+        completeInitialSync(readerActor);
+
         // then
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage newMessage = ChatMessage.create(
@@ -328,5 +338,127 @@ class ChannelReaderActorTest {
                 Duration.ofSeconds(3)
         );
         assertThat(deliveredMessage.message()).isEqualTo(newMessage);
+    }
+
+    @Test
+    void RequestInitialHistory_메시지를_받으면_채팅_히스토리를_ClientSessionActor에게_전달한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, mockChannelEntity, registryProbe.ref())
+        );
+
+        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe();
+
+        List<ChatMessage> historyMessages = List.of(
+                mock(ChatMessage.class),
+                mock(ChatMessage.class)
+        );
+
+        given(mockMessages.getMessages()).willReturn(historyMessages);
+
+        completeInitialSync(readerActor);
+
+        // when
+        readerActor.tell(new RequestInitialHistory(replyProbe.ref()));
+
+        // then
+        FoundHistory foundHistory = replyProbe.expectMessageClass(FoundHistory.class);
+        assertThat(foundHistory.history()).isEqualTo(historyMessages);
+    }
+
+    @Test
+    void RequestInitialHistory_메시지를_받았을_때_채팅_히스토리가_동기화되지_않았다면_별도로_관리된다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, mockChannelEntity, registryProbe.ref())
+        );
+
+        TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe();
+
+        given(mockMessages.getMessages()).willReturn(List.of());
+
+        // when
+        readerActor.tell(new RequestInitialHistory(replyProbe.ref()));
+
+        // then
+        replyProbe.expectNoMessage(Duration.ofMillis(100));
+    }
+
+    @Test
+    void DeliverSyncMessages_이전까지_대기중이던_RequestInitialHistory에게_히스토리를_전달한다() {
+        // given
+        ChatMessages chatMessages = new ChatMessages();
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, chatMessages, mockChannelEntity, registryProbe.ref())
+        );
+
+        TestProbe<ClientSessionCommand> pendingReplyProbe = testKit.createTestProbe();
+        TestProbe<ClientSessionCommand> immediateReplyProbe = testKit.createTestProbe();
+
+        readerActor.tell(new RequestInitialHistory(pendingReplyProbe.ref()));
+
+        LocalDateTime timestamp = LocalDateTime.now();
+        List<ChatMessage> syncedMessages = List.of(
+                ChatMessage.create(1L, 1L, 10L, "hello", timestamp, timestamp)
+        );
+
+        // when
+        readerActor.tell(new ChannelReaderActor.DeliverSyncMessages(syncedMessages));
+
+        // then
+        FoundHistory foundHistoryFromPending = pendingReplyProbe.expectMessageClass(FoundHistory.class);
+        assertThat(foundHistoryFromPending.history()).isEqualTo(syncedMessages);
+
+        readerActor.tell(new RequestInitialHistory(immediateReplyProbe.ref()));
+        FoundHistory foundHistoryAfterSync = immediateReplyProbe.expectMessageClass(FoundHistory.class);
+        assertThat(foundHistoryAfterSync.history()).isEqualTo(syncedMessages);
+    }
+
+    @Test
+    void 초기_동기화_전_도착한_SyncNewMessage는_대기하다가_동기화_완료_후에_전파된다() {
+        // given
+        ChatMessages chatMessages = new ChatMessages();
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe();
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, chatMessages, mockChannelEntity, registryProbe.ref())
+        );
+
+        readerActor.tell(new RegisterClientSession(100L, clientSessionProbe.ref()));
+
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage pendingMessage = ChatMessage.create(1L, 200L, 11L, "pending", timestamp, timestamp);
+
+        // when
+        readerActor.tell(new SyncNewMessage(pendingMessage));
+
+        // then
+        clientSessionProbe.expectNoMessage(Duration.ofMillis(100));
+
+        readerActor.tell(new ChannelReaderActor.DeliverSyncMessages(List.of()));
+
+        DeliverNewMessage delivered = clientSessionProbe.expectMessageClass(DeliverNewMessage.class);
+        assertThat(delivered.message()).isEqualTo(pendingMessage);
+    }
+
+    private void completeInitialSync(ActorRef<ChannelReaderCommand> readerActor) {
+        readerActor.tell(new ChannelReaderActor.DeliverSyncMessages(List.of()));
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -5,7 +5,6 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.PongHealthCheck;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
@@ -16,7 +15,6 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessag
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
-import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -83,9 +81,6 @@ class ChannelReaderActorTest {
 
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
-
-        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
-        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
 
         // when
         readerActor.tell(new SyncNewMessage(newMessage));
@@ -221,9 +216,6 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
 
-        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
-        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
-
         given(mockMessages.delete(messageId)).willReturn(deletedMessage);
 
         // when
@@ -277,9 +269,6 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
 
-        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
-        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
-
         given(mockMessages.update(eq(messageId), eq(updatedMessageContent), any(LocalDateTime.class))).willReturn(updatedMessage);
 
         // when
@@ -322,8 +311,6 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
         // then
-        registeredSessionProbe.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
-
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage newMessage = ChatMessage.create(
                 1L,
@@ -341,45 +328,5 @@ class ChannelReaderActorTest {
                 Duration.ofSeconds(3)
         );
         assertThat(deliveredMessage.message()).isEqualTo(newMessage);
-    }
-
-    @Test
-    void PongHealthCheck_메시지를_받으면_Health_Check_타임아웃이_발생하지_않는다() {
-        // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
-        @SuppressWarnings("unchecked")
-        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
-        TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-
-        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
-        );
-
-        Long userId = 100L;
-        readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
-        registeredSessionProbe.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
-
-        LocalDateTime timestamp = LocalDateTime.now();
-        ChatMessage newMessage = ChatMessage.create(
-                1L,
-                1001L,
-                1L,
-                "Test",
-                timestamp,
-                timestamp
-        );
-
-        // when
-        readerActor.tell(new PongHealthCheck(userId));
-
-        // then
-        readerActor.tell(new SyncNewMessage(newMessage));
-
-        DeliverNewMessage actual = registeredSessionProbe.expectMessageClass(
-                DeliverNewMessage.class,
-                Duration.ofSeconds(3)
-        );
-        assertThat(actual.message()).isEqualTo(newMessage);
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -10,13 +10,13 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSes
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
-import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PingHealthCheck;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -83,6 +83,9 @@ class ChannelReaderActorTest {
 
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
+
+        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
+        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
 
         // when
         readerActor.tell(new SyncNewMessage(newMessage));
@@ -218,6 +221,9 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
 
+        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
+        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
+
         given(mockMessages.delete(messageId)).willReturn(deletedMessage);
 
         // when
@@ -271,6 +277,9 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
         readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
 
+        clientSessionProbe1.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
+        clientSessionProbe2.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
+
         given(mockMessages.update(eq(messageId), eq(updatedMessageContent), any(LocalDateTime.class))).willReturn(updatedMessage);
 
         // when
@@ -313,6 +322,8 @@ class ChannelReaderActorTest {
         readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
 
         // then
+        registeredSessionProbe.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(1));
+
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage newMessage = ChatMessage.create(
                 1L,
@@ -333,41 +344,6 @@ class ChannelReaderActorTest {
     }
 
     @Test
-    void UnregisterClientSession_메시지를_받으면_clientSessions에서_제거된다() {
-        // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
-        @SuppressWarnings("unchecked")
-        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
-        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
-        TestProbe<ClientSessionCommand> registeredSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
-
-        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
-                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
-        );
-
-        Long userId = 100L;
-        readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
-
-        // when
-        readerActor.tell(new UnregisterClientSession(userId));
-
-        // then
-        LocalDateTime timestamp = LocalDateTime.now();
-        ChatMessage newMessage = ChatMessage.create(
-                1L,
-                1001L,
-                1L,
-                "Test",
-                timestamp,
-                timestamp
-        );
-
-        readerActor.tell(new SyncNewMessage(newMessage));
-
-        registeredSessionProbe.expectNoMessage(Duration.ofSeconds(1));
-    }
-
-    @Test
     void PongHealthCheck_메시지를_받으면_Health_Check_타임아웃이_발생하지_않는다() {
         // given
         ChatMessages mockMessages = mock(ChatMessages.class);
@@ -382,6 +358,7 @@ class ChannelReaderActorTest {
 
         Long userId = 100L;
         readerActor.tell(new RegisterClientSession(userId, registeredSessionProbe.ref()));
+        registeredSessionProbe.expectMessageClass(PingHealthCheck.class, Duration.ofSeconds(3));
 
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage newMessage = ChatMessage.create(

--- a/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
@@ -8,7 +8,6 @@ import com.tok.pekko.global.actor.GuardianActor.SpawnClientSession;
 import com.tok.pekko.global.actor.GuardianActor.SpawnedClientSession;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.time.Clock;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -43,7 +42,7 @@ class GuardianActorTest {
     @BeforeEach
     void beforeEach() {
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(Clock.systemDefaultZone()),
+                GuardianActor.create(),
                 "test-system",
                 config
         );
@@ -51,7 +50,7 @@ class GuardianActorTest {
         Cluster cluster = Cluster.get(system);
         cluster.manager().tell(new Join(cluster.selfMember().address()));
 
-        guardianActor = testKit.spawn(GuardianActor.create(Clock.systemDefaultZone()));
+        guardianActor = testKit.spawn(GuardianActor.create());
         responseProbe = testKit.createTestProbe();
     }
 


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #18 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
- ClientSessionActor-ChannelReaderActor 간 Health Check 로직 삭제
- 채널 최초 입장 시의 채팅 히스토리 조회 방식 변경 
- Soft Failure WebSocket Session에 대한 Health Check 로직 추가