### PR TITLE
실시간성 및 동시성 문제가 발생하는 비즈니스 로직 수행 위치 변경

### DIFF
--- a/actor-message-flow.md
+++ b/actor-message-flow.md
@@ -440,3 +440,73 @@
 - WebSocketSession -> ClientSessionActor
   - ClientSessionProtocol.SessionPongReceived 메시지 전달
     - Client Session인 WebSocket Session으로부터 Pong을 전달하기 위한 메시지
+
+## ChannelEventHandlerEntity 도메인 이벤트 처리
+
+> ChannelEntity가 발생시킨 도메인 이벤트를 ChannelEventHandlerEntity가 외부 스토리지에 반영하고 처리 결과를 재전파하는 과정
+
+### 1. ChannelEntity에서 도메인 이벤트 전달
+
+> ChannelEntity 내부적으로 수행한 비즈니스 로직 결과를 ChannelEventHandlerEntity에게 전달하는 과정
+
+- ChannelEntity -> ChannelEventHandlerEntity
+  - ChannelEventHandlerProtocol.HandleChannelPolicyChanged
+    - 채널 정책 변경 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleChannelNameEdited
+    - 채널 이름 변경 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleUserJoined
+    - 채널 참여 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleMemberLeft
+    - 채널 탈퇴 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleUserInvited
+    - 채널 초대 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandlePromotedToManager
+    - 매니저 승격 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleDemotedToMember
+    - 멤버 강등 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandlePermissionAdded
+    - 권한 추가 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandlePermissionRemoved
+    - 권한 삭제 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleMemberKicked
+    - 강퇴 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleMessageEdited
+    - 채팅 메시지 수정 도메인 이벤트를 처리하는 메시지
+  - ChannelEventHandlerProtocol.HandleMessageDeleted
+    - 채팅 메시지 삭제 도메인 이벤트를 처리하는 메시지
+
+### 2. ChannelEventHandlerEntity의 스토리지 반영
+
+> 수신한 도메인 이벤트를 외부 영속 계층에 적용하는 과정
+
+- ChannelEventHandlerEntity -> ChannelActorStoragePort
+  - ChannelActorStoragePort.update() 호출
+    - 채널 정책/이름 변경 이벤트를 영속화
+- ChannelEventHandlerEntity -> ChannelMembershipActorStoragePort
+  - join()/leave()/inviteUser()/promoteToManager()/demoteToMember()/addPermission()/removePermission()/kickMember() 호출
+    - 멤버십 관련 도메인 이벤트를 영속화
+- ChannelEventHandlerEntity -> MessageStoragePort
+  - update()/delete() 호출
+    - 메시지 수정/삭제 도메인 이벤트를 영속화
+
+### 3. 스토리지 처리 결과 전파
+
+> 스토리지 어댑터가 도메인 이벤트 처리 결과를 전달하고 ChannelEntity가 이벤트 보관소에서 정리하는 과정
+
+- ChannelActorStoragePort / ChannelMembershipActorStoragePort / MessageStoragePort -> ChannelEventHandlerEntity
+  - ChannelEventHandlerProtocol.EventSucceeded 또는 ChannelEventHandlerProtocol.EventFailed 메시지 전달
+    - 도메인 이벤트 처리 성공/실패를 알리기 위한 메시지
+- ChannelEventHandlerEntity -> ChannelEntity
+  - ChannelEntity.DomainEventProcessed 메시지 전달
+    - 처리 결과와 무관하게 ChannelEntity에 이벤트 처리가 종료되었음을 알리는 메시지
+
+### 4. 영속화된 멤버십 정보 반영
+
+> 멤버십 영속화 시 생성된 PK 등을 ChannelEntity에 반영하는 과정
+
+- ChannelMembershipActorStoragePort -> ChannelEventHandlerEntity
+  - ChannelEventHandlerProtocol.NotifyStoredMembership 메시지 전달
+    - ChannelMembership 영속화 시 생성된 PK를 ChannelEntity에서 관리하는 Channel에 반영하기 위한 메시지
+- ChannelEventHandlerEntity -> ChannelEntity
+  - ChannelProtocol.SyncStoredMembership 메시지 전달
+    - 영속화된 ChannelMembership을 Primary 상태에 동기화하기 위한 메시지

--- a/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
@@ -9,6 +9,7 @@ import com.tok.pekko.domain.chat.actor.ChannelEntity;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SessionPongReceived;
 import java.net.URI;
 import java.util.Map;
@@ -93,13 +94,14 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
             WebSocketConnectionContext context,
             WebSocketMessageSender messageSender
     ) {
-        try {
-            ActorRef<ClientSessionCommand> existing = managementService.findClientSession(context.userId());
+        return managementService.findClientSessionOptional(context.userId())
+                                .map(this::reSyncAndWrap)
+                                .orElseGet(() -> managementService.createClientSessionActor(messageSender, context.userId()));
+    }
 
-            return CompletableFuture.completedFuture(existing);
-        } catch (ClientSessionActorManagementService.ClientSessionNotFoundException ignored) {
-            return managementService.createClientSessionActor(messageSender, context.userId());
-        }
+    private CompletionStage<ActorRef<ClientSessionCommand>> reSyncAndWrap(ActorRef<ClientSessionCommand> actorRef) {
+        actorRef.tell(new ReSyncSession());
+        return CompletableFuture.completedFuture(actorRef);
     }
 
     private Mono<Void> handleInboundMessages(
@@ -128,7 +130,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
             return Mono.empty();
         }
 
-        forwardMessageToActor(context, payload);
+        forwardMessageToActor(payload, context.userId());
         return Mono.empty();
     }
 
@@ -168,14 +170,16 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
         return false;
     }
 
-    private void forwardMessageToActor(WebSocketConnectionContext context, String messagePayload) {
-        EntityRef<ChannelEntityCommand> channelEntity = getEntity(context.channelId());
-        SendMessage command = new SendMessage(
-                context.userId(),
-                messagePayload
-        );
+    private void forwardMessageToActor(String messagePayload, Long userId) {
+        ClientMessage clientMessage = parseClientMessage(messagePayload);
 
-        channelEntity.tell(command);
+        if (clientMessage == null) {
+            return;
+        }
+
+        EntityRef<ChannelEntityCommand> channelEntity = getEntity(clientMessage.channelId());
+
+        channelEntity.tell(new SendMessage(userId, clientMessage.message()));
     }
 
     private Flux<WebSocketMessage> handleOutboundMessages(
@@ -214,7 +218,25 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
         );
     }
 
-    private record WebSocketConnectionContext(Long channelId, Long userId) {
+    private ClientMessage parseClientMessage(String payload) {
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            Long channelId = node.path("channelId").asLong();
+            String message = node.path("message").asText();
+
+            if (channelId <= 0 || message == null || message.isBlank()) {
+                return null;
+            }
+
+            return new ClientMessage(channelId, message);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private record ClientMessage(Long channelId, String message) { }
+
+    private record WebSocketConnectionContext(Long userId) {
 
         static WebSocketConnectionContext from(WebSocketSession session) {
             URI uri = session.getHandshakeInfo().getUri();
@@ -222,10 +244,9 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
                                                                        .build()
                                                                        .getQueryParams();
 
-            Long channelId = extractRequiredParam(params, "channelId");
             Long userId = extractRequiredParam(params, "userId");
 
-            return new WebSocketConnectionContext(channelId, userId);
+            return new WebSocketConnectionContext(userId);
         }
 
         private static Long extractRequiredParam(MultiValueMap<String, String> params, String key) {

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelActorStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelActorStorageAdapter.java
@@ -1,0 +1,44 @@
+package com.tok.pekko.adapter.out.persistence;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import lombok.RequiredArgsConstructor;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelActorStorageAdapter implements ChannelActorStoragePort {
+
+    private final ChannelRepository channelRepository;
+
+    @Override
+    public void find(Long channelId, ActorRef<ChannelEntityCommand> replyTo) {
+        Mono.fromCallable(() -> channelRepository.findById(channelId))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnNext(
+                    target -> target.ifPresentOrElse(
+                            channel -> replyTo.tell(new SyncChannel(channel)),
+                            () -> replyTo.tell(new Shutdown())
+                    )
+            )
+            .subscribe();
+    }
+
+    @Override
+    public void update(Channel channel, Long eventId, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> channelRepository.update(channel))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipActorStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipActorStorageAdapter.java
@@ -1,0 +1,132 @@
+package com.tok.pekko.adapter.out.persistence;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import lombok.RequiredArgsConstructor;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelMembershipActorStorageAdapter implements ChannelMembershipActorStoragePort {
+
+    private final ChannelMembershipRepository channelMembershipRepository;
+
+    @Override
+    public void join(
+            Long eventId,
+            ChannelId channelId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromCallable(() -> channelMembershipRepository.joinChannel(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(stored -> {
+                replyTo.tell(new NotifyStoredMembership(stored));
+                replyTo.tell(new EventSucceeded(eventId));
+            })
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void leave(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> channelMembershipRepository.leaveChannel(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void inviteUser(
+            Long eventId,
+            ChannelId channelId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromCallable(() -> channelMembershipRepository.joinChannel(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(stored -> {
+                replyTo.tell(new NotifyStoredMembership(stored));
+                replyTo.tell(new EventSucceeded(eventId));
+            })
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void promoteToManager(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.promoteToManager(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void demoteToMember(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.demoteToMember(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void addPermission(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ChannelPermissionType permission,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.addManagerPermission(channelMembership.getId(), permission))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void removePermission(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ChannelPermissionType permission,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.deleteManagerPermission(channelMembership.getId(), permission))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void kickMember(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.leaveChannel(channelMembership))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipRepository.java
@@ -1,16 +1,24 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
 import com.tok.pekko.domain.user.model.vo.UserId;
 
 public interface ChannelMembershipRepository {
 
-    void joinChannel(ChannelMembership channelMembership);
+    ChannelMembership joinChannel(ChannelMembership channelMembership);
 
-    void leaveChannel(ChannelId channelId, UserId userId);
+    void leaveChannel(ChannelMembership channelMembership);
 
-    void updateRole(ChannelMembership channelMembership);
+    void promoteToManager(ChannelMembership channelMembership);
+
+    void demoteToMember(ChannelMembership channelMembership);
 
     void delete(ChannelId channelId, UserId userId);
+
+    void addManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission);
+
+    void deleteManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission);
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
@@ -18,25 +18,20 @@ public class ChannelMembershipStorageAdapter implements ChannelMembershipStorage
     @Override
     public void joinChannel(ChannelId channelId, ChannelMembership channelMembership) {
         channelMembershipRepository.joinChannel(channelMembership);
-        channelRepository.incrementMemberCount(channelId);
     }
 
     @Override
     public void leaveChannel(ChannelMembership channelMembership) {
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
-        channelMembershipRepository.leaveChannel(channelMembership.getChannelId(), channelMembership.getUserId());
-        channelRepository.decrementMemberCount(channelMembership.getChannelId());
     }
 
     @Override
     public void promoteToManager(ChannelMembership channelMembership) {
-        channelMembershipRepository.updateRole(channelMembership);
         channelManagePermissionRepository.saveAll(channelMembership);
     }
 
     @Override
     public void demoteToMember(ChannelMembership channelMembership) {
-        channelMembershipRepository.updateRole(channelMembership);
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
     }
 
@@ -54,6 +49,5 @@ public class ChannelMembershipStorageAdapter implements ChannelMembershipStorage
     public void kickMember(ChannelMembership channelMembership) {
         channelMembershipRepository.delete(channelMembership.getChannelId(), channelMembership.getUserId());
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
-        channelRepository.decrementMemberCount(channelMembership.getChannelId());
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelRepository.java
@@ -10,11 +10,9 @@ public interface ChannelRepository {
 
     Optional<Channel> findByIdWithMembership(Long channelId, Long... memberIds);
 
+    Optional<Channel> findById(Long channelId);
+
     void update(Channel channel);
 
     void deleteById(ChannelId channelId);
-
-    void incrementMemberCount(ChannelId channelId);
-
-    void decrementMemberCount(ChannelId channelId);
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
@@ -1,11 +1,14 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +20,7 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
 
     @Override
     @Transactional
-    public void joinChannel(ChannelMembership channelMembership) {
+    public ChannelMembership joinChannel(ChannelMembership channelMembership) {
         String sql = """
                 INSERT INTO channel_memberships (channel_id, user_id, channel_role, joined_at)
                 VALUES (:channelId, :userId, :channelRole, :joinedAt)
@@ -29,37 +32,94 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
                 .addValue("channelRole", channelMembership.getRole().name())
                 .addValue("joinedAt", channelMembership.getJoinedAt());
 
-        jdbcTemplate.update(sql, params);
+        var keyHolder = new org.springframework.jdbc.support.GeneratedKeyHolder();
+        jdbcTemplate.update(sql, params, keyHolder, new String[]{"id"});
+
+        Number generatedId = keyHolder.getKey();
+        if (generatedId == null) {
+            throw new IllegalStateException("채널 멤버십 ID를 생성하지 못했습니다.");
+        }
+
+        return channelMembership.withAssignedId(generatedId.longValue());
     }
 
     @Override
     @Transactional
-    public void leaveChannel(ChannelId channelId, UserId userId) {
-        String sql = """
+    public void leaveChannel(ChannelMembership channelMembership) {
+        // 매니저 권한 테이블을 먼저 정리한 뒤 멤버십을 삭제한다.
+        String deletePermSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deletePermParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermSql, deletePermParams);
+
+        String deleteMembershipSql = """
                 DELETE FROM channel_memberships
-                WHERE channel_id = :channelId AND user_id = :userId
+                WHERE id = :membershipId
                 """;
 
         MapSqlParameterSource params = new MapSqlParameterSource()
-                .addValue("channelId", channelId.getValue())
-                .addValue("userId", userId.getValue());
+                .addValue("membershipId", channelMembership.getId().getValue());
 
-        jdbcTemplate.update(sql, params);
+        jdbcTemplate.update(deleteMembershipSql, params);
     }
 
     @Override
     @Transactional
-    public void updateRole(ChannelMembership channelMembership) {
-        String sql = """
+    public void promoteToManager(ChannelMembership channelMembership) {
+        String roleSql = """
                 UPDATE channel_memberships
-                SET channel_role = :role
+                SET channel_role = 'MANAGER'
                 WHERE id = :membershipId
                 """;
-        MapSqlParameterSource parameter = new MapSqlParameterSource()
-                .addValue("role", channelMembership.getRole().name())
+        MapSqlParameterSource roleParams = new MapSqlParameterSource()
                 .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(roleSql, roleParams);
 
-        jdbcTemplate.update(sql, parameter);
+        String deletePermSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deleteParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermSql, deleteParams);
+
+        var permissions = channelMembership.getPermissions().getAll();
+        if (permissions != null && !permissions.isEmpty()) {
+            String insertPermSql = """
+                    INSERT INTO channel_manager_permissions (manager_membership_id, permission)
+                    VALUES (:membershipId, :permission)
+                    """;
+            SqlParameterSource[] batchParams = permissions.stream()
+                                                          .map(permission -> new MapSqlParameterSource()
+                                                                  .addValue("membershipId", channelMembership.getId().getValue())
+                                                                  .addValue("permission", permission.name()))
+                                                          .toArray(SqlParameterSource[]::new);
+            jdbcTemplate.batchUpdate(insertPermSql, batchParams);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void demoteToMember(ChannelMembership channelMembership) {
+        String roleSql = """
+                UPDATE channel_memberships
+                SET channel_role = 'MEMBER'
+                WHERE id = :membershipId
+                """;
+        MapSqlParameterSource roleParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(roleSql, roleParams);
+
+        String deletePermSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deleteParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermSql, deleteParams);
     }
 
     @Override
@@ -76,5 +136,37 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
 
         jdbcTemplate.update(sql, parameter);
     }
-}
 
+    @Override
+    @Transactional
+    public void addManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission) {
+        if (permission == null) {
+            return;
+        }
+        String sql = """
+                INSERT INTO channel_manager_permissions (manager_membership_id, permission)
+                VALUES (:membershipId, :permission)
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("membershipId", membershipId.getValue())
+                .addValue("permission", permission.name());
+        jdbcTemplate.update(sql, params);
+    }
+
+    @Override
+    @Transactional
+    public void deleteManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission) {
+        if (permission == null) {
+            return;
+        }
+        String sql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                AND permission = :permission
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("membershipId", membershipId.getValue())
+                .addValue("permission", permission.name());
+        jdbcTemplate.update(sql, params);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
@@ -2,14 +2,16 @@ package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.ChannelRole;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,9 +101,11 @@ public class JdbcChannelRepository implements ChannelRepository {
                     cm.id AS membership_id,
                     cm.user_id AS membership_user_id,
                     cm.channel_role,
-                    cm.joined_at AS membership_joined_at
+                    cm.joined_at AS membership_joined_at,
+                    cmp.permission AS manager_permission
                 FROM channels c
                 INNER JOIN channel_memberships cm ON cm.channel_id = c.id
+                LEFT JOIN channel_manager_permissions cmp ON cmp.manager_membership_id = cm.id
                 WHERE c.id = :channelId AND c.is_deleted = false AND cm.user_id IN (:memberIds)
                 """;
 
@@ -128,9 +132,11 @@ public class JdbcChannelRepository implements ChannelRepository {
                     cm.id AS membership_id,
                     cm.user_id AS membership_user_id,
                     cm.channel_role,
-                    cm.joined_at AS membership_joined_at
+                    cm.joined_at AS membership_joined_at,
+                    cmp.permission AS manager_permission
                 FROM channels c
                 LEFT JOIN channel_memberships cm ON c.id = cm.channel_id
+                LEFT JOIN channel_manager_permissions cmp ON cmp.manager_membership_id = cm.id
                 WHERE c.id = :channelId AND c.is_deleted = false
                 """;
 
@@ -193,9 +199,10 @@ public class JdbcChannelRepository implements ChannelRepository {
                     rs.getBoolean("can_delete_own_message"),
                     rs.getBoolean("is_public")
             );
-            LocalDateTime createdAt = toLocalDateTime(rs.getTimestamp("created_at"));
+            LocalDateTime createdAt = rs.getTimestamp("created_at").toLocalDateTime();
             Map<UserId, ChannelMembership> memberships = new HashMap<>();
-            ChannelId chId = ChannelId.create(channelId);
+
+            Map<Long, EnumSet<ChannelPermissionType>> managerPermissions = new HashMap<>();
 
             do {
                 Long membershipId = rs.getLong("membership_id");
@@ -206,18 +213,49 @@ public class JdbcChannelRepository implements ChannelRepository {
                 Long userIdValue = rs.getLong("membership_user_id");
                 UserId userId = UserId.create(userIdValue);
                 ChannelRole role = ChannelRole.find(rs.getString("channel_role"));
-                LocalDateTime joinedAt = toLocalDateTime(rs.getTimestamp("membership_joined_at"));
+                LocalDateTime joinedAt = rs.getTimestamp("membership_joined_at").toLocalDateTime();
 
-                ChannelMembership membership = ChannelMembership.create(chId, userId, role, joinedAt)
-                                                                .withAssignedId(membershipId);
+                String managerPermission = rs.getString("manager_permission");
+                if (managerPermission != null) {
+                    managerPermissions.computeIfAbsent(membershipId, ignored -> EnumSet.noneOf(ChannelPermissionType.class))
+                                .add(ChannelPermissionType.valueOf(managerPermission));
+                }
+
+                ChannelMembership membership = createMembership(
+                        ChannelId.create(channelId),
+                        membershipId,
+                        userId,
+                        role,
+                        joinedAt,
+                        managerPermissions.get(membershipId)
+                );
                 memberships.put(userId, membership);
             } while (rs.next());
 
             return Channel.create(channelId, name, creatorId, channelPolicy, memberships, createdAt);
         }
 
-        private LocalDateTime toLocalDateTime(Timestamp timestamp) {
-            return timestamp != null ? timestamp.toLocalDateTime() : null;
+        private ChannelMembership createMembership(
+                ChannelId channelId,
+                Long membershipId,
+                UserId userId,
+                ChannelRole role,
+                LocalDateTime joinedAt,
+                EnumSet<ChannelPermissionType> permissions
+        ) {
+            if (role.isManager() && permissions != null && !permissions.isEmpty()) {
+                return ChannelMembership.create(
+                        membershipId,
+                        channelId.getValue(),
+                        userId.getValue(),
+                        role,
+                        ChannelManagePermissions.ofManager(permissions),
+                        joinedAt
+                );
+            }
+
+            return ChannelMembership.create(channelId, userId, role, joinedAt)
+                                    .withAssignedId(membershipId);
         }
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
@@ -6,14 +6,17 @@ import com.tok.pekko.domain.channel.model.ChannelRole;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.user.model.vo.UserId;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.RowMapper;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -24,33 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 @RequiredArgsConstructor
 public class JdbcChannelRepository implements ChannelRepository {
-
-    private static final RowMapper<Channel> channelRowMapper = (rs, rowNum) -> {
-        ChannelPolicy channelPolicy = new ChannelPolicy(
-                rs.getBoolean("can_edit_own_message"),
-                rs.getBoolean("can_delete_own_message"),
-                rs.getBoolean("is_public")
-        );
-        LocalDateTime createdAt = rs.getObject("created_at", LocalDateTime.class);
-        ChannelRole role = ChannelRole.find(rs.getString("channel_role"));
-        UserId membershipUserId = UserId.create(rs.getLong("membership_user_id"));
-        LocalDateTime membershipJoinedAt = rs.getObject("membership_joined_at", LocalDateTime.class);
-        Long channelId = rs.getLong("channel_id");
-        ChannelMembership membership = ChannelMembership.create(ChannelId.create(channelId), membershipUserId, role, membershipJoinedAt)
-                                                        .withAssignedId(rs.getLong("membership_id"));
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-
-        memberships.put(membership.getUserId(), membership);
-
-        return Channel.create(
-                channelId,
-                rs.getString("name"),
-                rs.getLong("creator_id"),
-                channelPolicy,
-                memberships,
-                createdAt
-        );
-    };
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -65,8 +41,7 @@ public class JdbcChannelRepository implements ChannelRepository {
                     can_delete_own_message,
                     is_public,
                     is_deleted,
-                    created_at,
-                    membership_count
+                    created_at
                 )
                 VALUES (
                     :name,
@@ -75,8 +50,7 @@ public class JdbcChannelRepository implements ChannelRepository {
                     :canDeleteOwnMessage,
                     :isPublic,
                     :isDeleted,
-                    :createdAt,
-                    :membershipCount
+                    :createdAt
                 )
                 """;
         MapSqlParameterSource parameters = new MapSqlParameterSource()
@@ -86,10 +60,9 @@ public class JdbcChannelRepository implements ChannelRepository {
                 .addValue("canDeleteOwnMessage", channel.getChannelPolicy().canDeleteOwnMessage())
                 .addValue("isPublic", channel.getChannelPolicy().isPublic())
                 .addValue("isDeleted", false)
-                .addValue("createdAt", channel.getCreatedAt())
-                .addValue("membershipCount", channel.getMemberships().size());
-        KeyHolder keyHolder = new GeneratedKeyHolder();
+                .addValue("createdAt", channel.getCreatedAt());
 
+        KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(sql, parameters, keyHolder, new String[]{"id"});
 
         Number generatedId = keyHolder.getKey();
@@ -110,6 +83,10 @@ public class JdbcChannelRepository implements ChannelRepository {
 
     @Override
     public Optional<Channel> findByIdWithMembership(Long channelId, Long... memberIds) {
+        if (memberIds == null || memberIds.length == 0) {
+            return findById(channelId);
+        }
+
         String sql = """
                 SELECT
                     c.id AS channel_id,
@@ -127,17 +104,42 @@ public class JdbcChannelRepository implements ChannelRepository {
                 INNER JOIN channel_memberships cm ON cm.channel_id = c.id
                 WHERE c.id = :channelId AND c.is_deleted = false AND cm.user_id IN (:memberIds)
                 """;
+
         MapSqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("channelId", channelId)
                 .addValue("memberIds", List.of(memberIds));
 
-        try {
-            Channel channel = jdbcTemplate.queryForObject(sql, parameters, channelRowMapper);
+        Channel channel = jdbcTemplate.query(sql, parameters, new ChannelWithMembershipsExtractor());
 
-            return Optional.ofNullable(channel);
-        } catch (EmptyResultDataAccessException ex) {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(channel);
+    }
+
+    @Override
+    public Optional<Channel> findById(Long channelId) {
+        String sql = """
+                SELECT
+                    c.id AS channel_id,
+                    c.name,
+                    c.creator_id,
+                    c.can_edit_own_message,
+                    c.can_delete_own_message,
+                    c.is_public,
+                    c.created_at,
+                    cm.id AS membership_id,
+                    cm.user_id AS membership_user_id,
+                    cm.channel_role,
+                    cm.joined_at AS membership_joined_at
+                FROM channels c
+                LEFT JOIN channel_memberships cm ON c.id = cm.channel_id
+                WHERE c.id = :channelId AND c.is_deleted = false
+                """;
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("channelId", channelId);
+
+        Channel channel = jdbcTemplate.query(sql, parameters, new ChannelWithMembershipsExtractor());
+
+        return Optional.ofNullable(channel);
     }
 
     @Override
@@ -175,29 +177,47 @@ public class JdbcChannelRepository implements ChannelRepository {
         jdbcTemplate.update(sql, parameters);
     }
 
-    @Override
-    @Transactional
-    public void incrementMemberCount(ChannelId channelId) {
-        String sql = """
-                UPDATE channels
-                SET membership_count = membership_count + 1
-                WHERE id = :channelId AND is_deleted = false
-                """;
-        MapSqlParameterSource parameters = new MapSqlParameterSource("channelId", channelId.getValue());
+    private static class ChannelWithMembershipsExtractor implements ResultSetExtractor<Channel> {
 
-        jdbcTemplate.update(sql, parameters);
-    }
+        @Override
+        public Channel extractData(ResultSet rs) throws SQLException, DataAccessException {
+            if (!rs.next()) {
+                return null;
+            }
 
-    @Override
-    @Transactional
-    public void decrementMemberCount(ChannelId channelId) {
-        String sql = """
-                UPDATE channels
-                SET membership_count = membership_count - 1
-                WHERE id = :channelId AND is_deleted = false
-                """;
-        MapSqlParameterSource parameters = new MapSqlParameterSource("channelId", channelId.getValue());
+            Long channelId = rs.getLong("channel_id");
+            String name = rs.getString("name");
+            Long creatorId = rs.getLong("creator_id");
+            ChannelPolicy channelPolicy = new ChannelPolicy(
+                    rs.getBoolean("can_edit_own_message"),
+                    rs.getBoolean("can_delete_own_message"),
+                    rs.getBoolean("is_public")
+            );
+            LocalDateTime createdAt = toLocalDateTime(rs.getTimestamp("created_at"));
+            Map<UserId, ChannelMembership> memberships = new HashMap<>();
+            ChannelId chId = ChannelId.create(channelId);
 
-        jdbcTemplate.update(sql, parameters);
+            do {
+                Long membershipId = rs.getLong("membership_id");
+                if (rs.wasNull()) {
+                    continue;
+                }
+
+                Long userIdValue = rs.getLong("membership_user_id");
+                UserId userId = UserId.create(userIdValue);
+                ChannelRole role = ChannelRole.find(rs.getString("channel_role"));
+                LocalDateTime joinedAt = toLocalDateTime(rs.getTimestamp("membership_joined_at"));
+
+                ChannelMembership membership = ChannelMembership.create(chId, userId, role, joinedAt)
+                                                                .withAssignedId(membershipId);
+                memberships.put(userId, membership);
+            } while (rs.next());
+
+            return Channel.create(channelId, name, creatorId, channelPolicy, memberships, createdAt);
+        }
+
+        private LocalDateTime toLocalDateTime(Timestamp timestamp) {
+            return timestamp != null ? timestamp.toLocalDateTime() : null;
+        }
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcMessageRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcMessageRepository.java
@@ -1,37 +1,114 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class JdbcMessageRepository implements MessageRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Clock clock;
+
+    private final RowMapper<ChatMessage> rowMapper = (rs, rowNum) -> new ChatMessage(
+            rs.getLong("id"),
+            rs.getLong("channel_id"),
+            rs.getLong("user_id"),
+            rs.getLong("order_sequence"),
+            rs.getString("message"),
+            rs.getTimestamp("created_at").toLocalDateTime(),
+            rs.getTimestamp("updated_at").toLocalDateTime()
+    );
 
     @Override
     public ChatMessage save(ChatMessage chatMessage) {
-        // NO-OP
-        return chatMessage;
+        KeyHolder keyHolder = new org.springframework.jdbc.support.GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(
+                    """
+                            INSERT INTO messages (
+                                channel_id, user_id, order_sequence, message, created_at, updated_at
+                            ) VALUES (?, ?, ?, ?, ?, ?)
+                            """,
+                    new String[]{"id"}
+            );
+            ps.setLong(1, chatMessage.channelId());
+            ps.setLong(2, chatMessage.userId());
+            ps.setLong(3, chatMessage.orderSequence());
+            ps.setString(4, chatMessage.message());
+            ps.setTimestamp(5, Timestamp.valueOf(chatMessage.createdAt()));
+            ps.setTimestamp(6, Timestamp.valueOf(chatMessage.updatedAt()));
+            return ps;
+        }, keyHolder);
+
+        Long generatedId = keyHolder.getKey().longValue();
+        return new ChatMessage(
+                generatedId,
+                chatMessage.channelId(),
+                chatMessage.userId(),
+                chatMessage.orderSequence(),
+                chatMessage.message(),
+                chatMessage.createdAt(),
+                chatMessage.updatedAt()
+        );
     }
 
     @Override
     public void update(Long messageId, String updatedMessage) {
-        // NO-OP
+        jdbcTemplate.update(
+                "UPDATE messages SET message = ?, updated_at = ? WHERE id = ?",
+                updatedMessage,
+                Timestamp.valueOf(LocalDateTime.now(clock)),
+                messageId
+        );
     }
 
     @Override
     public void delete(Long messageId) {
-        // NO-OP
+        jdbcTemplate.update("DELETE FROM messages WHERE id = ?", messageId);
     }
 
     @Override
     public List<ChatMessage> findHistory(Long channelId, long messageSequence, int size) {
-        // NO-OP
-        return List.of();
+        List<ChatMessage> history = jdbcTemplate.query(
+                """
+                        SELECT id, channel_id, user_id, order_sequence, message, created_at, updated_at
+                        FROM messages
+                        WHERE channel_id = ? AND order_sequence < ?
+                        ORDER BY order_sequence DESC
+                        LIMIT ?
+                        """,
+                rowMapper,
+                channelId,
+                messageSequence,
+                size
+        );
+        history.sort((a, b) -> Long.compare(a.orderSequence(), b.orderSequence()));
+        return history;
     }
 
     @Override
     public List<ChatMessage> findLatest(Long channelId, int size) {
-        // NO-OP
-        return List.of();
+        return jdbcTemplate.query(
+                """
+                        SELECT id, channel_id, user_id, order_sequence, message, created_at, updated_at
+                        FROM messages
+                        WHERE channel_id = ?
+                        ORDER BY order_sequence DESC
+                        LIMIT ?
+                        """,
+                rowMapper,
+                channelId,
+                size
+        );
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcParticipatingChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcParticipatingChannelRepository.java
@@ -1,14 +1,32 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class JdbcParticipatingChannelRepository implements ParticipatingChannelRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
 
     @Override
     public List<Long> findAllChannelIds(Long userId) {
-        // NO-OP
-        return List.of();
+        String sql = """
+                SELECT channel_id
+                FROM channel_memberships
+                WHERE user_id = :userId
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("userId", userId);
+
+        return jdbcTemplate.query(
+                sql,
+                params,
+                (rs, rowNum) -> rs.getLong("channel_id")
+        );
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
@@ -1,12 +1,11 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
 import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
@@ -32,26 +31,11 @@ public class MessageStorageAdapter implements MessageStoragePort {
     }
 
     @Override
-    public void update(Long messageId, String updatedMessage, ActorRef<ChannelEntityCommand> replyTo) {
-        Mono.fromRunnable(() -> messageRepository.update(messageId, updatedMessage))
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnSuccess(ignored -> replyTo.tell(new SyncUpdatedMessage(messageId, updatedMessage)))
-            .subscribe();
-    }
-
-    @Override
     public void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo) {
         Mono.fromRunnable(() -> messageRepository.update(updatedMessage.messageId(), updatedMessage.message()))
             .subscribeOn(Schedulers.boundedElastic())
             .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
-            .subscribe();
-    }
-
-    @Override
-    public void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo) {
-        Mono.fromRunnable(() -> messageRepository.delete(messageId))
-            .subscribeOn(Schedulers.boundedElastic())
-            .doOnSuccess(ignored -> replyTo.tell(new SyncDeletedMessage(messageId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
             .subscribe();
     }
 
@@ -60,6 +44,7 @@ public class MessageStorageAdapter implements MessageStoragePort {
         Mono.fromRunnable(() -> messageRepository.delete(messageId))
             .subscribeOn(Schedulers.boundedElastic())
             .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
             .subscribe();
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
@@ -6,6 +6,8 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -38,10 +40,26 @@ public class MessageStorageAdapter implements MessageStoragePort {
     }
 
     @Override
+    public void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> messageRepository.update(updatedMessage.messageId(), updatedMessage.message()))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .subscribe();
+    }
+
+    @Override
     public void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo) {
         Mono.fromRunnable(() -> messageRepository.delete(messageId))
             .subscribeOn(Schedulers.boundedElastic())
             .doOnSuccess(ignored -> replyTo.tell(new SyncDeletedMessage(messageId)))
+            .subscribe();
+    }
+
+    @Override
+    public void delete(Long eventId, Long messageId, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> messageRepository.delete(messageId))
+            .subscribeOn(Schedulers.boundedElastic())
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
             .subscribe();
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActor.java
@@ -3,7 +3,7 @@ package com.tok.pekko.adapter.out.websocket;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
 import com.tok.pekko.domain.chat.actor.ChannelReaderActor;
-import com.tok.pekko.domain.chat.actor.ChatMessages;
+import com.tok.pekko.domain.chat.actor.ChannelReaderMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RegisterReader;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemoveShutdownReader;
@@ -161,7 +161,7 @@ public class ChannelReaderRegistryActor extends AbstractBehavior<ChannelReaderRe
                 Behaviors.supervise(
                         ChannelReaderActor.create(
                                 channelId,
-                                new ChatMessages(),
+                                new ChannelReaderMessages(),
                                 channelEntity,
                                 getContext().getSelf()
                         )

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.adapter.out.websocket;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
 
@@ -16,4 +18,18 @@ public interface ClientMessageSender {
     void sendWebSocketPing();
 
     void requestSessionReconnect();
+
+    void sendChangedChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount);
+
+    void sendChangedMembershipCount(Long channelId, int membershipCount);
+
+    void sendInvitedChannel(Long channelId);
+
+    void sendEditedChannelName(Long channelId, String editedName);
+
+    void sendKickedFromChannel(Long channelId);
+
+    void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy);
+
+    void sendError(Long channelId, String reason);
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -25,6 +25,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembers
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncInvitedChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SessionPongReceived;
@@ -119,6 +120,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(FoundRegisteredChannelIds.class, this::onFoundRegisteredChannelIds)
                                   .onMessage(FoundChannelReaders.class, this::onFoundChannelReaders)
                                   .onMessage(SyncJoinChannel.class, this::onSyncJoinChannel)
+                                  .onMessage(SyncInvitedChannel.class, this::onSyncInvitedChannel)
                                   .onMessage(SyncLeaveChannel.class, this::onSyncLeaveChannel)
                                   .onMessage(Shutdown.class, this::onShutdown)
                                   .onMessage(SessionPongReceived.class, this::onSessionPongReceived)
@@ -221,6 +223,12 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
 
     private Behavior<ClientSessionCommand> onSyncJoinChannel(SyncJoinChannel command) {
         readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onSyncInvitedChannel(SyncInvitedChannel command) {
+        readerRegistry.tell(new GetChannelReaderActor(userId, List.of(command.channelId()), getContext().getSelf()));
+        clientMessageSender.sendInvitedChannel(command.channelId());
         return this;
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -16,6 +16,13 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
@@ -63,6 +70,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                         userId,
                                         clientMessageSender,
                                         messageStoragePort,
+                                        channelMembershipActorMessagePort,
                                         readerRegistry
                                 );
                             }
@@ -74,6 +82,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     private final Long userId;
     private final ClientMessageSender clientMessageSender;
     private final MessageStoragePort messageStoragePort;
+    private final ChannelMembershipActorMessagePort channelMembershipActorMessagePort;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
     private final Map<Long, RequestHistory> pendingRequestHistory;
@@ -84,12 +93,14 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
+            ChannelMembershipActorMessagePort channelMembershipActorMessagePort,
             ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
         super(context);
 
         this.userId = userId;
         this.messageStoragePort = messageStoragePort;
+        this.channelMembershipActorMessagePort = channelMembershipActorMessagePort;
         this.clientMessageSender = clientMessageSender;
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
@@ -112,6 +123,13 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(Shutdown.class, this::onShutdown)
                                   .onMessage(SessionPongReceived.class, this::onSessionPongReceived)
                                   .onMessage(SessionHealthCheck.class, this::onSessionHealthCheck)
+                                  .onMessage(PropagateChangeChannelMembership.class, this::onPropagateChangeChannelMembership)
+                                  .onMessage(PropagateMembershipCount.class, this::onPropagateMembershipCount)
+                                  .onMessage(PropagateChangeChannelPolicy.class, this::onPropagateChangeChannelPolicy)
+                                  .onMessage(PropagateEditChannelName.class, this::onPropagateEditChannelName)
+                                  .onMessage(PropagateKickedMember.class, this::onPropagateKickedMember)
+                                  .onMessage(ReSyncSession.class, this::onReSyncSession)
+                                  .onMessage(PropagateFailure.class, this::onPropagateFailure)
                                   .build();
     }
 
@@ -242,6 +260,49 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             clientMessageSender.requestSessionReconnect();
             missedSessionPongs = 0;
         }
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateChangeChannelMembership(PropagateChangeChannelMembership command) {
+        clientMessageSender.sendChangedChannelMembership(command.channelId(), command.channelMembership(), command.membershipCount());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateMembershipCount(PropagateMembershipCount command) {
+        clientMessageSender.sendChangedMembershipCount(command.channelId(), command.membershipCount());
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateChangeChannelPolicy(PropagateChangeChannelPolicy command) {
+        clientMessageSender.sendChangedChannelPolicy(command.channelId(), command.channelPolicy());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateEditChannelName(PropagateEditChannelName command) {
+        clientMessageSender.sendEditedChannelName(command.channelId(), command.editedName());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateKickedMember(PropagateKickedMember command) {
+        clientMessageSender.sendKickedFromChannel(command.channelId());
+        readers.remove(command.channelId());
+        readerRegistry.tell(new ReleaseClientSessionActor(userId, List.of(command.channelId())));
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onReSyncSession(ReSyncSession command) {
+        channelMembershipActorMessagePort.sendParticipatingChannels(userId, getContext().getSelf());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateFailure(PropagateFailure command) {
+        clientMessageSender.sendError(command.channelId(), command.reason());
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/InviteUserEventListenerActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/InviteUserEventListenerActor.java
@@ -1,0 +1,53 @@
+package com.tok.pekko.adapter.out.websocket;
+
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.Invited;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
+import org.apache.pekko.actor.typed.javadsl.ActorContext;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.actor.typed.pubsub.Topic;
+import org.apache.pekko.actor.typed.pubsub.Topic.Command;
+
+public class InviteUserEventListenerActor extends AbstractBehavior<InviteUserEventCommand> {
+
+    private final ClientSessionActorManagementService clientSessionActorManagementService;
+
+    public static Behavior<InviteUserEventCommand> create(
+            ActorRef<Command<InviteUserEventCommand>> inviteUserTopic,
+            ClientSessionActorManagementService clientSessionActorManagementService
+    ) {
+        return Behaviors.setup(context -> new InviteUserEventListenerActor(
+                context,
+                inviteUserTopic,
+                clientSessionActorManagementService)
+        );
+    }
+
+    public InviteUserEventListenerActor(
+            ActorContext<InviteUserEventCommand> context,
+            ActorRef<Command<InviteUserEventCommand>> inviteUserTopic,
+            ClientSessionActorManagementService clientSessionActorManagementService
+    ) {
+        super(context);
+
+        this.clientSessionActorManagementService = clientSessionActorManagementService;
+
+        inviteUserTopic.tell(Topic.subscribe(context.getSelf()));
+    }
+
+    @Override
+    public Receive<InviteUserEventCommand> createReceive() {
+        return newReceiveBuilder().onMessage(Invited.class, this::onInvited)
+                                  .build();
+    }
+
+    private Behavior<InviteUserEventCommand> onInvited(Invited command) {
+        clientSessionActorManagementService.syncInvitedChannel(command.channelId(), command.inviteeId());
+
+        return this;
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
@@ -1,7 +1,11 @@
 package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import reactor.core.publisher.Sinks;
 
@@ -12,6 +16,13 @@ public class WebSocketMessageSender implements ClientMessageSender {
     public static final String EVENT_DELETED = "DELETED";
     public static final String EVENT_WS_PING = "WS_HEALTH_PING";
     public static final String EVENT_WS_RECONNECT = "WS_RECONNECT";
+    public static final String EVENT_CHANNEL_MEMBERSHIP_CHANGED = "CHANNEL_MEMBERSHIP_CHANGED";
+    public static final String EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED = "CHANNEL_MEMBERSHIP_COUNT_CHANGED";
+    public static final String EVENT_INVITED_CHANNEL = "CHANNEL_INVITED";
+    public static final String EVENT_CHANNEL_NAME_EDITED = "CHANNEL_NAME_EDITED";
+    public static final String EVENT_CHANNEL_KICKED = "CHANNEL_KICKED";
+    public static final String EVENT_CHANNEL_POLICY_CHANGED = "CHANNEL_POLICY_CHANGED";
+    public static final String EVENT_ERROR = "ERROR";
 
     private final AtomicReference<Sinks.Many<WebSocketPayload>> sinkHolder;
 
@@ -33,7 +44,9 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendMessage(ChatMessage message) {
-        emit(new WebSocketPayload(EVENT_NEW, message));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_NEW, message);
+
+        emit(webSocketPayload);
     }
 
     @Override
@@ -43,22 +56,92 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendDeletedMessage(ChatMessage deletedMessage) {
-        emit(new WebSocketPayload(EVENT_DELETED, deletedMessage));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_DELETED, deletedMessage);
+
+        emit(webSocketPayload);
     }
 
     @Override
     public void sendUpdatedMessage(ChatMessage updatedMessage) {
-        emit(new WebSocketPayload(EVENT_UPDATED, updatedMessage));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_UPDATED, updatedMessage);
+
+        emit(webSocketPayload);
     }
 
     @Override
     public void sendWebSocketPing() {
-        emit(new WebSocketPayload(EVENT_WS_PING, null));
+        emit(WebSocketPayload.PING_PAYLOAD);
     }
 
     @Override
     public void requestSessionReconnect() {
-        emit(new WebSocketPayload(EVENT_WS_RECONNECT, null));
+        emit(WebSocketPayload.RECONNECT_PAYLOAD);
+    }
+
+    @Override
+    public void sendChangedChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount) {
+        ChannelMembershipPayload channelMembershipPayload = ChannelMembershipPayload.from(
+                channelId,
+                channelMembership,
+                membershipCount
+        );
+        WebSocketPayload webSocketPayload = new WebSocketPayload(
+                EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                channelMembershipPayload
+        );
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendChangedMembershipCount(Long channelId, int membershipCount) {
+        ChannelMembershipCountPayload channelMembershipCountPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(
+                EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                channelMembershipCountPayload
+        );
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendInvitedChannel(Long channelId) {
+        ChannelInvitePayload channelInvitePayload = new ChannelInvitePayload(channelId);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_INVITED_CHANNEL, channelInvitePayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendEditedChannelName(Long channelId, String editedName) {
+        ChannelNamePayload channelNamePayload = new ChannelNamePayload(channelId, editedName);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_NAME_EDITED, channelNamePayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendKickedFromChannel(Long channelId) {
+        ChannelKickedPayload channelKickedPayload = new ChannelKickedPayload(channelId);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_KICKED, channelKickedPayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy) {
+        ChannelPolicyPayload channelPolicyPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_POLICY_CHANGED, channelPolicyPayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendError(Long channelId, String reason) {
+        ErrorPayload errorPayload = new ErrorPayload(channelId, reason);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_ERROR, errorPayload);
+
+        emit(webSocketPayload);
     }
 
     private void emit(WebSocketPayload payload) {
@@ -69,5 +152,53 @@ public class WebSocketMessageSender implements ClientMessageSender {
         }
     }
 
-    public record WebSocketPayload(String type, ChatMessage message) { }
+    public record WebSocketPayload(String type, Object message) {
+
+        static final WebSocketPayload PING_PAYLOAD = new WebSocketPayload(EVENT_WS_PING, null);
+        static final WebSocketPayload RECONNECT_PAYLOAD = new WebSocketPayload(EVENT_WS_RECONNECT, null);
+    }
+
+    public record ChannelMembershipPayload(
+            Long channelId,
+            Long memberId,
+            String role,
+            Set<ChannelPermissionType> permissions,
+            int membershipCount
+    ) {
+        static ChannelMembershipPayload from(Long channelId, ChannelMembership channelMembership, int membershipCount) {
+            return new ChannelMembershipPayload(
+                    channelId,
+                    channelMembership.getUserId().getValue(),
+                    channelMembership.getRole().name(),
+                    channelMembership.getPermissions().getAll(),
+                    membershipCount
+            );
+        }
+    }
+
+    public record ChannelNamePayload(Long channelId, String name) { }
+
+    public record ChannelInvitePayload(Long channelId) { }
+
+    public record ChannelKickedPayload(Long channelId) { }
+
+    public record ChannelMembershipCountPayload(Long channelId, int membershipCount) { }
+
+    public record ChannelPolicyPayload(
+            Long channelId,
+            boolean canEditOwnMessage,
+            boolean canDeleteOwnMessage,
+            boolean isPublic
+    ) {
+        static ChannelPolicyPayload from(Long channelId, ChannelPolicy policy) {
+            return new ChannelPolicyPayload(
+                    channelId,
+                    policy.canEditOwnMessage(),
+                    policy.canDeleteOwnMessage(),
+                    policy.isPublic()
+            );
+        }
+    }
+
+    public record ErrorPayload(Long channelId, String reason) { }
 }

--- a/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
@@ -13,6 +13,7 @@ import com.tok.pekko.global.actor.GuardianActor.SpawnClientSession;
 import com.tok.pekko.global.actor.GuardianActor.SpawnedClientSession;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -74,6 +75,10 @@ public class ClientSessionActorManagementService {
         }
 
         return clientSession;
+    }
+
+    public Optional<ActorRef<ClientSessionCommand>> findClientSessionOptional(Long userId) {
+        return Optional.ofNullable(clientSessions.get(userId));
     }
 
     public void syncJoinChannel(Long channelId, Long userId) {

--- a/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
@@ -15,7 +15,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.RequiredArgsConstructor;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.actor.typed.javadsl.AskPattern;
@@ -24,13 +23,25 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 @Service
-@RequiredArgsConstructor
 public class ClientSessionActorManagementService {
 
     private final ActorSystem<GuardianCommand> actorSystem;
     private final MessageStoragePort messageStoragePort;
     private final ChannelMembershipActorMessagePort channelMembershipActorMessagePort;
-    private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions = new ConcurrentHashMap<>();
+    private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions;
+
+    public ClientSessionActorManagementService(
+            ActorSystem<GuardianCommand> actorSystem,
+            MessageStoragePort messageStoragePort,
+            ChannelMembershipActorMessagePort channelMembershipActorMessagePort
+    ) {
+        this.actorSystem = actorSystem;
+        this.messageStoragePort = messageStoragePort;
+        this.channelMembershipActorMessagePort = channelMembershipActorMessagePort;
+        this.clientSessions = new ConcurrentHashMap<>();
+
+        actorSystem.tell(new GuardianActor.InitializeInviteUserListener(this));
+    }
 
     public CompletionStage<ActorRef<ClientSessionCommand>> createClientSessionActor(
             ClientMessageSender clientMessageSender,

--- a/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/actor/ClientSessionActorManagementService.java
@@ -3,6 +3,7 @@ package com.tok.pekko.application.actor;
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncInvitedChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -19,6 +20,8 @@ import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.actor.typed.javadsl.AskPattern;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 @RequiredArgsConstructor
@@ -75,6 +78,20 @@ public class ClientSessionActorManagementService {
 
         if (clientSession != null) {
             clientSession.tell(new SyncLeaveChannel(channelId));
+        }
+    }
+
+    public void syncInvitedChannel(Long channelId, Long inviteeId) {
+        Mono.fromRunnable(() -> asyncInvitedChannel(channelId, inviteeId))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe();
+    }
+
+    private void asyncInvitedChannel(Long channelId, Long userId) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(userId);
+
+        if (clientSession != null) {
+            clientSession.tell(new SyncInvitedChannel(channelId));
         }
     }
 

--- a/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
@@ -1,109 +1,90 @@
 package com.tok.pekko.application.channel;
 
 import com.tok.pekko.application.actor.ClientSessionActorManagementService;
-import com.tok.pekko.application.channel.exception.ChannelNotFoundException;
-import com.tok.pekko.domain.channel.model.Channel;
-import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.channel.model.ChannelPermissionType;
-import com.tok.pekko.domain.channel.model.ChannelRole;
-import com.tok.pekko.domain.channel.port.out.ChannelMembershipStoragePort;
-import com.tok.pekko.domain.channel.port.out.ChannelStoragePort;
+import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.AddPermission;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.DemoteToMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.InviteUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.JoinUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.KickMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.LeaveMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.PromoteToManager;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemovePermission;
 import com.tok.pekko.domain.user.model.vo.UserId;
-import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ChannelMembershipService {
 
-    private final Clock clock;
-    private final ChannelStoragePort channelStoragePort;
-    private final ChannelMembershipStoragePort channelMembershipStoragePort;
+    private final ClusterSharding clusterSharding;
     private final ClientSessionActorManagementService clientSessionActorManagementService;
 
     public void joinChannel(Long channelId, Long joinerId) {
-        Channel channel = channelStoragePort.findChannel(channelId, joinerId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId joiner = UserId.create(joinerId);
-        ChannelMembership joinerMembership = channel.joinUser(joiner, ChannelRole.MEMBER, LocalDateTime.now(clock));
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.joinChannel(channel.getChannelId(), joinerMembership);
-        clientSessionActorManagementService.syncJoinChannel(channelId, joinerId);
+        channelEntity.ask(
+                (ActorRef<ChannelEntityCommand> replyTo) -> new JoinUser(
+                        UserId.create(joinerId),
+                        replyTo
+                ),
+                Duration.ofSeconds(3L)
+        ).thenAccept(response -> clientSessionActorManagementService.syncJoinChannel(channelId, joinerId));
     }
 
     public void inviteMember(Long channelId, Long inviterId, Long inviteeId) {
-        Channel channel = channelStoragePort.findChannel(channelId, inviterId, inviteeId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId inviter = UserId.create(inviterId);
-        UserId invitee = UserId.create(inviteeId);
-        ChannelMembership inviteeMembership = channel.inviteMember(inviter, invitee, LocalDateTime.now(clock));
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.joinChannel(channel.getChannelId(), inviteeMembership);
-        clientSessionActorManagementService.syncJoinChannel(channelId, inviteeId);
+         channelEntity.tell(new InviteUser(UserId.create(inviterId), UserId.create(inviteeId)));
     }
 
-    public void leaveChannel(Long channelId, Long userId) {
-        Channel channel = channelStoragePort.findChannel(channelId, userId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId user = UserId.create(userId);
-        ChannelMembership leaveMembership = channel.leaveMember(user);
+    public void leaveChannel(Long channelId, Long memberId) {
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.leaveChannel(leaveMembership);
-        clientSessionActorManagementService.syncLeaveChannel(channelId, userId);
+        channelEntity.tell(new LeaveMember(UserId.create(memberId)));
     }
 
     public void promoteToManager(Long channelId, Long executorId, Long targetUserId) {
-        Channel channel = channelStoragePort.findChannel(channelId, executorId, targetUserId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId executor = UserId.create(executorId);
-        UserId targetUser = UserId.create(targetUserId);
-        ChannelMembership targetUserMembership = channel.promoteToManager(executor, targetUser);
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.promoteToManager(targetUserMembership);
+        channelEntity.tell(new PromoteToManager(UserId.create(executorId), UserId.create(targetUserId)));
     }
 
     public void demoteToMember(Long channelId, Long executorId, Long targetUserId) {
-        Channel channel = channelStoragePort.findChannel(channelId, executorId, targetUserId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId executor = UserId.create(executorId);
-        UserId targetUser = UserId.create(targetUserId);
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        ChannelMembership targetUserMembership = channel.demoteToMember(executor, targetUser);
-
-        channelMembershipStoragePort.demoteToMember(targetUserMembership);
+        channelEntity.tell(new DemoteToMember(UserId.create(executorId), UserId.create(targetUserId)));
     }
 
     public void addPermission(Long channelId, Long grantorId, Long granteeId, ChannelPermissionType permission) {
-        Channel channel = channelStoragePort.findChannel(channelId, grantorId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId grantor = UserId.create(grantorId);
-        UserId grantee = UserId.create(granteeId);
-        ChannelMembership granteeMembership = channel.addPermission(grantor, grantee, permission);
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.addPermission(granteeMembership, permission);
+        channelEntity.tell(new AddPermission(UserId.create(grantorId), UserId.create(granteeId), permission));
     }
 
     public void removePermission(Long channelId, Long grantorId, Long granteeId, ChannelPermissionType permission) {
-        Channel channel = channelStoragePort.findChannel(channelId, grantorId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId grantor = UserId.create(grantorId);
-        UserId grantee = UserId.create(granteeId);
-        ChannelMembership granteeMembership = channel.removePermission(grantor, grantee, permission);
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.removePermission(granteeMembership, permission);
+        channelEntity.tell(new RemovePermission(UserId.create(grantorId), UserId.create(granteeId), permission));
     }
 
     public void kickMember(Long channelId, Long executorId, Long targetUserId) {
-        Channel channel = channelStoragePort.findChannel(channelId, executorId, targetUserId)
-                                           .orElseThrow(ChannelNotFoundException::new);
-        UserId executor = UserId.create(executorId);
-        UserId targetUser = UserId.create(targetUserId);
-        ChannelMembership kickedMembership = channel.kickMember(executor, targetUser);
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelMembershipStoragePort.kickMember(kickedMembership);
+        channelEntity.tell(new KickMember(UserId.create(executorId), UserId.create(targetUserId)));
+    }
+
+    private EntityRef<ChannelEntityCommand> getChannelEntity(Long channelId) {
+        return clusterSharding.entityRefFor(
+                ChannelEntity.ENTITY_TYPE_KEY,
+                String.valueOf(channelId)
+        );
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/channel/ChannelMembershipService.java
@@ -29,15 +29,7 @@ public class ChannelMembershipService {
         Channel channel = channelStoragePort.findChannel(channelId, joinerId)
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId joiner = UserId.create(joinerId);
-
-        channel.validateJoinMember(joiner);
-
-        ChannelMembership joinerMembership = ChannelMembership.create(
-                channel.getChannelId(),
-                joiner,
-                ChannelRole.MEMBER,
-                LocalDateTime.now(clock)
-        );
+        ChannelMembership joinerMembership = channel.joinUser(joiner, ChannelRole.MEMBER, LocalDateTime.now(clock));
 
         channelMembershipStoragePort.joinChannel(channel.getChannelId(), joinerMembership);
         clientSessionActorManagementService.syncJoinChannel(channelId, joinerId);
@@ -46,18 +38,9 @@ public class ChannelMembershipService {
     public void inviteMember(Long channelId, Long inviterId, Long inviteeId) {
         Channel channel = channelStoragePort.findChannel(channelId, inviterId, inviteeId)
                                             .orElseThrow(ChannelNotFoundException::new);
-
         UserId inviter = UserId.create(inviterId);
         UserId invitee = UserId.create(inviteeId);
-
-        channel.validateInviteMember(inviter, invitee);
-
-        ChannelMembership inviteeMembership = ChannelMembership.create(
-                channel.getChannelId(),
-                invitee,
-                ChannelRole.MEMBER,
-                LocalDateTime.now(clock)
-        );
+        ChannelMembership inviteeMembership = channel.inviteMember(inviter, invitee, LocalDateTime.now(clock));
 
         channelMembershipStoragePort.joinChannel(channel.getChannelId(), inviteeMembership);
         clientSessionActorManagementService.syncJoinChannel(channelId, inviteeId);
@@ -67,8 +50,7 @@ public class ChannelMembershipService {
         Channel channel = channelStoragePort.findChannel(channelId, userId)
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId user = UserId.create(userId);
-
-        ChannelMembership leaveMembership = channel.getValidatedLeaveMember(user);
+        ChannelMembership leaveMembership = channel.leaveMember(user);
 
         channelMembershipStoragePort.leaveChannel(leaveMembership);
         clientSessionActorManagementService.syncLeaveChannel(channelId, userId);
@@ -100,8 +82,7 @@ public class ChannelMembershipService {
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId grantor = UserId.create(grantorId);
         UserId grantee = UserId.create(granteeId);
-
-        ChannelMembership granteeMembership = channel.getValidatedAddTarget(grantor, grantee, permission);
+        ChannelMembership granteeMembership = channel.addPermission(grantor, grantee, permission);
 
         channelMembershipStoragePort.addPermission(granteeMembership, permission);
     }
@@ -111,8 +92,8 @@ public class ChannelMembershipService {
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId grantor = UserId.create(grantorId);
         UserId grantee = UserId.create(granteeId);
+        ChannelMembership granteeMembership = channel.removePermission(grantor, grantee, permission);
 
-        ChannelMembership granteeMembership = channel.getValidatedRemoveTarget(grantor, grantee, permission);
         channelMembershipStoragePort.removePermission(granteeMembership, permission);
     }
 
@@ -121,8 +102,7 @@ public class ChannelMembershipService {
                                            .orElseThrow(ChannelNotFoundException::new);
         UserId executor = UserId.create(executorId);
         UserId targetUser = UserId.create(targetUserId);
-
-        ChannelMembership kickedMembership = channel.getValidatedKickedMember(executor, targetUser);
+        ChannelMembership kickedMembership = channel.kickMember(executor, targetUser);
 
         channelMembershipStoragePort.kickMember(kickedMembership);
     }

--- a/pekko/src/main/java/com/tok/pekko/application/channel/ChannelService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/channel/ChannelService.java
@@ -5,19 +5,32 @@ import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.channel.port.out.ChannelStoragePort;
+import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.EditChannelName;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ChannelService {
 
+    private final ClusterSharding clusterSharding;
     private final ChannelStoragePort channelStoragePort;
+    private final TransactionTemplate transactionTemplate;
 
+    @Transactional
     public ChannelId createChannel(String name, Long creatorId) {
         Channel channel = Channel.create(name, creatorId, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
 
@@ -30,8 +43,18 @@ public class ChannelService {
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId deleter = UserId.create(deleterId);
 
-        channel.validateDeleteChannel(deleter);
-        channelStoragePort.delete(channel.getChannelId());
+        transactionTemplate.executeWithoutResult(
+                status -> {
+                    channel.validateDeleteChannel(deleter);
+                    channelStoragePort.delete(channel.getChannelId());
+                }
+        );
+
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
+        EntityRef<ChannelEventHandlerCommand> channelEventHandler = getChannelEventHandler(channelId);
+
+        channelEntity.tell(new ChannelProtocol.Shutdown());
+        channelEventHandler.tell(new ChannelEventHandlerProtocol.Shutdown());
     }
 
     public void changeChannelPolicy(
@@ -41,21 +64,30 @@ public class ChannelService {
             boolean canDeleteOwnMessage,
             boolean isPublic
     ) {
-        Channel channel = channelStoragePort.findChannel(channelId, changerId)
-                                            .orElseThrow();
-        UserId changer = UserId.create(changerId);
-        ChannelPolicy updatedChannelPolicy = new ChannelPolicy(canEditOwnMessage, canDeleteOwnMessage, isPublic);
-        Channel updatedPolicyChannel = channel.changeChannelPolicy(changer, updatedChannelPolicy);
+        EntityRef<ChannelEntityCommand> channel = getChannelEntity(channelId);
 
-        channelStoragePort.update(updatedPolicyChannel);
+        channel.tell(
+                new ChangeChannelPolicy(UserId.create(changerId), canEditOwnMessage, canDeleteOwnMessage, isPublic)
+        );
     }
 
-    public void changeChannelName(Long channelId, Long changerId, String changedName) {
-        Channel channel = channelStoragePort.findChannel(channelId, changerId)
-                                            .orElseThrow(ChannelNotFoundException::new);
-        UserId changer = UserId.create(changerId);
-        Channel updatedChannel = channel.editName(changer, changedName);
+    public void editChannelName(Long channelId, Long changerId, String changedName) {
+        EntityRef<ChannelEntityCommand> channelEntity = getChannelEntity(channelId);
 
-        channelStoragePort.update(updatedChannel);
+        channelEntity.tell(new EditChannelName(UserId.create(changerId), changedName));
+    }
+
+    private EntityRef<ChannelEntityCommand> getChannelEntity(Long channelId) {
+        return clusterSharding.entityRefFor(
+                ChannelEntity.ENTITY_TYPE_KEY,
+                String.valueOf(channelId)
+        );
+    }
+
+    private EntityRef<ChannelEventHandlerCommand> getChannelEventHandler(Long channelId) {
+        return clusterSharding.entityRefFor(
+                ChannelEventHandlerEntity.ENTITY_TYPE_KEY,
+                String.valueOf(channelId)
+        );
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/application/channel/ChannelService.java
+++ b/pekko/src/main/java/com/tok/pekko/application/channel/ChannelService.java
@@ -54,7 +54,7 @@ public class ChannelService {
         Channel channel = channelStoragePort.findChannel(channelId, changerId)
                                             .orElseThrow(ChannelNotFoundException::new);
         UserId changer = UserId.create(changerId);
-        Channel updatedChannel = channel.changeName(changer, changedName);
+        Channel updatedChannel = channel.editName(changer, changedName);
 
         channelStoragePort.update(updatedChannel);
     }

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
@@ -88,7 +88,7 @@ public class Channel {
     }
 
     public void validateJoinMember(UserId userId) {
-        if (!channelPolicy.isPublic()) {
+        if (channelPolicy.isPrivate()) {
             throw new IllegalArgumentException("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
         }
         if (memberships.containsKey(userId)) {
@@ -106,7 +106,7 @@ public class Channel {
         if (inviterMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (!inviterMembership.canInviteMember()) {
+        if (inviterMembership.cannotInviteMember()) {
             throw new ChannelMembershipOperationForbiddenException("멤버를 초대할 권한이 없습니다.");
         }
     }
@@ -118,7 +118,7 @@ public class Channel {
             throw new ChannelMembershipNotFoundException();
         }
 
-        if (!executorMembership.canMemberRoleManagement()) {
+        if (executorMembership.cannotManageRole()) {
             throw new ChannelMembershipOperationForbiddenException("멤버의 역할을 변경할 권한이 없습니다.");
         }
 
@@ -127,7 +127,6 @@ public class Channel {
         if (targetUserMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-
         if (targetUserMembership.isManager()) {
             throw new IllegalArgumentException("이미 매니저입니다.");
         }
@@ -145,7 +144,7 @@ public class Channel {
             throw new ChannelMembershipNotFoundException();
         }
 
-        if (!executorMembership.canMemberRoleManagement()) {
+        if (executorMembership.cannotManageRole()) {
             throw new ChannelMembershipOperationForbiddenException("멤버의 역할을 변경할 권한이 없습니다.");
         }
 
@@ -171,7 +170,7 @@ public class Channel {
             throw new ChannelMembershipNotFoundException();
         }
 
-        if (!grantorMembership.canPermissionManagement()) {
+        if (grantorMembership.cannotManagePermission()) {
             throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
         }
 
@@ -197,7 +196,7 @@ public class Channel {
             throw new ChannelMembershipNotFoundException();
         }
 
-        if (!grantorMembership.canPermissionManagement()) {
+        if (grantorMembership.cannotManagePermission()) {
             throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
         }
 
@@ -209,7 +208,7 @@ public class Channel {
         if (!granteeMembership.isManager()) {
             throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
         }
-        if (!granteeMembership.hasPermission(permission)) {
+        if (granteeMembership.lacksPermission(permission)) {
             throw new IllegalArgumentException("해당 권한을 가지고 있지 않습니다.");
         }
 
@@ -235,7 +234,7 @@ public class Channel {
         if (deleterMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (!deleterMembership.canDeleteChannel()) {
+        if (deleterMembership.cannotDeleteChannel()) {
             throw new ChannelOperationForbiddenException("채널을 삭제할 권한이 없습니다.");
         }
     }
@@ -246,10 +245,9 @@ public class Channel {
         if (executorMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (!executorMembership.canKickMember()) {
+        if (executorMembership.cannotKickMember()) {
             throw new IllegalArgumentException("멤버를 강퇴할 권한이 없습니다.");
         }
-
         if (executorId.equals(targetUserId)) {
             throw new IllegalArgumentException("자기 자신을 강퇴할 수 없습니다.");
         }
@@ -259,7 +257,6 @@ public class Channel {
         if (targetUserMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-
         if (targetUserMembership.isOwner()) {
             throw new IllegalArgumentException("오너를 강퇴할 수 없습니다.");
         }
@@ -273,7 +270,7 @@ public class Channel {
         if (changerMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (!changerMembership.canEditChannelName()) {
+        if (changerMembership.cannotEditChannelName()) {
             throw new ChannelOperationForbiddenException("채널 이름을 변경할 권한이 없습니다.");
         }
 
@@ -295,7 +292,7 @@ public class Channel {
         if (channelMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (!channelMembership.canChangeChannelPolicy()) {
+        if (channelMembership.cannotChangeChannelPolicy()) {
             throw new ChannelOperationForbiddenException("채널 정책을 변경할 권한이 없습니다.");
         }
 

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
@@ -3,7 +3,9 @@ package com.tok.pekko.domain.channel.model;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.user.model.vo.UserId;
+import com.tok.pekko.global.common.ActorThreadSafe;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,28 +89,147 @@ public class Channel {
         );
     }
 
-    public void validateJoinMember(UserId userId) {
+    @ActorThreadSafe
+    public ChannelMembership joinUser(UserId userId, ChannelRole role, LocalDateTime joinedAt) {
         if (channelPolicy.isPrivate()) {
-            throw new IllegalArgumentException("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
+            throw new ChannelMembershipOperationForbiddenException("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
         }
         if (memberships.containsKey(userId)) {
             throw new IllegalArgumentException("이미 채널에 참여한 사용자입니다.");
         }
+
+        ChannelMembership joinerMembership = ChannelMembership.create(this.channelId, userId, role, joinedAt);
+
+        memberships.put(userId, joinerMembership);
+        return joinerMembership;
     }
 
-    public void validateInviteMember(UserId inviterId, UserId inviteeId) {
-        if (memberships.containsKey(inviteeId)) {
-            throw new IllegalArgumentException("이미 채널에 참여한 사용자입니다.");
-        }
-
+    @ActorThreadSafe
+    public ChannelMembership inviteMember(UserId inviterId, UserId inviteeId, LocalDateTime invitedAt) {
         ChannelMembership inviterMembership = memberships.get(inviterId);
 
         if (inviterMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
         if (inviterMembership.cannotInviteMember()) {
-            throw new ChannelMembershipOperationForbiddenException("멤버를 초대할 권한이 없습니다.");
+            throw new ChannelMembershipOperationForbiddenException("멤버 초대 권한이 없습니다.");
         }
+        if (memberships.containsKey(inviteeId)) {
+            throw new IllegalArgumentException("이미 해당 채널에 참여한 사용자입니다.");
+        }
+
+        ChannelMembership inviteeMembership = ChannelMembership.create(
+                this.channelId,
+                inviteeId,
+                ChannelRole.MEMBER,
+                invitedAt
+        );
+
+        memberships.put(inviteeId, inviteeMembership);
+        return inviteeMembership;
+    }
+
+    @ActorThreadSafe
+    public ChannelMembership leaveMember(UserId memberId) {
+        ChannelMembership channelMembership = memberships.get(memberId);
+
+        if (channelMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (channelMembership.isOwner()) {
+            throw new IllegalArgumentException("채널 오너는 채널에서 나갈 수 없습니다.");
+        }
+
+        return memberships.remove(memberId);
+    }
+
+    @ActorThreadSafe
+    public ChannelMembership kickMember(UserId executorId, UserId targetUserId) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (!executorMembership.canKickMember()) {
+            throw new ChannelMembershipOperationForbiddenException("멤버를 강퇴할 권한이 없습니다.");
+        }
+
+        ChannelMembership targetUserMembership = memberships.get(targetUserId);
+
+        if (targetUserMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (targetUserMembership.isNotMember()) {
+            throw new IllegalArgumentException("멤버만 강퇴할 수 있습니다.");
+        }
+
+        return memberships.remove(targetUserId);
+    }
+
+    @ActorThreadSafe
+    public ChannelMembership addPermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
+        ChannelMembership grantorMembership = memberships.get(grantorId);
+
+        if (grantorMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (grantorMembership.cannotManagePermission()) {
+            throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
+        }
+
+        ChannelMembership granteeMembership = memberships.get(granteeId);
+
+        if (granteeMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (granteeMembership.isNotManager()) {
+            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
+        }
+        if (granteeMembership.hasPermission(permission)) {
+            throw new IllegalArgumentException("이미 해당 권한을 가지고 있습니다.");
+        }
+
+        ChannelMembership addedPermissionMembership = granteeMembership.addPermission(permission);
+
+        memberships.put(granteeId, addedPermissionMembership);
+
+        return addedPermissionMembership;
+    }
+
+    @ActorThreadSafe
+    public ChannelMembership removePermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
+        ChannelMembership grantorMembership = memberships.get(grantorId);
+
+        if (grantorMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+
+        if (grantorMembership.cannotManagePermission()) {
+            throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
+        }
+
+        ChannelMembership granteeMembership = memberships.get(granteeId);
+
+        if (granteeMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (granteeMembership.isNotManager()) {
+            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
+        }
+        if (granteeMembership.lacksPermission(permission)) {
+            throw new IllegalArgumentException("해당 권한을 가지고 있지 않습니다.");
+        }
+
+        ChannelMembership removedPermissionMembership = granteeMembership.removePermission(permission);
+
+        memberships.put(granteeId, removedPermissionMembership);
+
+        return removedPermissionMembership;
+    }
+
+    @ActorThreadSafe
+    public void syncMembership(ChannelMembership membership) {
+        memberships.put(membership.getUserId(), membership);
     }
 
     public ChannelMembership promoteToManager(UserId executorId, UserId targetUserId) {
@@ -117,9 +238,8 @@ public class Channel {
         if (executorMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-
         if (executorMembership.cannotManageRole()) {
-            throw new ChannelMembershipOperationForbiddenException("멤버의 역할을 변경할 권한이 없습니다.");
+            throw new ChannelMembershipOperationForbiddenException("역할을 변경할 권한이 없습니다.");
         }
 
         ChannelMembership targetUserMembership = memberships.get(targetUserId);
@@ -127,11 +247,11 @@ public class Channel {
         if (targetUserMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (targetUserMembership.isManager()) {
-            throw new IllegalArgumentException("이미 매니저입니다.");
-        }
         if (targetUserMembership.isOwner()) {
-            throw new IllegalArgumentException("오너를 매니저로 강등시킬 수 없습니다.");
+            throw new IllegalArgumentException("채널 오너를 매니저로 강등할 수 없습니다.");
+        }
+        if (targetUserMembership.isManager()) {
+            throw  new IllegalArgumentException("이미 매니저입니다.");
         }
 
         return targetUserMembership.promoteToManager(ChannelManagePermissions.ofManager());
@@ -143,9 +263,8 @@ public class Channel {
         if (executorMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-
         if (executorMembership.cannotManageRole()) {
-            throw new ChannelMembershipOperationForbiddenException("멤버의 역할을 변경할 권한이 없습니다.");
+            throw new ChannelMembershipOperationForbiddenException("역할을 변경할 권한이 없습니다.");
         }
 
         ChannelMembership targetUserMembership = memberships.get(targetUserId);
@@ -153,124 +272,23 @@ public class Channel {
         if (targetUserMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
+        if (targetUserMembership.isOwner()) {
+            throw new IllegalArgumentException("채널 오너를 멤버로 강등시킬 수 없습니다.");
+        }
         if (targetUserMembership.isMember()) {
             throw new IllegalArgumentException("이미 멤버입니다.");
-        }
-        if (targetUserMembership.isOwner()) {
-            throw new IllegalArgumentException("오너를 멤버로 강등시킬 수 없습니다.");
         }
 
         return targetUserMembership.demoteToMember();
     }
 
-    public ChannelMembership getValidatedAddTarget(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
-        ChannelMembership grantorMembership = memberships.get(grantorId);
+    public Channel editName(UserId changerId, String newName) {
+        ChannelMembership channelMembership = memberships.get(changerId);
 
-        if (grantorMembership == null) {
+        if (channelMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-
-        if (grantorMembership.cannotManagePermission()) {
-            throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
-        }
-
-        ChannelMembership granteeMembership = memberships.get(granteeId);
-
-        if (granteeMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (!granteeMembership.isManager()) {
-            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
-        }
-        if (granteeMembership.hasPermission(permission)) {
-            throw new IllegalArgumentException("이미 해당 권한을 가지고 있습니다.");
-        }
-
-        return granteeMembership;
-    }
-
-    public ChannelMembership getValidatedRemoveTarget(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
-        ChannelMembership grantorMembership = memberships.get(grantorId);
-
-        if (grantorMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-
-        if (grantorMembership.cannotManagePermission()) {
-            throw new ChannelMembershipOperationForbiddenException("매니저의 권한을 추가할 권한이 없습니다.");
-        }
-
-        ChannelMembership granteeMembership = memberships.get(granteeId);
-
-        if (granteeMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (!granteeMembership.isManager()) {
-            throw new IllegalArgumentException("해당 멤버는 매니저가 아닙니다.");
-        }
-        if (granteeMembership.lacksPermission(permission)) {
-            throw new IllegalArgumentException("해당 권한을 가지고 있지 않습니다.");
-        }
-
-        return granteeMembership;
-    }
-
-    public ChannelMembership getValidatedLeaveMember(UserId userId) {
-        ChannelMembership leaveMembership = memberships.get(userId);
-
-        if (leaveMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (leaveMembership.isOwner()) {
-            throw new IllegalArgumentException("오너는 채널에서 나갈 수 없습니다.");
-        }
-
-        return leaveMembership;
-    }
-
-    public void validateDeleteChannel(UserId deleterId) {
-        ChannelMembership deleterMembership = memberships.get(deleterId);
-
-        if (deleterMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (deleterMembership.cannotDeleteChannel()) {
-            throw new ChannelOperationForbiddenException("채널을 삭제할 권한이 없습니다.");
-        }
-    }
-
-    public ChannelMembership getValidatedKickedMember(UserId executorId, UserId targetUserId) {
-        ChannelMembership executorMembership = memberships.get(executorId);
-
-        if (executorMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (executorMembership.cannotKickMember()) {
-            throw new IllegalArgumentException("멤버를 강퇴할 권한이 없습니다.");
-        }
-        if (executorId.equals(targetUserId)) {
-            throw new IllegalArgumentException("자기 자신을 강퇴할 수 없습니다.");
-        }
-
-        ChannelMembership targetUserMembership = memberships.get(targetUserId);
-
-        if (targetUserMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (targetUserMembership.isOwner()) {
-            throw new IllegalArgumentException("오너를 강퇴할 수 없습니다.");
-        }
-
-        return targetUserMembership;
-    }
-
-    public Channel changeName(UserId changerId, String newName) {
-        ChannelMembership changerMembership = memberships.get(changerId);
-
-        if (changerMembership == null) {
-            throw new ChannelMembershipNotFoundException();
-        }
-        if (changerMembership.cannotEditChannelName()) {
+        if (channelMembership.cannotEditChannelName()) {
             throw new ChannelOperationForbiddenException("채널 이름을 변경할 권한이 없습니다.");
         }
 
@@ -286,13 +304,13 @@ public class Channel {
         );
     }
 
-    public Channel changeChannelPolicy(UserId userId, ChannelPolicy channelPolicy) {
-        ChannelMembership channelMembership = memberships.get(userId);
+    public Channel changeChannelPolicy(UserId changerId, ChannelPolicy channelPolicy) {
+        ChannelMembership executorMembership = memberships.get(changerId);
 
-        if (channelMembership == null) {
+        if (executorMembership == null) {
             throw new ChannelMembershipNotFoundException();
         }
-        if (channelMembership.cannotChangeChannelPolicy()) {
+        if (executorMembership.cannotChangeChannelPolicy()) {
             throw new ChannelOperationForbiddenException("채널 정책을 변경할 권한이 없습니다.");
         }
 
@@ -306,12 +324,51 @@ public class Channel {
         );
     }
 
-    public boolean isPublic() {
-        return channelPolicy.isPublic();
+    public void validateDeleteChannel(UserId deleterId) {
+        ChannelMembership deleterMembership = memberships.get(deleterId);
+
+        if (deleterMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (deleterMembership.cannotDeleteChannel()) {
+            throw new ChannelOperationForbiddenException("채널을 삭제할 권한이 없습니다.");
+        }
     }
 
-    public boolean isPrivate() {
-        return !isPublic();
+    public void validateMemberEditMessage(UserId executorId, ChatMessage message) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotEditMessage()) {
+            throw new ChannelMembershipOperationForbiddenException("메시지를 수정할 권한이 없습니다.");
+        }
+        if (channelPolicy.cannotEditOwnMessage()) {
+            throw new ChannelOperationForbiddenException("자신의 메시지를 수정할 수 없습니다.");
+        }
+    }
+
+    public void validateMemberDeleteMessage(UserId executorId, ChatMessage message) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
+        if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotDeleteMessage()) {
+            throw new ChannelMembershipOperationForbiddenException("메시지를 삭제할 권한이 없습니다.");
+        }
+        if (channelPolicy.cannotDeleteOwnMessage()) {
+            throw new ChannelOperationForbiddenException("자신의 메시지를 삭제할 수 없습니다.");
+        }
+    }
+
+    public void validateMemberSendMessage(UserId senderId) {
+        ChannelMembership senderMembership = memberships.get(senderId);
+
+        if (senderMembership == null) {
+            throw new ChannelMembershipNotFoundException();
+        }
     }
 
     public static class ChannelMembershipNotFoundException extends IllegalArgumentException {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
@@ -148,6 +148,32 @@ public class ChannelMembership {
         );
     }
 
+    public ChannelMembership addPermission(ChannelPermissionType permission) {
+        validateRole(this.role);
+
+        return new ChannelMembership(
+                this.id,
+                this.channelId,
+                this.userId,
+                this.role,
+                this.permissions.add(permission),
+                this.joinedAt
+        );
+    }
+
+    public ChannelMembership removePermission(ChannelPermissionType permission) {
+        validateRole(this.role);
+
+        return new ChannelMembership(
+                this.id,
+                this.channelId,
+                this.userId,
+                this.role,
+                this.permissions.remove(permission),
+                this.joinedAt
+        );
+    }
+
     public boolean hasPermission(ChannelPermissionType permission) {
         if (this.role.isOwner()) {
             return true;
@@ -201,6 +227,18 @@ public class ChannelMembership {
         return false;
     }
 
+    public boolean canDeleteMessage() {
+        if (this.role.isOwner()) {
+            return true;
+        }
+
+        return this.role.isManager() && permissions.has(ChannelPermissionType.MESSAGE_DELETE);
+    }
+
+    public boolean cannotDeleteMessage() {
+        return !this.canDeleteMessage();
+    }
+
     public boolean canEditMessage(ChannelPolicy policy) {
         if (this.role.isOwner()) {
             return true;
@@ -213,6 +251,18 @@ public class ChannelMembership {
         }
 
         return false;
+    }
+
+    public boolean canEditMessage() {
+        if (this.role.isOwner()) {
+            return true;
+        }
+
+        return this.role.isManager() && permissions.has(ChannelPermissionType.MESSAGE_EDIT);
+    }
+
+    public boolean cannotEditMessage() {
+        return !canEditMessage();
     }
 
     public boolean canInviteMember() {
@@ -263,8 +313,16 @@ public class ChannelMembership {
         return this.role.isManager();
     }
 
+    public boolean isNotManager() {
+        return !this.isManager();
+    }
+
     public boolean isMember() {
         return this.role.isMember();
+    }
+
+    public boolean isNotMember() {
+        return !this.isMember();
     }
 
     public boolean isOwner() {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelMembership.java
@@ -159,6 +159,10 @@ public class ChannelMembership {
         return false;
     }
 
+    public boolean lacksPermission(ChannelPermissionType permission) {
+        return !this.hasPermission(permission);
+    }
+
     public boolean canEditChannelName() {
         if (this.role.isOwner()) {
             return true;
@@ -167,12 +171,20 @@ public class ChannelMembership {
         return this.role.isManager() && permissions.has(ChannelPermissionType.EDIT_CHANNEL_NAME);
     }
 
+    public boolean cannotEditChannelName() {
+        return !this.canEditChannelName();
+    }
+
     public boolean canKickMember() {
         if (this.role.isOwner()) {
             return true;
         }
 
         return this.role.isManager() && permissions.has(ChannelPermissionType.MEMBER_KICK);
+    }
+
+    public boolean cannotKickMember() {
+        return !this.canKickMember();
     }
 
     public boolean canDeleteMessage(ChannelPolicy policy) {
@@ -211,20 +223,40 @@ public class ChannelMembership {
         return this.role.isManager() && permissions.has(ChannelPermissionType.MEMBER_INVITE);
     }
 
-    public boolean canMemberRoleManagement() {
+    public boolean cannotInviteMember() {
+        return !this.canInviteMember();
+    }
+
+    public boolean canManageRole() {
         return this.role.isOwner();
     }
 
-    public boolean canPermissionManagement() {
+    public boolean cannotManageRole() {
+        return !this.canManageRole();
+    }
+
+    public boolean canManagePermission() {
         return this.role.isOwner();
+    }
+
+    public boolean cannotManagePermission() {
+        return !this.canManagePermission();
     }
 
     public boolean canDeleteChannel() {
         return this.role.isOwner();
     }
 
+    public boolean cannotDeleteChannel() {
+        return !this.canDeleteChannel();
+    }
+
     public boolean canChangeChannelPolicy() {
         return this.role.isOwner();
+    }
+
+    public boolean cannotChangeChannelPolicy() {
+        return !this.canChangeChannelPolicy();
     }
 
     public boolean isManager() {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissions.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelManagePermissions.java
@@ -1,7 +1,6 @@
 package com.tok.pekko.domain.channel.model.vo;
 
 import com.tok.pekko.domain.channel.model.ChannelPermissionType;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
@@ -62,7 +61,11 @@ public class ChannelManagePermissions {
     }
 
     public Set<ChannelPermissionType> getAll() {
-        return Collections.unmodifiableSet(EnumSet.copyOf(permissions));
+        if (permissions.isEmpty()) {
+            return EnumSet.noneOf(ChannelPermissionType.class);
+        }
+
+        return EnumSet.copyOf(permissions);
     }
 
     public int size() {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
@@ -21,4 +21,12 @@ public record ChannelPolicy(boolean canEditOwnMessage, boolean canDeleteOwnMessa
     public boolean isPrivate() {
         return !this.isPublic();
     }
+
+    public boolean cannotEditOwnMessage() {
+        return !this.canEditOwnMessage();
+    }
+
+    public boolean cannotDeleteOwnMessage() {
+        return !this.canDeleteOwnMessage();
+    }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/vo/ChannelPolicy.java
@@ -17,4 +17,8 @@ public record ChannelPolicy(boolean canEditOwnMessage, boolean canDeleteOwnMessa
     public ChannelPolicy updatePublic(boolean isPublic) {
         return new ChannelPolicy(this.canEditOwnMessage, this.canDeleteOwnMessage, isPublic);
     }
+
+    public boolean isPrivate() {
+        return !this.isPublic();
+    }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelDomainEvent.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelDomainEvent.java
@@ -1,0 +1,60 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import java.time.LocalDateTime;
+
+public interface ChannelDomainEvent {
+    
+    Long channelId();
+
+    Long eventId();
+    
+    LocalDateTime occurredAt();
+
+    // 채널 메타데이터 관련 도메인 이벤트
+    interface ChannelMetadataEvent extends ChannelDomainEvent { }
+
+    // 채널 정책 변경 도메인 이벤트
+    record ChannelPolicyChanged(Long channelId, Long eventId, LocalDateTime occurredAt, Channel channel) implements ChannelMetadataEvent { }
+
+    // 채널 이름 변경 도메인 이벤트
+    record ChannelNameEdited(Long channelId, Long eventId, LocalDateTime occurredAt, Channel channel) implements ChannelMetadataEvent { }
+
+    // 채널 참여자가 변경되는 도메인 이벤트
+    interface ChannelMembershipEvent extends ChannelDomainEvent { }
+
+    // 채널 참여 도메인 이벤트
+    record UserJoined(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 탈퇴 도메인 이벤트
+    record MemberLeft(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 초대 도메인 이벤트
+    record UserInvited(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 강퇴 도메인 이벤트
+    record MemberKicked(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 매니저 승격 도메인 이벤트
+    record PromotedToManager(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 멤버 강등 도메인 이벤트
+    record DemotedToMember(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 권한 추가 도메인 이벤트
+    record PermissionAdded(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership, ChannelPermissionType permissionType) implements ChannelMembershipEvent { }
+
+    // 권한 삭제 도메인 이벤트
+    record PermissionRemoved(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership, ChannelPermissionType permissionType) implements ChannelMembershipEvent { }
+
+    // 채팅 메시지 관련 도메인 이벤트
+    interface MessageEvent extends ChannelDomainEvent { }
+
+    // 메시지 수정 도메인 이벤트
+    record MessageEdited(Long channelId, Long eventId, LocalDateTime occurredAt, ChatMessage updatedMessage) implements MessageEvent { }
+
+    // 메시지 삭제 도메인 이벤트
+    record MessageDeleted(Long channelId, Long eventId, LocalDateTime occurredAt, Long deletedMessageId) implements MessageEvent { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
@@ -195,4 +195,8 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
 
     // 채팅 히스토리 동기화를 요청하는 메시지 : ChannelReaderActor -> ChannelEntity
     record RequestSyncMessages(ActorRef<ChannelReaderCommand> secondary) implements ChannelEntityCommand { }
+
+    // 이벤트 처리가 완료되었음을 전파받는 메시지 : ChannelEventHandlerEntity -> ChannelEntity
+    record DomainEventProcessed(Long eventId) implements ChannelEntityCommand { }
+
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
@@ -17,6 +17,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.actor.typed.pubsub.Topic.Command;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
 
 public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
@@ -41,7 +43,8 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
             Clock clock,
             Long channelId,
             ChatMessages messages,
-            MessageStoragePort messageStoragePort
+            MessageStoragePort messageStoragePort,
+            ActorRef<Command<InviteUserEventCommand>> inviteUserTopic
     ) {
         return Behaviors.setup(
                 context -> {
@@ -52,7 +55,8 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
                             clock,
                             channelId,
                             messages,
-                            messageStoragePort
+                            messageStoragePort,
+                            inviteUserTopic
                     );
                 }
         );
@@ -64,13 +68,15 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
     private final MessageStoragePort messageStoragePort;
     private final SnowflakeSequenceGenerator sequenceGenerator;
     private final Map<String, ActorRef<ChannelReaderCommand>> readers;
+    private final ActorRef<Command<InviteUserEventCommand>> inviteUserTopic;
 
     private ChannelEntity(
             ActorContext<ChannelEntityCommand> context,
             Clock clock,
             Long channelId,
             ChatMessages messages,
-            MessageStoragePort messageStoragePort
+            MessageStoragePort messageStoragePort,
+            ActorRef<Command<InviteUserEventCommand>> inviteUserTopic
     ) {
         super(context);
 
@@ -78,6 +84,7 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         this.channelId = channelId;
         this.messages = messages;
         this.messageStoragePort = messageStoragePort;
+        this.inviteUserTopic = inviteUserTopic;
         this.sequenceGenerator = new SnowflakeSequenceGenerator(channelId);
         this.readers = new HashMap<>();
     }
@@ -198,5 +205,4 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
 
     // 이벤트 처리가 완료되었음을 전파받는 메시지 : ChannelEventHandlerEntity -> ChannelEntity
     record DomainEventProcessed(Long eventId) implements ChannelEntityCommand { }
-
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
@@ -1,36 +1,92 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.DemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserJoined;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleDemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserJoined;
 import com.tok.pekko.domain.chat.actor.ChannelReaderActor.DeliverSyncMessages;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyChangeChannelMembership;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyChangeChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyEditChannelName;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyKickedMember;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyMemberLeft;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.AddPermission;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChangeChannelPolicy;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.DeleteMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.DemoteToMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.EditChannelName;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.InviteUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.JoinUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.JoinedUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.KickMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.LeaveMember;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.PromoteToManager;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RegisterReader;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemovePermission;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemoveShutdownReader;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.UpdateMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyFailure;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.Invited;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
 import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.actor.typed.pubsub.Topic;
 import org.apache.pekko.actor.typed.pubsub.Topic.Command;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
 
 public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
@@ -43,20 +99,35 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
             Clock clock,
             Long channelId,
             ChatMessages messages,
+            ClusterSharding clusterSharding,
             MessageStoragePort messageStoragePort,
-            ActorRef<Command<InviteUserEventCommand>> inviteUserTopic
+            ChannelActorStoragePort channelActorStoragePort,
+            ActorRef<Topic.Command<InviteUserEventCommand>> inviteUserTopic
     ) {
         return Behaviors.setup(
                 context -> {
                     messageStoragePort.findRecentMessages(channelId, DEFAULT_RECENT_MESSAGE_SIZE, context.getSelf());
+                    channelActorStoragePort.find(channelId, context.getSelf());
 
-                    return new ChannelEntity(
-                            context,
-                            clock,
-                            channelId,
-                            messages,
-                            messageStoragePort,
-                            inviteUserTopic
+                    EntityRef<ChannelEventHandlerCommand> channelEventHandler = clusterSharding.entityRefFor(
+                            ChannelEventHandlerEntity.ENTITY_TYPE_KEY,
+                            String.valueOf(channelId)
+                    );
+
+                    return Behaviors.withTimers(
+                            timer -> {
+                                timer.startTimerAtFixedRate(new DomainEventHeartBeat(), Duration.ofSeconds(120L));
+
+                                return new ChannelEntity(
+                                        context,
+                                        clock,
+                                        channelId,
+                                        messages,
+                                        messageStoragePort,
+                                        channelEventHandler,
+                                        inviteUserTopic
+                                );
+                            }
                     );
                 }
         );
@@ -65,10 +136,17 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
     private final Clock clock;
     private final Long channelId;
     private final ChatMessages messages;
+    private final ChannelHolder channelHolder;
+    private final Map<Long, EventHolder> events;
     private final MessageStoragePort messageStoragePort;
+    private final SnowflakeSequenceGenerator eventIdGenerator;
     private final SnowflakeSequenceGenerator sequenceGenerator;
+    private final List<ChannelEntityCommand> pendingChannelCommands;
     private final Map<String, ActorRef<ChannelReaderCommand>> readers;
+    private final EntityRef<ChannelEventHandlerCommand> channelEventHandler;
     private final ActorRef<Command<InviteUserEventCommand>> inviteUserTopic;
+    private final Map<String, ActorRef<ChannelReaderCommand>> pendingInitialSyncReaders;
+    private boolean initialMessagesLoaded;
 
     private ChannelEntity(
             ActorContext<ChannelEntityCommand> context,
@@ -76,6 +154,7 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
             Long channelId,
             ChatMessages messages,
             MessageStoragePort messageStoragePort,
+            EntityRef<ChannelEventHandlerCommand> channelEventHandler,
             ActorRef<Command<InviteUserEventCommand>> inviteUserTopic
     ) {
         super(context);
@@ -85,8 +164,15 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         this.messages = messages;
         this.messageStoragePort = messageStoragePort;
         this.inviteUserTopic = inviteUserTopic;
-        this.sequenceGenerator = new SnowflakeSequenceGenerator(channelId);
+        this.channelEventHandler = channelEventHandler;
+        this.events = new HashMap<>();
         this.readers = new HashMap<>();
+        this.channelHolder = new ChannelHolder();
+        this.pendingChannelCommands = new ArrayList<>();
+        this.pendingInitialSyncReaders = new HashMap<>();
+        this.eventIdGenerator = new SnowflakeSequenceGenerator(channelId);
+        this.sequenceGenerator = new SnowflakeSequenceGenerator(channelId);
+        this.initialMessagesLoaded = false;
     }
 
     @Override
@@ -102,11 +188,33 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
                                   .onMessage(RemoveShutdownReader.class, this::onRemoveShutdownReader)
                                   .onMessage(RequestSyncMessages.class, this::onRequestSyncMessages)
                                   .onMessage(ResolveHistory.class, this::onResolveHistory)
+                                  .onMessage(ChangeChannelPolicy.class, this::onChangeChannelPolicy)
+                                  .onMessage(EditChannelName.class, this::onEditChannelName)
+                                  .onMessage(JoinUser.class, this::onJoinUser)
+                                  .onMessage(LeaveMember.class, this::onLeaveMember)
+                                  .onMessage(InviteUser.class, this::onInviteUser)
+                                  .onMessage(PromoteToManager.class, this::onPromoteToManager)
+                                  .onMessage(DemoteToMember.class, this::onDemoteToMember)
+                                  .onMessage(AddPermission.class, this::onAddPermission)
+                                  .onMessage(RemovePermission.class, this::onRemovePermission)
+                                  .onMessage(KickMember.class, this::onKickMember)
+                                  .onMessage(ResolveMembership.class, this::onResolveMembership)
+                                  .onMessage(DomainEventHeartBeat.class, this::onDomainEventHeartBeat)
+                                  .onMessage(DomainEventProcessed.class, this::onDomainEventProcessed)
+                                  .onMessage(ResolveChannelMetadata.class, this::onResolveChannelMetadata)
+                                  .onMessage(SyncChannel.class, this::onSyncChannel)
                                   .build();
     }
 
     private Behavior<ChannelEntityCommand> onSyncRecentMessages(SyncRecentMessages command) {
         this.messages.syncMessages(command.messages());
+
+        if (!initialMessagesLoaded) {
+            pendingInitialSyncReaders.values()
+                                     .forEach(reader -> reader.tell(new DeliverSyncMessages(command.messages())));
+            initialMessagesLoaded = true;
+            pendingInitialSyncReaders.clear();
+        }
 
         return this;
     }
@@ -132,13 +240,13 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
     }
 
     private Behavior<ChannelEntityCommand> onSyncUpdatedMessage(SyncUpdatedMessage command) {
-        LocalDateTime updatedTimestamp = LocalDateTime.now(clock);
+        LocalDateTime now = LocalDateTime.now(clock);
 
-        messages.update(command.messageId(), command.updatedMessage(), updatedTimestamp);
+        messages.update(command.messageId(), command.updatedMessage(), now);
         readers.values()
                 .forEach(
                         reader -> reader.tell(
-                                new SyncUpdate(command.messageId(),command.updatedMessage(), updatedTimestamp)
+                                new SyncUpdate(command.messageId(), command.updatedMessage(), now)
                         )
                 );
         return this;
@@ -173,6 +281,11 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
     }
 
     private Behavior<ChannelEntityCommand> onRequestSyncMessages(RequestSyncMessages command) {
+        if (!initialMessagesLoaded) {
+            pendingInitialSyncReaders.put(command.secondary().path().name(), command.secondary());
+            return this;
+        }
+
         command.secondary()
                .tell(new DeliverSyncMessages(messages.getMessages()));
 
@@ -187,17 +300,518 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         return this;
     }
 
+    private Behavior<ChannelEntityCommand> onChangeChannelPolicy(ChangeChannelPolicy command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelPolicy changedPolicy = new ChannelPolicy(
+                    command.canEditOwnMessage(),
+                    command.canDeleteOwnMessage(),
+                    command.isPublic()
+            );
+
+            this.channelHolder.channel = this.channelHolder.channel.changeChannelPolicy(
+                    command.changerId(),
+                    changedPolicy
+            );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.changerId().getValue(), ex.getMessage());
+        }
+
+        Long eventId = eventIdGenerator.nextSequence();
+        ChannelPolicyChanged channelPolicyChangedEvent = new ChannelPolicyChanged(
+                channelId,
+                eventId,
+                LocalDateTime.now(clock),
+                this.channelHolder.channel
+        );
+        EventHolder eventHolder = new EventHolder(
+                channelPolicyChangedEvent,
+                event -> channelEventHandler.tell(new HandleChannelPolicyChanged(event))
+        );
+
+        events.put(eventId, eventHolder);
+        channelEventHandler.tell(new HandleChannelPolicyChanged(channelPolicyChangedEvent));
+        readers.values()
+               .forEach(reader ->
+                       reader.tell(
+                               new NotifyChangeChannelPolicy(this.channelHolder.channel.getChannelPolicy()
+                               )
+                       )
+               );
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onEditChannelName(EditChannelName command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            this.channelHolder.channel = this.channelHolder.channel.editName(
+                    command.changerId(),
+                    command.changedName()
+            );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.changerId().getValue(), ex.getMessage());
+        }
+
+        Long eventId = eventIdGenerator.nextSequence();
+        ChannelNameEdited channelNameEditedEvent = new ChannelNameEdited(
+                channelId,
+                eventId,
+                LocalDateTime.now(clock),
+                this.channelHolder.channel
+        );
+        EventHolder eventHolder = new EventHolder(
+                channelNameEditedEvent,
+                event -> channelEventHandler.tell(new HandleChannelNameEdited(event))
+        );
+
+        events.put(eventId, eventHolder);
+        channelEventHandler.tell(new HandleChannelNameEdited(channelNameEditedEvent));
+        readers.values()
+               .forEach(reader -> reader.tell(new NotifyEditChannelName(this.channelHolder.channel.getName())));
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onJoinUser(JoinUser command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        try {
+            ChannelMembership joinerMembership = this.channelHolder.channel.joinUser(
+                    command.joinerId(),
+                    ChannelRole.MEMBER,
+                    now
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            UserJoined userJoinedEvent = new UserJoined(channelId, eventId, now, joinerMembership);
+            EventHolder eventHolder = new EventHolder(
+                    userJoinedEvent,
+                    event -> channelEventHandler.tell(new HandleUserJoined(userJoinedEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleUserJoined(userJoinedEvent));
+            command.replyTo()
+                   .tell(new JoinedUser(channelId, command.joinerId().getValue()));
+            broadcastMembershipCount();
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.joinerId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onLeaveMember(LeaveMember command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership leaveMembership = this.channelHolder.channel.leaveMember(command.memberId());
+
+            Long eventId = eventIdGenerator.nextSequence();
+            MemberLeft memberLeftEvent = new MemberLeft(channelId, eventId, LocalDateTime.now(clock), leaveMembership);
+            EventHolder eventHolder = new EventHolder(
+                    memberLeftEvent,
+                    event -> channelEventHandler.tell(new HandleMemberLeft(memberLeftEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleMemberLeft(memberLeftEvent));
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.memberId().getValue(), ex.getMessage());
+        }
+
+        readers.values()
+               .forEach(reader -> reader.tell(new NotifyMemberLeft(command.memberId().getValue())));
+        broadcastMembershipCount();
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onInviteUser(InviteUser command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        try {
+            ChannelMembership inviteeMembership = this.channelHolder.channel.inviteMember(
+                    command.inviterId(),
+                    command.inviteeId(),
+                    now
+            );
+
+            Long eventId = eventIdGenerator.nextSequence();
+            UserInvited userInvitedEvent = new UserInvited(channelId, eventId, now, inviteeMembership);
+            EventHolder eventHolder = new EventHolder(
+                    userInvitedEvent,
+                    event -> channelEventHandler.tell(new HandleUserInvited(userInvitedEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleUserInvited(userInvitedEvent));
+            inviteUserTopic.tell(Topic.publish(new Invited(channelId, command.inviteeId().getValue())));
+            broadcastMembershipCount();
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.inviterId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onPromoteToManager(PromoteToManager command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership managerMembership = this.channelHolder.channel.promoteToManager(
+                    command.executorId(),
+                    command.targetUserId()
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            PromotedToManager promotedToManagerEvent = new PromotedToManager(
+                    channelId,
+                    eventId,
+                    LocalDateTime.now(clock),
+                    managerMembership
+            );
+            EventHolder eventHolder = new EventHolder(
+                    promotedToManagerEvent,
+                    event -> channelEventHandler.tell(new HandlePromotedToManager(promotedToManagerEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandlePromotedToManager(promotedToManagerEvent));
+            readers.values()
+                   .forEach(
+                           reader ->
+                                   reader.tell(
+                                           new NotifyChangeChannelMembership(
+                                                   command.targetUserId().getValue(),
+                                                   managerMembership,
+                                                   currentMembershipCount()
+                                           )
+                                   )
+                   );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.executorId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onDemoteToMember(DemoteToMember command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership memberMembership = this.channelHolder.channel.demoteToMember(
+                    command.executorId(),
+                    command.targetUserId()
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            DemotedToMember demotedToMemberEvent = new DemotedToMember(
+                    channelId,
+                    eventId,
+                    LocalDateTime.now(clock),
+                    memberMembership
+            );
+            EventHolder eventHolder = new EventHolder(
+                    demotedToMemberEvent,
+                    event -> channelEventHandler.tell(new HandleDemotedToMember(demotedToMemberEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleDemotedToMember(demotedToMemberEvent));
+            readers.values()
+                   .forEach(
+                           reader ->
+                                   reader.tell(
+                                           new NotifyChangeChannelMembership(
+                                                   command.targetUserId().getValue(),
+                                                   memberMembership,
+                                                   currentMembershipCount()
+                                           )
+                                   )
+                   );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.executorId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onAddPermission(AddPermission command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership addedPermissionMembership = this.channelHolder.channel.addPermission(
+                    command.grantorId(),
+                    command.granteeId(),
+                    command.permission()
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            PermissionAdded permissionAddedEvent = new PermissionAdded(
+                    channelId,
+                    eventId,
+                    LocalDateTime.now(clock),
+                    addedPermissionMembership,
+                    command.permission()
+            );
+            EventHolder eventHolder = new EventHolder(
+                    permissionAddedEvent,
+                    event -> channelEventHandler.tell(new HandlePermissionAdded(permissionAddedEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandlePermissionAdded(permissionAddedEvent));
+            readers.values()
+                   .forEach(
+                           reader ->
+                                   reader.tell(
+                                           new NotifyChangeChannelMembership(
+                                                   command.granteeId().getValue(),
+                                                   addedPermissionMembership,
+                                                   currentMembershipCount()
+                                           )
+                                   )
+                   );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.grantorId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onRemovePermission(RemovePermission command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership removedPermissionMembership = this.channelHolder.channel.removePermission(
+                    command.grantorId(),
+                    command.granteeId(),
+                    command.permission()
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            PermissionRemoved permissionRemovedEvent = new PermissionRemoved(
+                    channelId,
+                    eventId,
+                    LocalDateTime.now(clock),
+                    removedPermissionMembership,
+                    command.permission()
+            );
+            EventHolder eventHolder = new EventHolder(
+                    permissionRemovedEvent,
+                    event -> channelEventHandler.tell(new HandlePermissionRemoved(event))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandlePermissionRemoved(permissionRemovedEvent));
+            readers.values()
+                   .forEach(
+                           reader ->
+                                   reader.tell(
+                                           new NotifyChangeChannelMembership(
+                                                   command.granteeId().getValue(),
+                                                   removedPermissionMembership,
+                                                   currentMembershipCount()
+                                           )
+                                   )
+                   );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.grantorId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onKickMember(KickMember command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            ChannelMembership kickedMembership = this.channelHolder.channel.kickMember(
+                    command.executorId(),
+                    command.targetUserId()
+            );
+            Long eventId = eventIdGenerator.nextSequence();
+            MemberKicked memberKickedEvent = new MemberKicked(
+                    channelId,
+                    eventId,
+                    LocalDateTime.now(clock),
+                    kickedMembership
+            );
+            EventHolder eventHolder = new EventHolder(
+                    memberKickedEvent,
+                    event -> channelEventHandler.tell(new HandleMemberKicked(memberKickedEvent))
+            );
+
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleMemberKicked(memberKickedEvent));
+            readers.values()
+                   .forEach(reader -> reader.tell(new NotifyKickedMember(command.targetUserId().getValue())));
+            broadcastMembershipCount();
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.executorId().getValue(), ex.getMessage());
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onResolveMembership(ResolveMembership command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        ChannelMembership membership = this.channelHolder.channel.getMemberships()
+                                                                 .get(command.userId());
+        if (membership != null) {
+            command.replyTo()
+                   .tell(
+                           new SyncMembership(
+                                   command.userId().getValue(),
+                                   membership,
+                                   currentMembershipCount()
+                           )
+                   );
+        }
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onDomainEventHeartBeat(DomainEventHeartBeat command) {
+        events.values()
+              .forEach(EventHolder::execute);
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onDomainEventProcessed(DomainEventProcessed command) {
+        events.remove(command.eventId());
+
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onResolveChannelMetadata(ResolveChannelMetadata command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        command.replyTo()
+               .tell(
+                       new SyncChannelMetadata(
+                               this.channelHolder.channel.getChannelId().getValue(),
+                               this.channelHolder.channel.getName(),
+                               this.channelHolder.channel.getChannelPolicy(),
+                               this.channelHolder.channel.getMemberships().size()
+                       )
+               );
+        return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onSyncChannel(SyncChannel command) {
+        this.channelHolder.channel = command.channel();
+        processPendingChannelCommands();
+
+        return this;
+    }
+
     private ChatMessage createChatMessage(SendMessage command) {
         long messageSequence = sequenceGenerator.nextSequence();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         return ChatMessage.create(
                 channelId,
                 command.userId(),
                 messageSequence,
                 command.message(),
-                LocalDateTime.now(clock),
-                LocalDateTime.now(clock)
+                now,
+                now
         );
+    }
+
+    private void broadcastMembershipCount() {
+        int membershipCount = currentMembershipCount();
+
+        readers.values()
+               .forEach(reader -> reader.tell(new NotifyMembershipCountChanged(membershipCount)));
+    }
+
+    private int currentMembershipCount() {
+        if (this.channelHolder.channel == null) {
+            return 0;
+        }
+
+        return this.channelHolder.channel.getMemberships().size();
+    }
+
+    private boolean deferUntilChannelSynced(ChannelEntityCommand command) {
+        if (this.channelHolder.channel != null) {
+            return false;
+        }
+
+        pendingChannelCommands.add(command);
+        return true;
+    }
+
+    private void processPendingChannelCommands() {
+        if (pendingChannelCommands.isEmpty()) {
+            return;
+        }
+
+        List<ChannelEntityCommand> pending = new ArrayList<>(pendingChannelCommands);
+
+        pendingChannelCommands.clear();
+        pending.forEach(command -> getContext().getSelf().tell(command));
+    }
+
+    private void notifyFailure(Long userId, String reason) {
+        readers.values()
+               .forEach(
+                       reader -> reader.tell(
+                               new NotifyFailure(userId, reason)
+                       )
+               );
+    }
+
+    private static class ChannelHolder {
+
+        private Channel channel;
+
+        private ChannelHolder() {
+            this.channel = null;
+        }
+    }
+
+    private static class EventHolder {
+
+        private final ChannelDomainEvent event;
+        private final Consumer<ChannelDomainEvent> handler;
+
+        @SuppressWarnings("unchecked")
+        private <T extends ChannelDomainEvent> EventHolder(T event, Consumer<T> handler) {
+            this.event = event;
+            this.handler = (Consumer<ChannelDomainEvent>) handler;
+        }
+
+        private void execute() {
+            handler.accept(event);
+        }
     }
 
     // 채팅 히스토리 동기화를 요청하는 메시지 : ChannelReaderActor -> ChannelEntity
@@ -205,4 +819,7 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
 
     // 이벤트 처리가 완료되었음을 전파받는 메시지 : ChannelEventHandlerEntity -> ChannelEntity
     record DomainEventProcessed(Long eventId) implements ChannelEntityCommand { }
+
+    // 아직 처리되지 않은 이벤트에 대한 처리를 진행하기 위한 메시지 : ChannelEntity -> ChannelEntity
+    private record DomainEventHeartBeat() implements ChannelEntityCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
@@ -9,6 +9,8 @@ import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelPolicyChanged;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.DemotedToMember;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberKicked;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageEdited;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionAdded;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionRemoved;
 import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PromotedToManager;
@@ -19,6 +21,8 @@ import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelPo
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleDemotedToMember;
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberKicked;
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageEdited;
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionAdded;
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionRemoved;
 import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePromotedToManager;
@@ -49,11 +53,11 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncStoredMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.UpdateMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyFailure;
@@ -69,6 +73,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
 import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.Invited;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -183,8 +188,6 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
                                   .onMessage(UpdateMessage.class, this::onUpdateMessage)
                                   .onMessage(DeleteMessage.class, this::onDeleteMessage)
                                   .onMessage(SyncPersistedMessage.class, this::onSyncPersistedMessage)
-                                  .onMessage(SyncUpdatedMessage.class, this::onSyncUpdatedMessage)
-                                  .onMessage(SyncDeletedMessage.class, this::onSyncDeletedMessage)
                                   .onMessage(RemoveShutdownReader.class, this::onRemoveShutdownReader)
                                   .onMessage(RequestSyncMessages.class, this::onRequestSyncMessages)
                                   .onMessage(ResolveHistory.class, this::onResolveHistory)
@@ -203,6 +206,8 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
                                   .onMessage(DomainEventProcessed.class, this::onDomainEventProcessed)
                                   .onMessage(ResolveChannelMetadata.class, this::onResolveChannelMetadata)
                                   .onMessage(SyncChannel.class, this::onSyncChannel)
+                                  .onMessage(SyncStoredMembership.class, this::onSyncStoredMembership)
+                                  .onMessage(Shutdown.class, this::onShutdown)
                                   .build();
     }
 
@@ -210,8 +215,7 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         this.messages.syncMessages(command.messages());
 
         if (!initialMessagesLoaded) {
-            pendingInitialSyncReaders.values()
-                                     .forEach(reader -> reader.tell(new DeliverSyncMessages(command.messages())));
+            broadcastSyncMessages(command.messages());
             initialMessagesLoaded = true;
             pendingInitialSyncReaders.clear();
         }
@@ -226,42 +230,92 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
     }
 
     private Behavior<ChannelEntityCommand> onSendMessage(SendMessage command) {
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+
+        try {
+            this.channelHolder.channel.validateMemberSendMessage(UserId.create(command.userId()));
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.userId(), ex.getMessage());
+            return this;
+        }
+
         ChatMessage message = createChatMessage(command);
 
         messageStoragePort.store(message, getContext().getSelf());
-
         return this;
     }
 
     private Behavior<ChannelEntityCommand> onUpdateMessage(UpdateMessage command) {
-        messageStoragePort.update(command.messageId(), command.updatedMessage(), getContext().getSelf());
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+        try {
+            LocalDateTime now = LocalDateTime.now(clock);
+            ChatMessage updatedMessage = messages.update(
+                    this.channelHolder.channel,
+                    command.executorId(),
+                    command.messageId(),
+                    command.updatedMessage(),
+                    now
+            );
 
-        return this;
-    }
+            Long eventId = eventIdGenerator.nextSequence();
+            MessageEdited messageEditedEvent = new MessageEdited(
+                    channelId,
+                    eventId,
+                    now,
+                    updatedMessage
+            );
+            EventHolder eventHolder = new EventHolder(
+                    messageEditedEvent,
+                    event -> channelEventHandler.tell(new HandleMessageEdited(event))
+            );
 
-    private Behavior<ChannelEntityCommand> onSyncUpdatedMessage(SyncUpdatedMessage command) {
-        LocalDateTime now = LocalDateTime.now(clock);
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleMessageEdited(messageEditedEvent));
+            readers.values()
+                   .forEach(
+                           reader -> reader.tell(
+                                   new SyncUpdate(command.messageId(), command.updatedMessage(), now)
+                           )
+                   );
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.executorId(), ex.getMessage());
+        }
 
-        messages.update(command.messageId(), command.updatedMessage(), now);
-        readers.values()
-                .forEach(
-                        reader -> reader.tell(
-                                new SyncUpdate(command.messageId(), command.updatedMessage(), now)
-                        )
-                );
         return this;
     }
 
     private Behavior<ChannelEntityCommand> onDeleteMessage(DeleteMessage command) {
-        messageStoragePort.delete(command.messageId(), getContext().getSelf());
+        if (deferUntilChannelSynced(command)) {
+            return this;
+        }
+        try {
+            ChatMessage deletedMessage = messages.delete(
+                    this.channelHolder.channel,
+                    command.executorId(),
+                    command.messageId()
+            );
 
-        return this;
-    }
+            Long eventId = eventIdGenerator.nextSequence();
+            MessageDeleted messageDeletedEvent = new MessageDeleted(
+                    channelId, eventId, LocalDateTime.now(clock),
+                    deletedMessage.messageId()
+            );
+            EventHolder eventHolder = new EventHolder(
+                    messageDeletedEvent,
+                    event -> channelEventHandler.tell(new HandleMessageDeleted(event))
+            );
 
-    private Behavior<ChannelEntityCommand> onSyncDeletedMessage(SyncDeletedMessage command) {
-        messages.delete(command.messageId());
-        readers.values()
-               .forEach(reader -> reader.tell(new SyncDeletion(command.messageId())));
+            events.put(eventId, eventHolder);
+            channelEventHandler.tell(new HandleMessageDeleted(messageDeletedEvent));
+            readers.values()
+                   .forEach(reader -> reader.tell(new SyncDeletion(command.messageId())));
+        } catch (IllegalArgumentException ex) {
+            notifyFailure(command.executorId().getValue(), ex.getMessage());
+        }
 
         return this;
     }
@@ -426,6 +480,7 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
 
             events.put(eventId, eventHolder);
             channelEventHandler.tell(new HandleMemberLeft(memberLeftEvent));
+            broadcastMembershipCount();
         } catch (IllegalArgumentException ex) {
             notifyFailure(command.memberId().getValue(), ex.getMessage());
         }
@@ -674,6 +729,16 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         return this;
     }
 
+    private Behavior<ChannelEntityCommand> onSyncStoredMembership(SyncStoredMembership command) {
+        if (this.channelHolder.channel == null) {
+            deferUntilChannelSynced(command);
+            return this;
+        }
+
+        this.channelHolder.channel.syncMembership(command.channelMembership());
+        return this;
+    }
+
     private Behavior<ChannelEntityCommand> onResolveMembership(ResolveMembership command) {
         if (deferUntilChannelSynced(command)) {
             return this;
@@ -729,6 +794,10 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
         processPendingChannelCommands();
 
         return this;
+    }
+
+    private Behavior<ChannelEntityCommand> onShutdown(Shutdown command) {
+        return Behaviors.stopped();
     }
 
     private ChatMessage createChatMessage(SendMessage command) {
@@ -787,6 +856,11 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
                                new NotifyFailure(userId, reason)
                        )
                );
+    }
+
+    private void broadcastSyncMessages(List<ChatMessage> syncedMessages) {
+        pendingInitialSyncReaders.values()
+                                 .forEach(reader -> reader.tell(new DeliverSyncMessages(syncedMessages)));
     }
 
     private static class ChannelHolder {

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntity.java
@@ -1,0 +1,359 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.DemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageEdited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserJoined;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.DomainEventProcessed;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
+import org.apache.pekko.actor.typed.javadsl.ActorContext;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
+
+public class ChannelEventHandlerEntity extends AbstractBehavior<ChannelEventHandlerCommand> {
+
+    public static final EntityTypeKey<ChannelEventHandlerCommand> ENTITY_TYPE_KEY =
+            EntityTypeKey.create(ChannelEventHandlerCommand.class, "ChannelEventHandler");
+
+    public static Behavior<ChannelEventHandlerCommand> create(
+            ClusterSharding clusterSharding,
+            Long channelId,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
+    ) {
+        return Behaviors.setup(
+                context -> {
+                    EntityRef<ChannelEntityCommand> channelEntity = clusterSharding.entityRefFor(
+                            ChannelEntity.ENTITY_TYPE_KEY,
+                            String.valueOf(channelId)
+                    );
+
+                    return new ChannelEventHandlerEntity(
+                            context,
+                            channelEntity,
+                            messageStoragePort,
+                            channelActorStoragePort,
+                            channelMembershipActorStoragePort
+                    );
+                }
+
+        );
+    }
+
+    private final Map<Long, EventHolder> events;
+    private final EntityRef<ChannelEntityCommand> channelEntity;
+    private final MessageStoragePort messageStoragePort;
+    private final ChannelActorStoragePort channelActorStoragePort;
+    private final ChannelMembershipActorStoragePort channelMembershipActorStoragePort;
+
+    private ChannelEventHandlerEntity(
+            ActorContext<ChannelEventHandlerCommand> context,
+            EntityRef<ChannelEntityCommand> channelEntity,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
+    ) {
+        super(context);
+        this.events = new HashMap<>();
+        this.channelEntity = channelEntity;
+        this.messageStoragePort = messageStoragePort;
+        this.channelActorStoragePort = channelActorStoragePort;
+        this.channelMembershipActorStoragePort = channelMembershipActorStoragePort;
+    }
+
+    @Override
+    public Receive<ChannelEventHandlerCommand> createReceive() {
+        return newReceiveBuilder().onMessage(HandleChannelPolicyChanged.class, this::onHandleChannelPolicyChanged)
+                                  .onMessage(HandleChannelNameEdited.class, this::onHandleChannelNameChanged)
+                                  .onMessage(HandleUserJoined.class, this::onHandleUserJoined)
+                                  .onMessage(HandleMemberLeft.class, this::onHandleMemberLeft)
+                                  .onMessage(HandleUserInvited.class, this::onHandleUserInvited)
+                                  .onMessage(HandlePromotedToManager.class, this::onHandlePromotedToManager)
+                                  .onMessage(HandleDemotedToMember.class, this::onHandleDemotedToMember)
+                                  .onMessage(HandlePermissionAdded.class, this::onHandlePermissionAdded)
+                                  .onMessage(HandlePermissionRemoved.class, this::onHandlePermissionRemoved)
+                                  .onMessage(HandleMemberKicked.class, this::onHandleMemberKicked)
+                                  .onMessage(HandleMessageEdited.class, this::onHandleMessageEdited)
+                                  .onMessage(EventSucceeded.class, this::onEventSucceeded)
+                                  .onMessage(EventFailed.class, this::onEventFailed)
+                                  .onMessage(NotifyStoredMembership.class, this::onNotifyMembershipStored)
+                                  .onMessage(HandleMessageDeleted.class, this::onHandleMessageDeleted)
+                                  .onMessage(Shutdown.class, this::onShutdown)
+                                  .build();
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleChannelPolicyChanged(HandleChannelPolicyChanged command) {
+        ChannelPolicyChanged event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelActorStoragePort.update(event.channel(), event.eventId(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleChannelNameChanged(HandleChannelNameEdited command) {
+        ChannelNameEdited event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelActorStoragePort.update(event.channel(), event.eventId(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleUserJoined(HandleUserJoined command) {
+        UserJoined event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.join(
+                event.eventId(),
+                event.channelMembership().getChannelId(),
+                event.channelMembership(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMemberLeft(HandleMemberLeft command) {
+        MemberLeft event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.leave(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleUserInvited(HandleUserInvited command) {
+        UserInvited event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.inviteUser(
+                event.eventId(),
+                event.channelMembership().getChannelId(),
+                event.channelMembership(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePromotedToManager(HandlePromotedToManager command) {
+        PromotedToManager event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.promoteToManager(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleDemotedToMember(HandleDemotedToMember command) {
+        DemotedToMember event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.demoteToMember(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePermissionAdded(HandlePermissionAdded command) {
+        PermissionAdded event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.addPermission(
+                event.eventId(),
+                event.channelMembership(),
+                event.permissionType(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePermissionRemoved(HandlePermissionRemoved command) {
+        PermissionRemoved event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.removePermission(
+                event.eventId(),
+                event.channelMembership(),
+                event.permissionType(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMemberKicked(HandleMemberKicked command) {
+        MemberKicked event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.kickMember(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMessageEdited(HandleMessageEdited command) {
+        MessageEdited event = command.event;
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        messageStoragePort.update(event.eventId(), event.updatedMessage(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMessageDeleted(HandleMessageDeleted command) {
+        MessageDeleted event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        messageStoragePort.delete(event.eventId(), event.deletedMessageId(), getContext().getSelf());
+        return this;
+    }
+    
+    private Behavior<ChannelEventHandlerCommand> onEventSucceeded(EventSucceeded command) {
+        EventHolder eventHolder = events.get(command.eventId());
+        
+        if (eventHolder == null) {
+            return this;
+        }
+
+        eventHolder.eventStatus = EventStatus.SUCCEEDED;
+        channelEntity.tell(new DomainEventProcessed(command.eventId()));
+        return this;
+    }
+    
+    private Behavior<ChannelEventHandlerCommand> onEventFailed(EventFailed command) {
+        EventHolder eventHolder = events.get(command.eventId());
+
+        if (eventHolder == null) {
+            return this;
+        }
+
+        eventHolder.eventStatus = EventStatus.FAILED;
+        eventHolder.throwable = command.throwable();
+        channelEntity.tell(new DomainEventProcessed(command.eventId()));
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onNotifyMembershipStored(NotifyStoredMembership command) {
+        channelEntity.tell(new SyncStoredMembership(command.channelMembership()));
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onShutdown(Shutdown command) {
+        return Behaviors.stopped();
+    }
+
+    private static class EventHolder {
+
+        private final ChannelDomainEvent event;
+        private EventStatus eventStatus;
+        private Throwable throwable = null;
+
+        public EventHolder(ChannelDomainEvent event) {
+            this.event = event;
+            this.eventStatus = EventStatus.PENDING;
+        }
+    }
+
+    private enum EventStatus {
+        PENDING, SUCCEEDED, FAILED
+    }
+
+    // 채널 정책 변경 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleChannelPolicyChanged(ChannelPolicyChanged event) implements ChannelEventHandlerCommand { }
+
+    // 채널 이름 변경 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleChannelNameEdited(ChannelNameEdited event) implements ChannelEventHandlerCommand { }
+
+    // 채널 참여 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleUserJoined(UserJoined event) implements ChannelEventHandlerCommand { }
+
+    // 채널 탈퇴 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMemberLeft(MemberLeft event) implements ChannelEventHandlerCommand { }
+
+    // 채널 초대 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleUserInvited(UserInvited event) implements ChannelEventHandlerCommand { }
+
+    // 매니저 승격 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePromotedToManager(PromotedToManager event) implements ChannelEventHandlerCommand { }
+
+    // 멤버 강등 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleDemotedToMember(DemotedToMember event) implements ChannelEventHandlerCommand { }
+
+    // 권한 추가 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePermissionAdded(PermissionAdded event) implements ChannelEventHandlerCommand { }
+
+    // 권한 삭제 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePermissionRemoved(PermissionRemoved event) implements ChannelEventHandlerCommand { }
+
+    // 멤버 강퇴 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMemberKicked(MemberKicked event) implements ChannelEventHandlerCommand { }
+
+    // 채팅 메시지 변경 도메인 이벤트 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMessageEdited(MessageEdited event) implements ChannelEventHandlerCommand { }
+
+    // 채팅 메시지 삭제 도메인 이벤트 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMessageDeleted(MessageDeleted event) implements ChannelEventHandlerCommand { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -51,7 +51,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     public static Behavior<ChannelReaderCommand> create(
             Long channelId,
-            ChatMessages messages,
+            ChannelReaderMessages messages,
             EntityRef<ChannelEntityCommand> channelEntity,
             ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
@@ -81,7 +81,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     }
 
     private final Long channelId;
-    private final ChatMessages messages;
+    private final ChannelReaderMessages messages;
     private final EntityRef<ChannelEntityCommand> channelEntity;
     private final Map<Long, ActorRef<ClientSessionCommand>> clientSessions;
     private final List<RequestInitialHistory> requestInitialHistories;
@@ -91,7 +91,7 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
     private ChannelReaderActor(
             ActorContext<ChannelReaderCommand> context,
             Long channelId,
-            ChatMessages messages,
+            ChannelReaderMessages messages,
             EntityRef<ChannelEntityCommand> channelEntity
     ) {
         super(context);

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -4,7 +4,9 @@ import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyFailure;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
@@ -32,6 +34,7 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditCha
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -195,6 +198,9 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         clientSessions.put(command.userId(), command.clientSession());
         getContext().watch(command.clientSession());
 
+        channelEntity.tell(new ResolveMembership(UserId.create(command.userId()), getContext().getSelf()));
+        channelEntity.tell(new ResolveChannelMetadata(getContext().getSelf()));
+
         return this;
     }
 
@@ -276,7 +282,14 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     private Behavior<ChannelReaderCommand> onNotifyEditChannelName(NotifyEditChannelName command) {
         clientSessions.values()
-                      .forEach(clientSession -> clientSession.tell(new PropagateEditChannelName(channelId, command.editedName())));
+                      .forEach(
+                              clientSession -> clientSession.tell(
+                                      new PropagateEditChannelName(
+                                              channelId,
+                                              command.editedName()
+                                      )
+                              )
+                      );
 
         return this;
     }
@@ -285,7 +298,13 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.memberId());
 
         if (clientSession != null) {
-            clientSession.tell(new PropagateChangeChannelMembership(channelId, command.channelMembership(), command.membershipCount()));
+            clientSession.tell(
+                    new PropagateChangeChannelMembership(
+                            channelId,
+                            command.channelMembership(),
+                            command.membershipCount()
+                    )
+            );
         }
 
         return this;
@@ -293,15 +312,30 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     private Behavior<ChannelReaderCommand> onNotifyMembershipCountChanged(NotifyMembershipCountChanged command) {
         clientSessions.values()
-                      .forEach(session -> session.tell(new PropagateMembershipCount(channelId, command.membershipCount())));
+                      .forEach(
+                              session -> session.tell(
+                                      new PropagateMembershipCount(
+                                              channelId,
+                                              command.membershipCount()
+                                      )
+                              )
+                      );
         return this;
     }
 
     private Behavior<ChannelReaderCommand> onSyncMembership(SyncMembership command) {
         ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.userId());
+
         if (clientSession != null) {
-            clientSession.tell(new PropagateChangeChannelMembership(channelId, command.membership(), command.membershipCount()));
+            clientSession.tell(
+                    new PropagateChangeChannelMembership(
+                            channelId,
+                            command.membership(),
+                            command.membershipCount()
+                    )
+            );
         }
+
         return this;
     }
 

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderActor.java
@@ -1,24 +1,37 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyFailure;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.SpawnedChannelReaderActor;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,6 +116,15 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
                                   .onMessage(RegisterClientSession.class, this::onRegisterClientSession)
                                   .onMessage(UnregisterClientSession.class, this::onUnregisterClientSession)
                                   .onMessage(RequestInitialHistory.class, this::onRequestInitialHistory)
+                                  .onMessage(NotifyChangeChannelPolicy.class, this::onNotifyChangeChannelPolicy)
+                                  .onMessage(NotifyMemberLeft.class, this::onNotifyMemberLeft)
+                                  .onMessage(NotifyKickedMember.class, this::onNotifyKickedMember)
+                                  .onMessage(NotifyFailure.class, this::onNotifyFailure)
+                                  .onMessage(NotifyEditChannelName.class, this::onNotifyEditChannelName)
+                                  .onMessage(NotifyChangeChannelMembership.class, this::onNotifyChangeChannelMembership)
+                                  .onMessage(NotifyMembershipCountChanged.class, this::onNotifyMembershipCountChanged)
+                                  .onMessage(SyncMembership.class, this::onSyncMembership)
+                                  .onMessage(SyncChannelMetadata.class, this::onSyncChannelMetadata)
                                   .onSignal(Terminated.class, this::onTerminated)
                                   .onSignal(PostStop.class, this::onPostStop)
                                   .build();
@@ -212,6 +234,88 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
         return this;
     }
 
+    private Behavior<ChannelReaderCommand> onNotifyChangeChannelPolicy(NotifyChangeChannelPolicy command) {
+        clientSessions.values()
+                      .forEach(
+                              clientSession ->
+                                      clientSession.tell(
+                                              new PropagateChangeChannelPolicy(channelId, command.channelPolicy())
+                                      )
+                      );
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyMemberLeft(NotifyMemberLeft command) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.memberId());
+
+        if (clientSession != null) {
+            clientSession.tell(new ClientSessionProtocol.SyncLeaveChannel(channelId));
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyKickedMember(NotifyKickedMember command) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.remove(command.memberId());
+
+        if (clientSession != null) {
+            clientSession.tell(new PropagateKickedMember(channelId));
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyFailure(NotifyFailure command) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.userId());
+        if (clientSession != null) {
+            clientSession.tell(new PropagateFailure(channelId, command.reason()));
+        }
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyEditChannelName(NotifyEditChannelName command) {
+        clientSessions.values()
+                      .forEach(clientSession -> clientSession.tell(new PropagateEditChannelName(channelId, command.editedName())));
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyChangeChannelMembership(NotifyChangeChannelMembership command) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.memberId());
+
+        if (clientSession != null) {
+            clientSession.tell(new PropagateChangeChannelMembership(channelId, command.channelMembership(), command.membershipCount()));
+        }
+
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onNotifyMembershipCountChanged(NotifyMembershipCountChanged command) {
+        clientSessions.values()
+                      .forEach(session -> session.tell(new PropagateMembershipCount(channelId, command.membershipCount())));
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onSyncMembership(SyncMembership command) {
+        ActorRef<ClientSessionCommand> clientSession = clientSessions.get(command.userId());
+        if (clientSession != null) {
+            clientSession.tell(new PropagateChangeChannelMembership(channelId, command.membership(), command.membershipCount()));
+        }
+        return this;
+    }
+
+    private Behavior<ChannelReaderCommand> onSyncChannelMetadata(SyncChannelMetadata command) {
+        clientSessions.values()
+                      .forEach(session -> {
+                          session.tell(new PropagateEditChannelName(command.channelId(), command.name()));
+                          session.tell(new PropagateChangeChannelPolicy(command.channelId(), command.channelPolicy()));
+                          session.tell(new PropagateMembershipCount(command.channelId(), command.membershipCount()));
+                      });
+        return this;
+    }
+
+
     private void applySyncNewMessage(SyncNewMessage command) {
         messages.add(command.message());
         clientSessions.values()
@@ -263,4 +367,19 @@ public class ChannelReaderActor extends AbstractBehavior<ChannelReaderCommand> {
 
     // ChannelEntity가 동기화한 채팅 히스토리를 전달받는 메시지 : ChannelEntity -> ChannelReaderActor
     record DeliverSyncMessages(List<ChatMessage> messages) implements ChannelReaderCommand { }
+
+    // ClientSessonActor에게 채널 정책 변경을 알리기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyChangeChannelPolicy(ChannelPolicy channelPolicy) implements ChannelReaderCommand { }
+
+    // ClientSessionActor에게 채널 이름 변경을 알리기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyEditChannelName(String editedName) implements ChannelReaderCommand { }
+
+    // ClientSessionActor에게 채널에서 강퇴되었음을 알리기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyKickedMember(Long memberId) implements ChannelReaderCommand { }
+
+    // ClientSessionActor에게 채널 참여자의 정보가 변경되었음을 전파받기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyChangeChannelMembership(Long memberId, ChannelMembership channelMembership, int membershipCount) implements ChannelReaderCommand { }
+
+    // ClientSessionActor에게 채널 탈퇴를 알리기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyMemberLeft(Long memberId) implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderMessages.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelReaderMessages.java
@@ -1,0 +1,273 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.global.common.ActorThreadSafe;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ChannelReaderMessages {
+
+    private static final int MAX_SIZE = 100;
+
+    private final ChatMessageNode head;
+    private final ChatMessageNode tail;
+    private final Map<Long, ChatMessageNode> messageIdMap;
+    private int size;
+
+    public ChannelReaderMessages() {
+        this.head = new ChatMessageNode(null);
+        this.tail = new ChatMessageNode(null);
+        this.head.next = tail;
+        this.tail.prev = head;
+        this.messageIdMap = new HashMap<>();
+        this.size = 0;
+    }
+
+    @ActorThreadSafe
+    public void add(ChatMessage message) {
+        addNewMessageNode(message);
+        evictOldest();
+    }
+
+    @ActorThreadSafe
+    public ChatMessage delete(Long messageId) {
+        ChatMessageNode node = findChatMessageNode(messageId);
+        ChatMessage deletedMessage = node.data;
+
+        removeNode(node);
+        messageIdMap.remove(messageId);
+        size--;
+
+        return deletedMessage;
+    }
+
+    @ActorThreadSafe
+    public void syncMessages(List<ChatMessage> newMessages) {
+        if (newMessages.isEmpty()) {
+            return;
+        }
+
+        List<ChatMessage> mergedMessages = mergeWithCurrentMessages(newMessages);
+        List<ChatMessage> uniqueMessages = removeDuplicateMessages(mergedMessages);
+        List<ChatMessage> sortedMessages = sortByMessageSequenceDescending(uniqueMessages);
+        List<ChatMessage> limitedMessages = limitToMaxSize(sortedMessages);
+
+        rebuildWithMessages(limitedMessages);
+    }
+
+    @ActorThreadSafe
+    public ChatMessage update(Long messageId, String updatedMessage, LocalDateTime updatedAt) {
+        ChatMessageNode node = messageIdMap.get(messageId);
+
+        if (node == null) {
+            throw new IllegalArgumentException("존재하지 않는 채팅 메시지입니다.");
+        }
+
+        node.data = node.data
+                .updateMessage(updatedMessage, updatedAt);
+        return node.data;
+    }
+
+    @ActorThreadSafe
+    public List<ChatMessage> getHistory(long beforeMessageSequence, int size) {
+        validateSize(size);
+
+        List<ChatMessage> result = new ArrayList<>();
+        ChatMessageNode current = head.next;
+
+        while (current != tail && result.size() < size) {
+            if (current.data.orderSequence() < beforeMessageSequence) {
+                result.add(current.data);
+            }
+            current = current.next;
+        }
+
+        return result;
+    }
+
+    @ActorThreadSafe
+    public List<ChatMessage> getRecentMessages(int size) {
+        validateSize(size);
+
+        List<ChatMessage> result = new ArrayList<>();
+        ChatMessageNode current = head.next;
+
+        while (current != tail && result.size() < size) {
+            result.add(current.data);
+            current = current.next;
+        }
+
+        return result;
+    }
+
+    @ActorThreadSafe
+    public List<ChatMessage> getMessagesAfter(long afterMessageSequence) {
+        List<ChatMessage> result = new ArrayList<>();
+        ChatMessageNode current = head.next;
+
+        while (current != tail) {
+            if (current.data.orderSequence() > afterMessageSequence) {
+                result.add(current.data);
+            }
+            current = current.next;
+        }
+
+        return result;
+    }
+
+    public ChatMessage getMessage(Long messageId) {
+        return messageIdMap.get(messageId)
+                           .data;
+    }
+
+    public List<ChatMessage> getMessages() {
+        List<ChatMessage> result = new ArrayList<>();
+        ChatMessageNode current = head.next;
+
+        while (current != tail) {
+            result.add(current.data);
+            current = current.next;
+        }
+
+        return result;
+    }
+
+    private void validateSize(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("조회하려는 메시지 개수는 양수여야 합니다.");
+        }
+        if (size > MAX_SIZE) {
+            throw new IllegalArgumentException("조회하려는 메시지 개수는 " + MAX_SIZE + "개를 넘을 수 없습니다.");
+        }
+    }
+
+    private void addNewMessageNode(ChatMessage message) {
+        ChatMessageNode newNode = new ChatMessageNode(message);
+
+        addNodeAfterHead(newNode);
+        messageIdMap.put(message.messageId(), newNode);
+        size++;
+    }
+
+    private void evictOldest() {
+        if (size > MAX_SIZE) {
+            ChatMessageNode oldest = tail.prev;
+
+            removeNode(oldest);
+            messageIdMap.remove(oldest.data.messageId());
+            size--;
+        }
+    }
+
+    private ChatMessageNode findChatMessageNode(Long messageId) {
+        ChatMessageNode node = messageIdMap.get(messageId);
+
+        if (node == null) {
+            throw new MessageNotFoundException();
+        }
+
+        return node;
+    }
+
+    private List<ChatMessage> mergeWithCurrentMessages(List<ChatMessage> newMessages) {
+        List<ChatMessage> allMessages = getAllMessages();
+        allMessages.addAll(newMessages);
+        return allMessages;
+    }
+
+    private List<ChatMessage> removeDuplicateMessages(List<ChatMessage> messageList) {
+        Map<Long, ChatMessage> distinctMessageIdMap = messageList.stream()
+                                                                 .collect(
+                                                                         Collectors.toMap(
+                                                                                 ChatMessage::messageId,
+                                                                                 message -> message,
+                                                                                 (existing, replacement) -> replacement
+                                                                         )
+                                                                 );
+
+        return new ArrayList<>(distinctMessageIdMap.values());
+    }
+
+    private List<ChatMessage> sortByMessageSequenceDescending(List<ChatMessage> messages) {
+        messages.sort(Comparator.comparingLong(ChatMessage::orderSequence).reversed());
+        return messages;
+    }
+
+    private List<ChatMessage> limitToMaxSize(List<ChatMessage> messages) {
+        if (messages.size() > MAX_SIZE) {
+            return messages.subList(0, MAX_SIZE);
+        }
+        return messages;
+    }
+
+    private void rebuildWithMessages(List<ChatMessage> messages) {
+        clearNodeStatus();
+
+        for (ChatMessage message : messages) {
+            ChatMessageNode newNode = new ChatMessageNode(message);
+            addNodeBeforeTail(newNode);
+            messageIdMap.put(message.messageId(), newNode);
+            size++;
+        }
+    }
+
+    private void addNodeAfterHead(ChatMessageNode node) {
+        node.next = head.next;
+        node.prev = head;
+        head.next.prev = node;
+        head.next = node;
+    }
+
+    private void addNodeBeforeTail(ChatMessageNode node) {
+        node.prev = tail.prev;
+        node.next = tail;
+        tail.prev.next = node;
+        tail.prev = node;
+    }
+
+    private void removeNode(ChatMessageNode node) {
+        node.prev.next = node.next;
+        node.next.prev = node.prev;
+    }
+
+    private void clearNodeStatus() {
+        head.next = tail;
+        tail.prev = head;
+        messageIdMap.clear();
+        size = 0;
+    }
+
+    private List<ChatMessage> getAllMessages() {
+        List<ChatMessage> allMessages = new ArrayList<>();
+
+        ChatMessageNode current = head.next;
+        while (current != tail) {
+            allMessages.add(current.data);
+            current = current.next;
+        }
+
+        return allMessages;
+    }
+
+    private static class ChatMessageNode {
+
+        ChatMessage data;
+        ChatMessageNode prev;
+        ChatMessageNode next;
+
+        ChatMessageNode(ChatMessage data) {
+            this.data = data;
+        }
+    }
+
+    public static class MessageNotFoundException extends IllegalArgumentException {
+
+        public MessageNotFoundException() {
+            super("존재하지 않는 메시지입니다.");
+        }
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatMessage.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatMessage.java
@@ -48,4 +48,12 @@ public record ChatMessage(
                 updatedAt
         );
     }
+
+    public boolean isWriter(Long writerId) {
+        return this.userId.equals(writerId);
+    }
+
+    public boolean isNotWriter(Long writerId) {
+        return !this.isWriter(writerId);
+    }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatMessages.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatMessages.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import com.tok.pekko.global.common.ActorThreadSafe;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -47,11 +49,11 @@ public class ChatMessages {
     }
 
     @ActorThreadSafe
-    public ChatMessage delete(Long messageId) {
-        validateMessageId(messageId);
-
+    public ChatMessage delete(Channel channel, UserId executorId, Long messageId) {
         ChatMessageNode node = findChatMessageNode(messageId);
         ChatMessage deletedMessage = node.data;
+
+        channel.validateMemberDeleteMessage(executorId, deletedMessage);
 
         removeNode(node);
         messageIdMap.remove(messageId);
@@ -75,15 +77,17 @@ public class ChatMessages {
     }
 
     @ActorThreadSafe
-    public ChatMessage update(Long messageId, String updatedMessage, LocalDateTime updatedAt) {
+    public ChatMessage update(Channel channel, Long executorId, Long messageId, String updatedMessage, LocalDateTime updatedAt) {
         ChatMessageNode node = messageIdMap.get(messageId);
 
         if (node == null) {
-            throw new IllegalArgumentException("존재하지 않는 채팅 메시지입니다.");
+            throw new MessageNotFoundException();
         }
+        ChatMessage message = node.data;
+        channel.validateMemberEditMessage(UserId.create(executorId), message);
 
         node.data = node.data
-                        .updateMessage(updatedMessage, updatedAt);
+                .updateMessage(updatedMessage, updatedAt);
         return node.data;
     }
 
@@ -152,12 +156,6 @@ public class ChatMessages {
         }
     }
 
-    private void validateMessageId(Long messageId) {
-        if (messageId == null) {
-            throw new IllegalArgumentException("메시지 ID는 null 일 수 없습니다.");
-        }
-    }
-
     private void validateSize(int size) {
         if (size <= 0) {
             throw new IllegalArgumentException("조회하려는 메시지 개수는 양수여야 합니다.");
@@ -189,7 +187,7 @@ public class ChatMessages {
         ChatMessageNode node = messageIdMap.get(messageId);
 
         if (node == null) {
-            throw new IllegalArgumentException("존재하지 않는 메시지입니다: " + messageId);
+            throw new MessageNotFoundException();
         }
 
         return node;
@@ -283,6 +281,13 @@ public class ChatMessages {
 
         ChatMessageNode(ChatMessage data) {
             this.data = data;
+        }
+    }
+
+    public static class MessageNotFoundException extends IllegalArgumentException {
+
+        public MessageNotFoundException() {
+            super("존재하지 않는 채팅 메시지입니다.");
         }
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -2,7 +2,9 @@ package com.tok.pekko.domain.chat.port.in;
 
 import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
@@ -43,12 +45,51 @@ public interface ChannelProtocol {
     // ChannelEntity가 관리하고 있는 ChannelReaderActor 중 유효하지 않은 ChannelReaderActor의 제거 요청을 받는 메시지 : ChannelReaderRegistryActor -> ChannelEntity
     record RemoveShutdownReader(String readerName) implements ChannelEntityCommand { }
 
+    // 채널 정책을 변경하기 위한 메시지 : 외부 -> ChannelEntity
+    record ChangeChannelPolicy(UserId changerId, boolean canEditOwnMessage, boolean canDeleteOwnMessage, boolean isPublic) implements ChannelEntityCommand { }
+
+    // 채널 이름을 변경하기 위한 메시지 : 외부 -> ChannelEntity
+    record EditChannelName(UserId changerId, String changedName) implements ChannelEntityCommand { }
+
+    // 채널에 참여한 사용자에 대한 정보를 동기화하기 위한 메시지 : 외부 -> ChannelEntity
+    record JoinUser(UserId joinerId, ActorRef<ChannelEntityCommand> replyTo) implements ChannelEntityCommand { }
+
+    // 채널에 참여했음을 전파하기 위한 메시지 : ChannelEntity -> ChannelEntity
+    record JoinedUser(Long channelId, Long userId) implements ChannelEntityCommand { }
+
+    // 채널에서 탈퇴하기 위한 메시지 : 외부 -> ChannelEntity
+    record LeaveMember(UserId memberId) implements ChannelEntityCommand { }
+
+    // 채널에 사용자를 초대하기 위한 메시지 : 외부 -> ChannelEntity
+    record InviteUser(UserId inviterId, UserId inviteeId, ActorRef<ChannelEntityCommand> replyTo) implements ChannelEntityCommand { }
+
+    // 역할이 MEMBER인 채널 사용자를 MANAGER로 승격시키기 위한 메시지 : 외부 -> ChannelEntity
+    record PromoteToManager(UserId executorId, UserId targetUserId) implements ChannelEntityCommand { }
+
+    // 역할이 MANAGER인 채널 사용자를 MEMBER로 강등시키기 위한 메시지 : 외부 -> ChannelEntity
+    record DemoteToMember(UserId executorId, UserId targetUserId) implements ChannelEntityCommand { }
+
+    // 역할이 MANAGER인 채널 사용자의 권한을 추가하기 위한 메시지 : 외부 -> ChannelEntity
+    record AddPermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) implements ChannelEntityCommand { }
+
+    // 역할이 MANAGER인 채널 사용자의 권한을 삭제하기 위한 메시지 : 외부 -> ChannelEntity
+    record RemovePermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) implements ChannelEntityCommand { }
+
+    // 채널 참여자를 강퇴하기 위한 메시지 : 외부 -> ChannelEntity
+    record KickMember(UserId executorId, UserId targetUserId) implements ChannelEntityCommand { }
+
     // 영속화된 채널과 모든 채널 참여자를 동기화하기 위한 메시지 : 외부 -> ChannelEntity
     record SyncChannel(Channel channel) implements ChannelEntityCommand { }
+
+    // ChannelEntity를 외부에서 종료시키기 위한 메시지 : 외부 -> ChannelEntity
+    record Shutdown() implements ChannelEntityCommand { }
+
+    // ChannelReaderActor가 가입한 userId에 대한 멤버십 정보를 요청하기 위한 메시지
+    record ResolveMembership(UserId userId, ActorRef<ChannelReaderCommand> replyTo) implements ChannelEntityCommand { }
 
     // 영속화된 채널 참여자를 동기화하기 위한 메시지 : ChannelEventHandlerEntity -> ChannelEntity
     record SyncStoredMembership(ChannelMembership channelMembership) implements ChannelEntityCommand { }
 
-    // ChannelEntity를 외부에서 종료시키기 위한 메시지 : 외부 -> ChannelEntity
-    record Shutdown() implements ChannelEntityCommand { }
+    // 채널 메타데이터(이름/정책)를 조회하기 위한 메시지 : ChannelReaderActor -> ChannelEntity
+    record ResolveChannelMetadata(ActorRef<ChannelReaderCommand> replyTo) implements ChannelEntityCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -1,6 +1,7 @@
 package com.tok.pekko.domain.chat.port.in;
 
 import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
@@ -44,6 +45,9 @@ public interface ChannelProtocol {
 
     // 영속화된 채널과 모든 채널 참여자를 동기화하기 위한 메시지 : 외부 -> ChannelEntity
     record SyncChannel(Channel channel) implements ChannelEntityCommand { }
+
+    // 영속화된 채널 참여자를 동기화하기 위한 메시지 : ChannelEventHandlerEntity -> ChannelEntity
+    record SyncStoredMembership(ChannelMembership channelMembership) implements ChannelEntityCommand { }
 
     // ChannelEntity를 외부에서 종료시키기 위한 메시지 : 외부 -> ChannelEntity
     record Shutdown() implements ChannelEntityCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -25,19 +25,13 @@ public interface ChannelProtocol {
     record SendMessage(Long userId, String message) implements ChannelEntityCommand { }
 
     // 기존 채팅 메시지 수정을 요청받는 메시지 : 외부 -> ChannelEntity
-    record UpdateMessage(Long messageId, String updatedMessage) implements ChannelEntityCommand { }
+    record UpdateMessage(Long executorId, Long messageId, String updatedMessage) implements ChannelEntityCommand { }
 
     // 기존 채팅 메시지 삭제를 요청받는 메시지 : 외부 -> ChannelEntity
-    record DeleteMessage(Long messageId) implements ChannelEntityCommand { }
+    record DeleteMessage(UserId executorId, Long messageId) implements ChannelEntityCommand { }
 
     // 영속화된 채팅 메시지를 ChannelEntity에게 전달하는 메시지 : MessageStorageAdapter -> ChannelEntity
     record SyncPersistedMessage(ChatMessage message) implements ChannelEntityCommand { }
-
-    // 변경 사항이 영속화된 채팅 메시지를 ChannelEntity에게 전달하는 메시지 : MessageStorageAdapter -> ChannelEntity
-    record SyncUpdatedMessage(Long messageId, String updatedMessage) implements ChannelEntityCommand { }
-
-    // 삭제된 채팅 메시지를 ChannelEntity에게 전달하는 메시지 : MessageStorageAdapter -> ChannelEntity
-    record SyncDeletedMessage(Long messageId) implements ChannelEntityCommand { }
 
     // ChannelReaderActor가 아직 동기화받지 못한 채팅 히스토리를 ChannelEntity가 요청받는 메시지 : ChannelReaderActor -> ChannelEntity
     record ResolveHistory(long messageSequence, int size, ActorRef<ClientSessionCommand> replyTo) implements ChannelEntityCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -1,5 +1,6 @@
 package com.tok.pekko.domain.chat.port.in;
 
+import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
@@ -40,4 +41,10 @@ public interface ChannelProtocol {
 
     // ChannelEntity가 관리하고 있는 ChannelReaderActor 중 유효하지 않은 ChannelReaderActor의 제거 요청을 받는 메시지 : ChannelReaderRegistryActor -> ChannelEntity
     record RemoveShutdownReader(String readerName) implements ChannelEntityCommand { }
+
+    // 영속화된 채널과 모든 채널 참여자를 동기화하기 위한 메시지 : 외부 -> ChannelEntity
+    record SyncChannel(Channel channel) implements ChannelEntityCommand { }
+
+    // ChannelEntity를 외부에서 종료시키기 위한 메시지 : 외부 -> ChannelEntity
+    record Shutdown() implements ChannelEntityCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -61,7 +61,7 @@ public interface ChannelProtocol {
     record LeaveMember(UserId memberId) implements ChannelEntityCommand { }
 
     // 채널에 사용자를 초대하기 위한 메시지 : 외부 -> ChannelEntity
-    record InviteUser(UserId inviterId, UserId inviteeId, ActorRef<ChannelEntityCommand> replyTo) implements ChannelEntityCommand { }
+    record InviteUser(UserId inviterId, UserId inviteeId) implements ChannelEntityCommand { }
 
     // 역할이 MEMBER인 채널 사용자를 MANAGER로 승격시키기 위한 메시지 : 외부 -> ChannelEntity
     record PromoteToManager(UserId executorId, UserId targetUserId) implements ChannelEntityCommand { }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelReaderProtocol.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.domain.chat.port.in;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
@@ -30,4 +32,16 @@ public interface ChannelReaderProtocol {
 
     // ChannelEntity-ChannelReaderActor까지 동기화된 채팅 히스토리를 요청받는 메시지 : ClientSessionActor -> ChannelReaderActor
     record RequestInitialHistory(ActorRef<ClientSessionCommand> replyTo) implements ChannelReaderCommand { }
+
+    // ChannelEntity로부터 멤버십 정보를 전달받는 메시지 : ChannelEntity -> ChannelReaderActor
+    record SyncMembership(Long userId, ChannelMembership membership, int membershipCount) implements ChannelReaderCommand { }
+
+    // ChannelEntity로부터 채널 메타데이터를 전달받는 메시지 : ChannelEntity -> ChannelReaderActor
+    record SyncChannelMetadata(Long channelId, String name, ChannelPolicy channelPolicy, int membershipCount) implements ChannelReaderCommand { }
+
+    // 특정 사용자에게 요청 실패를 전달하기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyFailure(Long userId, String reason) implements ChannelReaderCommand { }
+
+    // 멤버 수 변경을 전달하기 위한 메시지 : ChannelEntity -> ChannelReaderActor
+    record NotifyMembershipCountChanged(int membershipCount) implements ChannelReaderCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelActorStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelActorStoragePort.java
@@ -1,0 +1,13 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import org.apache.pekko.actor.typed.ActorRef;
+
+public interface ChannelActorStoragePort {
+
+    void find(Long channelId, ActorRef<ChannelEntityCommand> replyTo);
+
+    void update(Channel channel, Long eventId, ActorRef<ChannelEventHandlerCommand> replyTo);
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
@@ -15,4 +15,7 @@ public interface ChannelEventHandlerProtocol {
 
     // 도메인 이벤트 처리가 실패되었음을 전파받기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
     record EventFailed(Long eventId, Throwable throwable) implements ChannelEventHandlerCommand { }
+
+    // ChannelEventHandlerEntity 종료를 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record Shutdown() implements ChannelEventHandlerCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
@@ -1,0 +1,18 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.global.common.CborSerializable;
+
+public interface ChannelEventHandlerProtocol {
+
+    interface ChannelEventHandlerCommand extends CborSerializable { }
+
+    // ChannelMembership 영속화 시 생성된 PK를 ChannelEntity에서 관리하는 Channel에 반영하기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record NotifyStoredMembership(ChannelMembership channelMembership) implements ChannelEventHandlerCommand { }
+
+    // 도메인 이벤트 처리가 성공되었음을 전파받기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record EventSucceeded(Long eventId) implements ChannelEventHandlerCommand { }
+
+    // 도메인 이벤트 처리가 실패되었음을 전파받기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record EventFailed(Long eventId, Throwable throwable) implements ChannelEventHandlerCommand { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipActorStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipActorStoragePort.java
@@ -1,0 +1,26 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import org.apache.pekko.actor.typed.ActorRef;
+
+public interface ChannelMembershipActorStoragePort {
+
+    void join(Long eventId, ChannelId channelId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void leave(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void inviteUser(Long eventId, ChannelId channelId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void promoteToManager(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void demoteToMember(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void addPermission(Long eventId, ChannelMembership channelMembership, ChannelPermissionType permission, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void removePermission(Long eventId, ChannelMembership channelMembership, ChannelPermissionType permission, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void kickMember(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.domain.chat.port.out;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
@@ -40,4 +42,25 @@ public interface ClientSessionProtocol {
 
     // Client Session인 WebSocketSession으로부터 Pong을 전달하기 위한 메시지 : WebSocketHandler -> ClientSessionActor
     record SessionPongReceived() implements ClientSessionCommand { }
+
+    // 채널 정책이 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateChangeChannelPolicy(Long channelId, ChannelPolicy channelPolicy) implements ClientSessionCommand { }
+
+    // 채널 이름이 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateEditChannelName(Long channelId, String editedName) implements ClientSessionCommand { }
+
+    // 채널 참여자가 강퇴되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateKickedMember(Long channelId) implements ClientSessionCommand { }
+
+    // 채널 멤버 수 변경을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateMembershipCount(Long channelId, int membershipCount) implements ClientSessionCommand { }
+
+    // 채널 참여자의 정보가 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateChangeChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount) implements ClientSessionCommand { }
+
+    // WebSocket 재연결 시 참여 채널/히스토리를 다시 동기화하기 위한 메시지 : WebSocketHandler -> ClientSessionActor
+    record ReSyncSession() implements ClientSessionCommand { }
+
+    // 요청 실패를 클라이언트로 전달하기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateFailure(Long channelId, String reason) implements ClientSessionCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -37,6 +37,9 @@ public interface ClientSessionProtocol {
     // 외부에서 클라이언트가 기존 채널에서 탈퇴했음을 전파하는 메시지 : ClientSessionActorManagementService -> ClientSessionActor
     record SyncLeaveChannel(Long channelId) implements ClientSessionCommand { }
 
+    // 외부에서 클라이언트가 새로운 채널에 참여했음을 전파하는 메시지 : ClientSessionActorManagementService -> ClientSessionActor
+    record SyncInvitedChannel(Long channelId) implements ClientSessionCommand { }
+
     // ClientSessionActor 종료를 위한 메시지 : 외부 -> Shutdown
     record Shutdown() implements ClientSessionCommand { }
 

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/InviteUserEventProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/InviteUserEventProtocol.java
@@ -1,0 +1,10 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.global.common.CborSerializable;
+
+public interface InviteUserEventProtocol {
+
+    interface InviteUserEventCommand extends CborSerializable { }
+
+    record Invited(Long channelId, Long inviteeId) implements InviteUserEventCommand { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
@@ -10,11 +10,7 @@ public interface MessageStoragePort {
 
     void store(ChatMessage message, ActorRef<ChannelEntityCommand> replyTo);
 
-    void update(Long messageId, String updatedMessage, ActorRef<ChannelEntityCommand> replyTo);
-
     void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo);
-
-    void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo);
 
     void delete(Long eventId, Long messageId, ActorRef<ChannelEventHandlerCommand> replyTo);
 

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
@@ -2,6 +2,7 @@ package com.tok.pekko.domain.chat.port.out;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import org.apache.pekko.actor.typed.ActorRef;
 
@@ -11,7 +12,11 @@ public interface MessageStoragePort {
 
     void update(Long messageId, String updatedMessage, ActorRef<ChannelEntityCommand> replyTo);
 
+    void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo);
+
     void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo);
+
+    void delete(Long eventId, Long messageId, ActorRef<ChannelEventHandlerCommand> replyTo);
 
     void findHistory(
             Long channelId,

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -95,7 +95,9 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                                 clock,
                                 Long.valueOf(entityContext.getEntityId()),
                                 new ChatMessages(),
+                                clusterSharding,
                                 messageStoragePort,
+                                channelActorStoragePort,
                                 inviteUserTopic
                         )
                 )

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -3,12 +3,21 @@ package com.tok.pekko.global.actor;
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor;
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor;
+import com.tok.pekko.adapter.out.websocket.InviteUserEventListenerActor;
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
+import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity;
+import com.tok.pekko.domain.chat.actor.ChatMessages;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
 import com.tok.pekko.global.common.CborSerializable;
+import java.time.Clock;
 import java.time.Duration;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.Behavior;
@@ -17,17 +26,42 @@ import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.actor.typed.pubsub.Topic;
+import org.apache.pekko.actor.typed.pubsub.Topic.Command;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.Entity;
 
 public class GuardianActor extends AbstractBehavior<GuardianCommand> {
 
-    public static Behavior<GuardianCommand> create() {
-        return Behaviors.setup(GuardianActor::new);
+    public static Behavior<GuardianCommand> create(
+            Clock clock,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort,
+            ClientSessionActorManagementService clientSessionActorManagementService
+    ) {
+        return Behaviors.setup(
+                context -> new GuardianActor(
+                        context,
+                        clock,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort,
+                        clientSessionActorManagementService
+                )
+        );
     }
 
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
 
-    private GuardianActor(ActorContext<GuardianCommand> context) {
+    private GuardianActor(
+            ActorContext<GuardianCommand> context,
+            Clock clock,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort,
+            ClientSessionActorManagementService clientSessionActorManagementService
+    ) {
         super(context);
 
         ClusterSharding clusterSharding = ClusterSharding.get(context.getSystem());
@@ -35,6 +69,41 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
         this.readerRegistry = context.spawn(
                 ChannelReaderRegistryActor.create(clusterSharding, Duration.ofSeconds(240L)),
                 "channel-reader-registry-actor"
+        );
+
+        ActorRef<Command<InviteUserEventCommand>> inviteUserTopic = context.spawn(
+                Topic.create(InviteUserEventCommand.class, "user-channel-events"),
+                "user-channel-topic"
+        );
+
+        clusterSharding.init(
+                Entity.of(
+                        ChannelEventHandlerEntity.ENTITY_TYPE_KEY,
+                        entityContext -> ChannelEventHandlerEntity.create(
+                                clusterSharding,
+                                Long.valueOf(entityContext.getEntityId()),
+                                messageStoragePort,
+                                channelActorStoragePort,
+                                channelMembershipActorStoragePort
+                        )
+                )
+        );
+        clusterSharding.init(
+                Entity.of(
+                        ChannelEntity.ENTITY_TYPE_KEY,
+                        entityContext -> ChannelEntity.create(
+                                clock,
+                                Long.valueOf(entityContext.getEntityId()),
+                                new ChatMessages(),
+                                messageStoragePort,
+                                inviteUserTopic
+                        )
+                )
+        );
+
+        context.spawn(
+                InviteUserEventListenerActor.create(inviteUserTopic, clientSessionActorManagementService),
+                "invite-user-event-listener-actor"
         );
     }
 

--- a/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
+++ b/pekko/src/main/java/com/tok/pekko/global/actor/GuardianActor.java
@@ -37,8 +37,7 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
             Clock clock,
             MessageStoragePort messageStoragePort,
             ChannelActorStoragePort channelActorStoragePort,
-            ChannelMembershipActorStoragePort channelMembershipActorStoragePort,
-            ClientSessionActorManagementService clientSessionActorManagementService
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
     ) {
         return Behaviors.setup(
                 context -> new GuardianActor(
@@ -46,21 +45,21 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                         clock,
                         messageStoragePort,
                         channelActorStoragePort,
-                        channelMembershipActorStoragePort,
-                        clientSessionActorManagementService
+                        channelMembershipActorStoragePort
                 )
         );
     }
 
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
+    private final ActorRef<Command<InviteUserEventCommand>> inviteUserTopic;
+    private ActorRef<InviteUserEventCommand> inviteUserEventListener;
 
     private GuardianActor(
             ActorContext<GuardianCommand> context,
             Clock clock,
             MessageStoragePort messageStoragePort,
             ChannelActorStoragePort channelActorStoragePort,
-            ChannelMembershipActorStoragePort channelMembershipActorStoragePort,
-            ClientSessionActorManagementService clientSessionActorManagementService
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
     ) {
         super(context);
 
@@ -71,10 +70,11 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                 "channel-reader-registry-actor"
         );
 
-        ActorRef<Command<InviteUserEventCommand>> inviteUserTopic = context.spawn(
+        this.inviteUserTopic = context.spawn(
                 Topic.create(InviteUserEventCommand.class, "user-channel-events"),
                 "user-channel-topic"
         );
+        this.inviteUserEventListener = null;
 
         clusterSharding.init(
                 Entity.of(
@@ -102,16 +102,12 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
                         )
                 )
         );
-
-        context.spawn(
-                InviteUserEventListenerActor.create(inviteUserTopic, clientSessionActorManagementService),
-                "invite-user-event-listener-actor"
-        );
     }
 
     @Override
     public Receive<GuardianCommand> createReceive() {
         return newReceiveBuilder().onMessage(SpawnClientSession.class, this::onSpawnClientSession)
+                                  .onMessage(InitializeInviteUserListener.class, this::onInitializeInviteUserListener)
                                   .build();
     }
 
@@ -134,6 +130,19 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
         return this;
     }
 
+    private Behavior<GuardianCommand> onInitializeInviteUserListener(InitializeInviteUserListener command) {
+        if (inviteUserEventListener != null) {
+            return this;
+        }
+
+        inviteUserEventListener = getContext().spawn(
+                InviteUserEventListenerActor.create(inviteUserTopic, command.clientSessionActorManagementService()),
+                "invite-user-event-listener-actor"
+        );
+
+        return this;
+    }
+
     public interface GuardianCommand extends CborSerializable { }
 
     // Client WebSocket Session 연결 시 외부로부터 ClientSessionActor Spawn을 요청하기 위한 메시지 : ClientSessionActorManagementService -> GuardianActor
@@ -141,4 +150,7 @@ public class GuardianActor extends AbstractBehavior<GuardianCommand> {
 
     // ClientSessionActor spawn 완료 후 ActorRef를 ClientSessionActorManagementService.AskPattern에 전달하기 위한 메시지 : ClientSessionActorManagementService -> GuardianActor
     public record SpawnedClientSession(ActorRef<ClientSessionCommand> clientSession) implements GuardianCommand { }
+
+    // InviteUserEventListenerActor를 초기화하기 위한 메시지 : 외부 -> GuardianActor
+    public record InitializeInviteUserListener(ClientSessionActorManagementService clientSessionActorManagementService) implements GuardianCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
@@ -1,8 +1,6 @@
 package com.tok.pekko.global.config.actor;
 
-import com.tok.pekko.domain.chat.actor.ChannelEntity;
-import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity;
-import com.tok.pekko.domain.chat.actor.ChatMessages;
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -18,7 +16,6 @@ import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.AddressFromURIString;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
-import org.apache.pekko.cluster.sharding.typed.javadsl.Entity;
 import org.apache.pekko.cluster.typed.Cluster;
 import org.apache.pekko.cluster.typed.JoinSeedNodes;
 import org.springframework.context.annotation.Bean;
@@ -35,36 +32,11 @@ public class ClusterConfig {
     private final MessageStoragePort messageStoragePort;
     private final ChannelActorStoragePort channelActorStoragePort;
     private final ChannelMembershipActorStoragePort channelMembershipActorStoragePort;
+    private final ClientSessionActorManagementService clientSessionActorManagementService;
     private final Environment environment;
 
     @Bean
-    public ClusterSharding clusterSharding(MessageStoragePort messageStoragePort) {
-        ClusterSharding clusterSharding = ClusterSharding.get(actorSystem());
-
-        clusterSharding.init(
-                Entity.of(
-                        ChannelEventHandlerEntity.ENTITY_TYPE_KEY,
-                        entityContext -> ChannelEventHandlerEntity.create(
-                                clusterSharding,
-                                Long.valueOf(entityContext.getEntityId()),
-                                messageStoragePort,
-                                channelActorStoragePort,
-                                channelMembershipActorStoragePort
-                        )
-                )
-        );
-        clusterSharding.init(
-                Entity.of(
-                        ChannelEntity.ENTITY_TYPE_KEY,
-                        entityContext -> ChannelEntity.create(
-                                clock,
-                                Long.valueOf(entityContext.getEntityId()),
-                                new ChatMessages(),
-                                messageStoragePort
-                        )
-                )
-        );
-
+    public ClusterSharding clusterSharding() {
         return ClusterSharding.get(actorSystem());
     }
 
@@ -72,7 +44,13 @@ public class ClusterConfig {
     public ActorSystem<GuardianCommand> actorSystem() {
         Config config = buildConfig();
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(
+                        clock,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort,
+                        clientSessionActorManagementService
+                ),
                 "ChatCluster",
                 config
         );

--- a/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
@@ -1,7 +1,10 @@
 package com.tok.pekko.global.config.actor;
 
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity;
 import com.tok.pekko.domain.chat.actor.ChatMessages;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
@@ -29,12 +32,27 @@ import org.springframework.core.env.Environment;
 public class ClusterConfig {
 
     private final Clock clock;
+    private final MessageStoragePort messageStoragePort;
+    private final ChannelActorStoragePort channelActorStoragePort;
+    private final ChannelMembershipActorStoragePort channelMembershipActorStoragePort;
     private final Environment environment;
 
     @Bean
     public ClusterSharding clusterSharding(MessageStoragePort messageStoragePort) {
         ClusterSharding clusterSharding = ClusterSharding.get(actorSystem());
 
+        clusterSharding.init(
+                Entity.of(
+                        ChannelEventHandlerEntity.ENTITY_TYPE_KEY,
+                        entityContext -> ChannelEventHandlerEntity.create(
+                                clusterSharding,
+                                Long.valueOf(entityContext.getEntityId()),
+                                messageStoragePort,
+                                channelActorStoragePort,
+                                channelMembershipActorStoragePort
+                        )
+                )
+        );
         clusterSharding.init(
                 Entity.of(
                         ChannelEntity.ENTITY_TYPE_KEY,

--- a/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/actor/ClusterConfig.java
@@ -1,6 +1,5 @@
 package com.tok.pekko.global.config.actor;
 
-import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -32,7 +31,6 @@ public class ClusterConfig {
     private final MessageStoragePort messageStoragePort;
     private final ChannelActorStoragePort channelActorStoragePort;
     private final ChannelMembershipActorStoragePort channelMembershipActorStoragePort;
-    private final ClientSessionActorManagementService clientSessionActorManagementService;
     private final Environment environment;
 
     @Bean
@@ -48,8 +46,7 @@ public class ClusterConfig {
                         clock,
                         messageStoragePort,
                         channelActorStoragePort,
-                        channelMembershipActorStoragePort,
-                        clientSessionActorManagementService
+                        channelMembershipActorStoragePort
                 ),
                 "ChatCluster",
                 config

--- a/pekko/src/test/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandlerTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandlerTest.java
@@ -41,7 +41,7 @@ class DevChatWebSocketHandlerTest {
     @Test
     void 정상적으로_웹소켓을_연결하면_필요한_흐름을_정의하고_Actor에게_메시지를_전달한다() throws Exception {
         // given
-        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        ObjectMapper objectMapper = new ObjectMapper();
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
         ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
         WebSocketSession session = mock(WebSocketSession.class);
@@ -52,15 +52,14 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
         given(session.receive()).willReturn(Flux.empty());
@@ -81,7 +80,7 @@ class DevChatWebSocketHandlerTest {
     @Test
     void 웹소켓으로_인한_메시지를_보낼_때_마다_EntityRe의_tell_메서드를_통해_적절한_메시지를_전달한다() throws Exception {
         // given
-        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        ObjectMapper objectMapper = new ObjectMapper();
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
         ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
         WebSocketSession session = mock(WebSocketSession.class);
@@ -93,16 +92,15 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
-        String messageContent = "테스트 메시지";
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
+        String messageContent = "{\"channelId\":1,\"message\":\"테스트\"}";
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
@@ -123,16 +121,15 @@ class DevChatWebSocketHandlerTest {
     }
 
     @Test
-    void 웹소켓_연결_시_channelId가_쿼리_파라미터에_없다면_예외가_발생한다() throws Exception {
+    void 웹소켓_연결_시_channelId가_없어도_userId만_있으면_연결된다() throws Exception {
         // given
-        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        ObjectMapper objectMapper = new ObjectMapper();
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
         ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
         WebSocketSession session = mock(WebSocketSession.class);
         HandshakeInfo handshakeInfo = mock(HandshakeInfo.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
@@ -142,11 +139,11 @@ class DevChatWebSocketHandlerTest {
         URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
+        given(session.receive()).willReturn(Flux.empty());
+        given(session.send(any())).willReturn(Mono.empty());
 
         // when & Then
-        assertThatThrownBy(() -> handler.handle(session))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("channelId");
+        StepVerifier.create(handler.handle(session)).verifyComplete();
     }
 
     @Test
@@ -158,15 +155,14 @@ class DevChatWebSocketHandlerTest {
         WebSocketSession session = mock(WebSocketSession.class);
         HandshakeInfo handshakeInfo = mock(HandshakeInfo.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1");
+        URI uri = new URI("ws://localhost:8080/ws/chat");
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
 
@@ -190,15 +186,14 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
@@ -230,15 +225,14 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
@@ -272,15 +266,14 @@ class DevChatWebSocketHandlerTest {
 
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = CompletableFuture.completedFuture(clientSessionActor);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
@@ -298,7 +291,7 @@ class DevChatWebSocketHandlerTest {
     @Test
     void 웹소켓_세션으로_여러_메시지를_받으면_순차적으로_처리한다() throws Exception {
         // given
-        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        ObjectMapper objectMapper = new ObjectMapper();
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
         ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
         WebSocketSession session = mock(WebSocketSession.class);
@@ -311,21 +304,20 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=1&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
         given(session.receive()).willReturn(Flux.just(message1, message2));
-        given(message1.getPayloadAsText()).willReturn("메시지1");
-        given(message2.getPayloadAsText()).willReturn("메시지2");
+        given(message1.getPayloadAsText()).willReturn("{\"channelId\":1,\"message\":\"메시지1\"}");
+        given(message2.getPayloadAsText()).willReturn("{\"channelId\":1,\"message\":\"메시지2\"}");
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);
@@ -354,15 +346,14 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=123&userId=456");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=456");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
@@ -381,7 +372,7 @@ class DevChatWebSocketHandlerTest {
     @Test
     void 웹소켓_연결_시_유효한_파라미터가_전달되면_유효한_channelId로_ChatChannelEntity를_조회한다() throws Exception {
         // given
-        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        ObjectMapper objectMapper = new ObjectMapper();
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
         ClientSessionActorManagementService managementService = mock(ClientSessionActorManagementService.class);
         WebSocketSession session = mock(WebSocketSession.class);
@@ -393,20 +384,19 @@ class DevChatWebSocketHandlerTest {
         @SuppressWarnings("unchecked")
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession = mock(CompletionStage.class);
 
-        given(managementService.findClientSession(anyLong()))
-                .willThrow(new ClientSessionActorManagementService.ClientSessionNotFoundException());
+        given(managementService.findClientSessionOptional(anyLong())).willReturn(java.util.Optional.empty());
         DevChatWebSocketHandler handler = new DevChatWebSocketHandler(
                 objectMapper,
                 clusterSharding,
                 managementService
         );
 
-        URI uri = new URI("ws://localhost:8080/ws/chat?channelId=999&userId=100");
+        URI uri = new URI("ws://localhost:8080/ws/chat?userId=100");
 
         given(session.getHandshakeInfo()).willReturn(handshakeInfo);
         given(handshakeInfo.getUri()).willReturn(uri);
         given(session.receive()).willReturn(Flux.just(webSocketMessage));
-        given(webSocketMessage.getPayloadAsText()).willReturn("테스트");
+        given(webSocketMessage.getPayloadAsText()).willReturn("{\"channelId\":999,\"message\":\"테스트\"}");
         given(session.send(any())).willReturn(Mono.empty());
         given(clusterSharding.<ChannelEntityCommand>entityRefFor(any(), anyString())).willReturn(entityRef);
         given(managementService.createClientSessionActor(any(ClientMessageSender.class), eq(100L))).willReturn(clientSession);

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapterTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapterTest.java
@@ -1,13 +1,32 @@
 package com.tok.pekko.adapter.out.persistence;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.global.config.dev.BlockHoundTestInstallUtils;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
@@ -17,25 +36,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -376,130 +378,112 @@ class MessageStorageAdapterTest {
     }
 
     @Test
-    void 메시지_삭제_성공_시_삭제_이벤트를_전달한다() {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+    void 메시지_삭제_성공_시_EventSucceeded를_전달한다() {
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
         Long messageId = 1L;
+        Long eventId = 99L;
 
         willDoNothing().given(messageRepository).delete(eq(messageId));
 
-        // when
-        adapter.delete(messageId, replyProbe.ref());
+        adapter.delete(eventId, messageId, replyProbe.ref());
 
-        // then
-        SyncDeletedMessage syncDeletedMessage = replyProbe.expectMessageClass(
-                SyncDeletedMessage.class,
-                Duration.ofSeconds(3)
-        );
-        assertThat(syncDeletedMessage.messageId()).isEqualTo(messageId);
+        replyProbe.expectMessageClass(EventSucceeded.class, Duration.ofSeconds(3));
+        verify(messageRepository, timeout(1000)).delete(messageId);
     }
 
     @Test
-    void 메시지_삭제_실패_시_이벤트를_전달하지_않는다() {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+    void 메시지_삭제_실패_시_EventFailed를_전달한다() {
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
         Long messageId = 1L;
+        Long eventId = 100L;
 
         willThrow(new RuntimeException("Database error")).given(messageRepository).delete(anyLong());
 
-        // when
-        adapter.delete(messageId, replyProbe.ref());
+        adapter.delete(eventId, messageId, replyProbe.ref());
 
-        // then
-        replyProbe.expectNoMessage(Duration.ofSeconds(1));
+        replyProbe.expectMessageClass(EventFailed.class, Duration.ofSeconds(3));
     }
 
     @Test
     void 메시지_삭제_시_호출자_스레드를_블로킹하지_않는다() throws InterruptedException {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
         Long messageId = 1L;
+        Long eventId = 200L;
 
         willDoNothing().given(messageRepository).delete(anyLong());
 
-        // when
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> errorHolder = new AtomicReference<>();
 
-        Mono.fromRunnable(() -> adapter.delete(messageId, replyProbe.ref()))
+        Mono.fromRunnable(() -> adapter.delete(eventId, messageId, replyProbe.ref()))
             .subscribeOn(Schedulers.parallel())
             .doFinally(ignored -> latch.countDown())
             .subscribe(null, errorHolder::set);
 
         latch.await();
 
-        // then
-        assertAll(
-                () -> assertThat(errorHolder.get()).isNull(),
-                () -> replyProbe.expectMessageClass(SyncDeletedMessage.class, Duration.ofSeconds(1))
-        );
+        assertThat(errorHolder.get()).isNull();
+        replyProbe.expectMessageClass(EventSucceeded.class, Duration.ofSeconds(1));
     }
 
     @Test
-    void 메시지_수정_성공_시_Repository의_update를_호출한다() {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+    void 메시지_수정_성공_시_EventSucceeded를_전달한다() {
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
-        Long messageId = 1L;
-        String updatedMessage = "Updated Message";
+        Long eventId = 50L;
+        ChatMessage updatedMessage = new ChatMessage(1L, 10L, 100L, 1L, "Updated Message", LocalDateTime.now(), LocalDateTime.now());
 
-        willDoNothing().given(messageRepository).update(eq(messageId), eq(updatedMessage));
+        willDoNothing().given(messageRepository).update(updatedMessage.messageId(), updatedMessage.message());
 
-        // when
-        adapter.update(messageId, updatedMessage, replyProbe.ref());
+        adapter.update(eventId, updatedMessage, replyProbe.ref());
 
-        // then
-        verify(messageRepository, timeout(1000)).update(messageId, updatedMessage);
+        replyProbe.expectMessageClass(EventSucceeded.class, Duration.ofSeconds(3));
+        verify(messageRepository, timeout(1000)).update(updatedMessage.messageId(), updatedMessage.message());
     }
 
     @Test
-    void 메시지_수정_실패_시_이벤트를_전달하지_않는다() {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+    void 메시지_수정_실패_시_EventFailed를_전달한다() {
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
-        Long messageId = 1L;
-        String updatedMessage = "Updated Message";
+        Long eventId = 60L;
+        ChatMessage updatedMessage = new ChatMessage(1L, 10L, 100L, 1L, "Updated Message", LocalDateTime.now(), LocalDateTime.now());
 
-        willThrow(new RuntimeException("Database error")).given(messageRepository).update(anyLong(), any());
+        willThrow(new RuntimeException("DB error")).given(messageRepository).update(anyLong(), anyString());
 
-        // when
-        adapter.update(messageId, updatedMessage, replyProbe.ref());
+        adapter.update(eventId, updatedMessage, replyProbe.ref());
 
-        // then
-        replyProbe.expectNoMessage(Duration.ofSeconds(1));
+        replyProbe.expectMessageClass(EventFailed.class, Duration.ofSeconds(3));
     }
 
     @Test
     void 메시지_수정_시_호출자_스레드를_블로킹하지_않는다() throws InterruptedException {
-        // given
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
+        TestProbe<ChannelEventHandlerCommand> replyProbe = testKit.createTestProbe(ChannelEventHandlerCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
         MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
-        Long messageId = 1L;
-        String updatedMessage = "Updated Message";
+        Long eventId = 70L;
+        ChatMessage updatedMessage = new ChatMessage(1L, 10L, 100L, 1L, "Updated Message", LocalDateTime.now(), LocalDateTime.now());
 
-        willDoNothing().given(messageRepository).update(anyLong(), any());
+        willDoNothing().given(messageRepository).update(anyLong(), anyString());
 
-        // when
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> errorHolder = new AtomicReference<>();
 
-        Mono.fromRunnable(() -> adapter.update(messageId, updatedMessage, replyProbe.ref()))
+        Mono.fromRunnable(() -> adapter.update(eventId, updatedMessage, replyProbe.ref()))
             .subscribeOn(Schedulers.parallel())
             .doFinally(ignored -> latch.countDown())
             .subscribe(null, errorHolder::set);
 
         latch.await();
 
-        // then
         assertThat(errorHolder.get()).isNull();
+        replyProbe.expectMessageClass(EventSucceeded.class, Duration.ofSeconds(1));
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -45,15 +45,13 @@ class ChannelReaderRegistryActorTest {
 
     private static ActorTestKit testKit;
     private static ClusterSharding clusterSharding;
-    private static MessageStoragePort mockMessageStoragePort;
 
     @BeforeAll
     static void setup() {
         testKit = ActorTestKit.create(ConfigFactory.load());
 
-        mockMessageStoragePort = mock(MessageStoragePort.class);
-
         clusterSharding = ClusterSharding.get(testKit.system());
+
         clusterSharding.init(
                 Entity.of(
                         ChannelEntity.ENTITY_TYPE_KEY,
@@ -61,7 +59,8 @@ class ChannelReaderRegistryActorTest {
                                 Clock.systemDefaultZone(),
                                 Long.parseLong(entityContext.getEntityId()),
                                 new ChatMessages(),
-                                mockMessageStoragePort
+                                mock(MessageStoragePort.class),
+                                mock(ActorRef.class)
                         )
                 )
         );

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ChannelReaderRegistryActorTest.java
@@ -1,5 +1,6 @@
 package com.tok.pekko.adapter.out.websocket;
 
+import com.tok.pekko.adapter.out.persistence.ChannelActorStorageAdapter;
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
@@ -59,7 +60,9 @@ class ChannelReaderRegistryActorTest {
                                 Clock.systemDefaultZone(),
                                 Long.parseLong(entityContext.getEntityId()),
                                 new ChatMessages(),
+                                clusterSharding,
                                 mock(MessageStoragePort.class),
+                                mock(ChannelActorStorageAdapter.class),
                                 mock(ActorRef.class)
                         )
                 )

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -2,6 +2,11 @@ package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
@@ -10,6 +15,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHis
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseClientSessionActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
@@ -17,6 +23,13 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
@@ -24,8 +37,10 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -433,5 +448,204 @@ class ClientSessionActorTest {
 
         // then
         readerProbe.expectMessageClass(UnregisterClientSession.class);
+    }
+
+    @Test
+    void PropagateChangeChannelMembership_메시지를_받으면_ClientMessageSender로_채널_멤버십_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        ChannelMembership membership = createManagerMembership(1L, channelId, 100L);
+        int membershipCount = 5;
+
+        // when
+        clientSessionActor.tell(new PropagateChangeChannelMembership(channelId, membership, membershipCount));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedChannelMembership(channelId, membership, membershipCount);
+    }
+
+    @Test
+    void PropagateMembershipCount_메시지를_받으면_ClientMessageSender로_멤버십_카운트_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        int membershipCount = 10;
+
+        // when
+        clientSessionActor.tell(new PropagateMembershipCount(channelId, membershipCount));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedMembershipCount(channelId, membershipCount);
+    }
+
+    @Test
+    void PropagateChangeChannelPolicy_메시지를_받으면_ClientMessageSender로_채널_정책_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
+                                                   .updatePublic(false)
+                                                   .updateEditOwnMessage(true)
+                                                   .updateDeleteOwnMessage(false);
+
+        // when
+        clientSessionActor.tell(new PropagateChangeChannelPolicy(channelId, channelPolicy));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedChannelPolicy(channelId, channelPolicy);
+    }
+
+    @Test
+    void PropagateEditChannelName_메시지를_받으면_ClientMessageSender로_채널_이름_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        String editedName = "새로운 채널명";
+
+        // when
+        clientSessionActor.tell(new PropagateEditChannelName(channelId, editedName));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendEditedChannelName(channelId, editedName);
+    }
+
+    @Test
+    void PropagateKickedMember_메시지를_받으면_ClientMessageSender로_강퇴_알림을_전송하고_reader를_제거한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        Map<Long, ActorRef<ChannelReaderCommand>> readers = Map.of(1L, readerProbe.ref());
+
+        clientSessionActor.tell(new FoundChannelReaders(readers));
+        readerProbe.expectMessageClass(RegisterClientSession.class);
+        readerProbe.expectMessageClass(RequestInitialHistory.class);
+
+        Long channelId = 1L;
+
+        // when
+        clientSessionActor.tell(new PropagateKickedMember(channelId));
+
+        // then
+        assertAll(
+                () -> verify(mockClientMessageSender, timeout(1000)).sendKickedFromChannel(channelId),
+                () -> {
+                    ReleaseClientSessionActor message = readerRegistryProbe.expectMessageClass(ReleaseClientSessionActor.class);
+                    assertThat(message.channelIds()).contains(channelId);
+                }
+        );
+    }
+
+    @Test
+    void ReSyncSession_메시지를_받으면_ChannelMembershipActorMessagePort로_참여_채널_조회를_요청한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        // when
+        clientSessionActor.tell(new ReSyncSession());
+
+        // then
+        verify(mockChannelMembershipActorMessagePort, timeout(1000).times(2))
+                .sendParticipatingChannels(eq(100L), any(ActorRef.class));
+    }
+
+    @Test
+    void NotifyFailure_메시지를_받으면_ClientMessageSender로_에러를_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        String reason = "권한이 없습니다";
+
+        // when
+        clientSessionActor.tell(new PropagateFailure(channelId, reason));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendError(channelId, reason);
+    }
+
+    private ChannelMembership createManagerMembership(Long membershipId, Long channelId, Long userId) {
+        Set<ChannelPermissionType> permissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+        return ChannelMembership.create(
+                membershipId,
+                channelId,
+                userId,
+                ChannelRole.MANAGER,
+                managePermissions,
+                LocalDateTime.now()
+        );
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
@@ -1,8 +1,23 @@
 package com.tok.pekko.adapter.out.websocket;
 
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelInvitePayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelKickedPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipCountPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelNamePayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelPolicyPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ErrorPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.WebSocketPayload;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -22,7 +37,7 @@ class WebSocketMessageSenderTest {
     void 단일_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage message = createMessage(1L, "테스트 메시지");
 
@@ -30,14 +45,14 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
     }
 
     @Test
     void 여러_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         List<ChatMessage> messages = List.of(
                 createMessage(1L, "메시지1"),
@@ -50,9 +65,9 @@ class WebSocketMessageSenderTest {
 
         // then
         assertAll(
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
         );
     }
 
@@ -60,7 +75,7 @@ class WebSocketMessageSenderTest {
     void 삭제된_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage deletedMessage = createMessage(1L, "삭제된 메시지");
 
@@ -68,14 +83,14 @@ class WebSocketMessageSenderTest {
         sender.sendDeletedMessage(deletedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
     }
 
     @Test
     void 수정된_메시지를_클라이언트에게_전송한다() {
         // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage updatedMessage = createMessage(1L, "수정된 메시지");
 
@@ -83,58 +98,226 @@ class WebSocketMessageSenderTest {
         sender.sendUpdatedMessage(updatedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
     }
 
     @Test
     void 웹소켓_헬스체크_핑을_전송한다() {
+        // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.sendWebSocketPing();
 
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
+        // then
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
     }
 
     @Test
     void 재연결을_요청한다() {
+        // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.requestSessionReconnect();
 
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
+        // then
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
     }
 
     @Test
     void sink를_교체하면_새로운_sink로_메시지를_전송한다() {
+        // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> firstSink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> firstSink = mock(Sinks.Many.class);
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> secondSink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> secondSink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(firstSink);
         ChatMessage message = createMessage(10L, "hello");
 
+        // when
         sender.sendMessage(message);
         sender.attachSink(secondSink);
         sender.sendMessage(message);
 
-        verify(firstSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
-        verify(secondSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        // then
+        verify(firstSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(secondSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
     }
 
     @Test
     void sink를_detach하면_추가_메시지가_전송되지_않는다() {
+        // given
         @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.detachSink(sink);
         sender.requestSessionReconnect();
 
+        // then
         verifyNoInteractions(sink);
+    }
+
+    @Test
+    void 채널_멤버십_변경_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        ChannelMembership membership = createManagerMembership(1L, channelId, 100L);
+        int membershipCount = 5;
+
+        ChannelMembershipPayload expectedPayload = ChannelMembershipPayload.from(channelId, membership, membershipCount);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedChannelMembership(channelId, membership, membershipCount);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_멤버십_카운트_변경_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        int membershipCount = 7;
+
+        ChannelMembershipCountPayload expectedPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedMembershipCount(channelId, membershipCount);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_초대_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+
+        ChannelInvitePayload expectedPayload = new ChannelInvitePayload(channelId);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_INVITED_CHANNEL,
+                expectedPayload
+        );
+
+        // when
+        sender.sendInvitedChannel(channelId);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_이름_변경_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        String editedName = "새로운 채널명";
+
+        ChannelNamePayload expectedPayload = new ChannelNamePayload(channelId, editedName);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_NAME_EDITED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendEditedChannelName(channelId, editedName);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_강퇴_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+
+        ChannelKickedPayload expectedPayload = new ChannelKickedPayload(channelId);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_KICKED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendKickedFromChannel(channelId);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_정책_변경_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
+                                                   .updatePublic(false)
+                                                   .updateEditOwnMessage(true)
+                                                   .updateDeleteOwnMessage(false);
+
+        ChannelPolicyPayload expectedPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_POLICY_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedChannelPolicy(channelId, channelPolicy);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 에러_이벤트를_전송한다() {
+        // given
+        @SuppressWarnings("unchecked")
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        String reason = "권한이 없습니다";
+
+        ErrorPayload expectedPayload = new ErrorPayload(channelId, reason);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_ERROR,
+                expectedPayload
+        );
+
+        // when
+        sender.sendError(channelId, reason);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
     }
 
     private ChatMessage createMessage(Long messageId, String content) {
@@ -144,6 +327,23 @@ class WebSocketMessageSenderTest {
                 messageId,
                 content,
                 LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    private ChannelMembership createManagerMembership(Long membershipId, Long channelId, Long userId) {
+        Set<ChannelPermissionType> permissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+        return ChannelMembership.create(
+                membershipId,
+                channelId,
+                userId,
+                ChannelRole.MANAGER,
+                managePermissions,
                 LocalDateTime.now()
         );
     }

--- a/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
@@ -1,12 +1,15 @@
 package com.tok.pekko.application.actor;
 
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
@@ -37,7 +40,13 @@ class ClientSessionActorManagementServiceTest {
         config = ConfigFactory.load();
         testKit = ActorTestKit.create(config);
         actorSystem = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(
+                        Clock.systemDefaultZone(),
+                        mock(MessageStoragePort.class),
+                        mock(ChannelActorStoragePort.class),
+                        mock(ChannelMembershipActorStoragePort.class),
+                        mock(ClientSessionActorManagementService.class)
+                ),
                 "test-system",
                 config
         );

--- a/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/actor/ClientSessionActorManagementServiceTest.java
@@ -44,8 +44,7 @@ class ClientSessionActorManagementServiceTest {
                         Clock.systemDefaultZone(),
                         mock(MessageStoragePort.class),
                         mock(ChannelActorStoragePort.class),
-                        mock(ChannelMembershipActorStoragePort.class),
-                        mock(ClientSessionActorManagementService.class)
+                        mock(ChannelMembershipActorStoragePort.class)
                 ),
                 "test-system",
                 config

--- a/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
@@ -94,7 +94,7 @@ class ChannelMembershipServiceTest {
         // when & then
         assertThatThrownBy(() -> service.inviteMember(2L, 30L, 40L))
                 .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
-                .hasMessage("멤버를 초대할 권한이 없습니다.");
+                .hasMessage("멤버 초대 권한이 없습니다.");
     }
 
     @Test

--- a/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/channel/ChannelMembershipServiceTest.java
@@ -1,132 +1,85 @@
 package com.tok.pekko.application.channel;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.tok.pekko.application.actor.ClientSessionActorManagementService;
-import com.tok.pekko.domain.channel.model.Channel;
-import com.tok.pekko.domain.channel.model.Channel.ChannelMembershipOperationForbiddenException;
-import com.tok.pekko.domain.channel.model.ChannelMembership;
-import com.tok.pekko.domain.channel.model.ChannelRole;
-import com.tok.pekko.domain.channel.model.vo.ChannelId;
-import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
-import com.tok.pekko.domain.channel.port.out.ChannelMembershipStoragePort;
-import com.tok.pekko.domain.channel.port.out.ChannelStoragePort;
-import com.tok.pekko.domain.user.model.vo.UserId;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.AddPermission;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.InviteUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.PromoteToManager;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemovePermission;
+import java.time.Duration;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ChannelMembershipServiceTest {
 
     @Test
-    void 멤버가_채널에_참여한다() {
+    void 멤버가_채널에_참여하면_ChannelEntity에_join을_요청하고_syncJoinChannel을_호출한다() {
         // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        ChannelMembershipStoragePort channelMembershipStoragePort = mock(ChannelMembershipStoragePort.class);
-        Clock clock = Clock.fixed(Instant.parse("2024-03-01T12:30:00Z"), ZoneOffset.UTC);
         ClientSessionActorManagementService clientSessionActorManagementService = mock(ClientSessionActorManagementService.class);
-        ChannelMembershipService service = new ChannelMembershipService(
-                clock,
-                channelStoragePort,
-                channelMembershipStoragePort,
-                clientSessionActorManagementService
-        );
-        Channel channel = Channel.create(
-                "general",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                LocalDateTime.now(clock)
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
+        EntityRef<ChannelEntityCommand> entityRef = mock(EntityRef.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "1"))
+                .thenReturn(entityRef);
+        when(entityRef.ask(any(), any(Duration.class))).thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+        ChannelMembershipService service = new ChannelMembershipService(clusterSharding, clientSessionActorManagementService);
 
         // when
         service.joinChannel(1L, 10L);
 
         // then
-        verify(channelMembershipStoragePort, times(1)).joinChannel(eq(channel.getChannelId()), any(ChannelMembership.class));
         verify(clientSessionActorManagementService, times(1)).syncJoinChannel(1L, 10L);
+        verify(entityRef, times(1)).ask(any(), any(Duration.class));
     }
 
     @Test
-    void 초대_권한이_없는_사용자는_멤버를_초대할_수_없다() {
+    void 멤버를_초대하면_ChannelEntity에_초대_메시지를_보낸다() {
         // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        ChannelMembershipStoragePort channelMembershipStoragePort = mock(ChannelMembershipStoragePort.class);
-        Clock clock = Clock.systemUTC();
         ClientSessionActorManagementService clientSessionActorManagementService = mock(ClientSessionActorManagementService.class);
-        ChannelMembershipService service = new ChannelMembershipService(
-                clock,
-                channelStoragePort,
-                channelMembershipStoragePort,
-                clientSessionActorManagementService
-        );
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(30L),
-                ChannelMembership.create(ChannelId.create(2L), UserId.create(30L), ChannelRole.MEMBER, LocalDateTime.now(clock))
-        );
-        Channel channel = Channel.create(
-                2L,
-                "channel-2",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                LocalDateTime.now(clock)
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(channel));
-
-        // when & then
-        assertThatThrownBy(() -> service.inviteMember(2L, 30L, 40L))
-                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
-                .hasMessage("멤버 초대 권한이 없습니다.");
-    }
-
-    @Test
-    void 오너는_멤버를_초대할_수_있다() {
-        // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        ChannelMembershipStoragePort channelMembershipStoragePort = mock(ChannelMembershipStoragePort.class);
-        ClientSessionActorManagementService clientSessionActorManagementService = mock(ClientSessionActorManagementService.class);
-        Clock clock = Clock.systemUTC();
-        ChannelMembershipService service = new ChannelMembershipService(
-                clock, channelStoragePort, channelMembershipStoragePort, clientSessionActorManagementService);
-
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(30L),
-                ChannelMembership.create(ChannelId.create(2L), UserId.create(30L), ChannelRole.OWNER, LocalDateTime.now(clock))
-        );
-        Channel channel = Channel.create(
-                2L,
-                "channel-2",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                LocalDateTime.now(clock)
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(channel));
+        EntityRef<ChannelEntityCommand> entityRef = Mockito.mock(EntityRef.class);
+        ClusterSharding clusterSharding = Mockito.mock(ClusterSharding.class);
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "2"))
+                .thenReturn(entityRef);
+        ChannelMembershipService service = new ChannelMembershipService(clusterSharding, clientSessionActorManagementService);
 
         // when
         service.inviteMember(2L, 30L, 40L);
 
         // then
-        verify(channelMembershipStoragePort, times(1)).joinChannel(eq(channel.getChannelId()), any(ChannelMembership.class));
-        verify(clientSessionActorManagementService, times(1)).syncJoinChannel(2L, 40L);
+        verify(entityRef, times(1)).tell(any(InviteUser.class));
+    }
+
+    @Test
+    void 승격과_권한_부여_메시지가_ChannelEntity로_전파된다() {
+        // given
+        ClientSessionActorManagementService clientSessionActorManagementService = mock(ClientSessionActorManagementService.class);
+        EntityRef<ChannelEntityCommand> entityRef = Mockito.mock(EntityRef.class);
+        ClusterSharding clusterSharding = Mockito.mock(ClusterSharding.class);
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "3"))
+                .thenReturn(entityRef);
+        ChannelMembershipService service = new ChannelMembershipService(clusterSharding, clientSessionActorManagementService);
+
+        // when
+        service.promoteToManager(3L, 1L, 2L);
+        service.addPermission(3L, 1L, 2L, ChannelPermissionType.MEMBER_INVITE);
+        service.removePermission(3L, 1L, 2L, ChannelPermissionType.MEMBER_INVITE);
+
+        // then
+        verify(entityRef, times(1)).tell(any(PromoteToManager.class));
+        verify(entityRef, times(1)).tell(any(AddPermission.class));
+        verify(entityRef, times(1)).tell(any(RemovePermission.class));
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/application/channel/ChannelServiceTest.java
+++ b/pekko/src/test/java/com/tok/pekko/application/channel/ChannelServiceTest.java
@@ -1,259 +1,120 @@
 package com.tok.pekko.application.channel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.tok.pekko.domain.channel.model.Channel;
-import com.tok.pekko.domain.channel.model.Channel.ChannelOperationForbiddenException;
-import com.tok.pekko.domain.channel.model.ChannelMembership;
-import com.tok.pekko.domain.channel.model.ChannelRole;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.channel.port.out.ChannelStoragePort;
-import com.tok.pekko.domain.user.model.vo.UserId;
-import java.time.Clock;
+import com.tok.pekko.domain.chat.actor.ChannelEntity;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.EditChannelName;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ChannelServiceTest {
 
     @Test
-    void 채널을_생성하면_식별자를_반환한다() {
-        // given
+    void 채널을_생성하면_스토리지에_저장한다() {
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
-        ChannelService channelService = new ChannelService(channelStoragePort);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        doAnswer(invocation -> {
+            channelStoragePort.delete(ChannelId.create(10L));
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
+        ChannelService channelService = new ChannelService(clusterSharding, channelStoragePort, transactionTemplate);
+
         Channel storedChannel = Channel.create(
-                99L,
+                1L,
                 "general",
                 1L,
                 ChannelPolicy.defaultPolicy(),
                 new HashMap<>(),
-                LocalDateTime.now(clock)
+                LocalDateTime.ofInstant(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
         );
         when(channelStoragePort.store(any(Channel.class))).thenReturn(storedChannel);
 
-        // when
-        ChannelId actual = channelService.createChannel("general", 1L);
+        channelService.createChannel("general", 1L);
 
-        // then
-        assertThat(actual).isEqualTo(storedChannel.getChannelId());
-
-        ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
-        verify(channelStoragePort).store(channelCaptor.capture());
-        Channel savedChannel = channelCaptor.getValue();
-
-        assertAll(
-                () -> assertThat(savedChannel.getName()).isEqualTo("general"),
-                () -> assertThat(savedChannel.getCreatorId()).isEqualTo(UserId.create(1L)),
-                () -> assertThat(savedChannel.getChannelPolicy()).isEqualTo(ChannelPolicy.defaultPolicy())
-        );
+        verify(channelStoragePort, times(1)).store(any(Channel.class));
     }
 
     @Test
-    void 권한이_없으면_채널을_삭제할_수_없다() {
-        // given
+    void 채널_삭제시_스토리지_삭제와_Actor_Shutdown을_전파한다() {
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(20L),
-                ChannelMembership.create(ChannelId.create(10L), UserId.create(20L), ChannelRole.MEMBER, createdAt)
-        );
-        Channel channel = Channel.create(
-                10L,
-                "channel-10",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        EntityRef<ChannelEntityCommand> channelEntityRef = Mockito.mock(EntityRef.class);
+        EntityRef<ChannelEventHandlerCommand> handlerRef = Mockito.mock(EntityRef.class);
+
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "10"))
+                .thenReturn(channelEntityRef);
+        when(clusterSharding.<ChannelEventHandlerCommand>entityRefFor(ChannelEventHandlerEntity.ENTITY_TYPE_KEY, "10"))
+                .thenReturn(handlerRef);
+        ChannelService channelService = new ChannelService(clusterSharding, channelStoragePort, transactionTemplate);
+        Channel channel = mock(Channel.class);
+        when(channel.getChannelId()).thenReturn(ChannelId.create(10L));
+        doAnswer(invocation -> null).when(channel).validateDeleteChannel(any());
         when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
 
-        // when & then
-        assertThatThrownBy(() -> channelService.deleteChannel(10L, 20L))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널을 삭제할 권한이 없습니다.");
-
-        verify(channelStoragePort, never()).delete(any(ChannelId.class));
-    }
-
-    @Test
-    void 권한이_있으면_채널을_삭제한다() {
-        // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(20L),
-                ChannelMembership.create(ChannelId.create(10L), UserId.create(20L), ChannelRole.OWNER, createdAt)
-        );
-        Channel channel = Channel.create(
-                10L,
-                "channel-10",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
-
-        // when
         channelService.deleteChannel(10L, 20L);
 
-        // then
-        verify(channelStoragePort).delete(channel.getChannelId());
+        verify(transactionTemplate, times(1)).executeWithoutResult(any());
+        verify(channelEntityRef, times(1)).tell(any(ChannelProtocol.Shutdown.class));
+        verify(handlerRef, times(1)).tell(any(ChannelEventHandlerProtocol.Shutdown.class));
     }
 
     @Test
-    void 권한이_없으면_채널_정책을_변경할_수_없다() {
-        // given
+    void 정책_변경은_ChannelEntity에_ChangeChannelPolicy를_전파한다() {
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(30L),
-                ChannelMembership.create(ChannelId.create(10L), UserId.create(30L), ChannelRole.MEMBER, createdAt)
-        );
-        Channel channel = Channel.create(
-                10L,
-                "channel-10",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        EntityRef<ChannelEntityCommand> channelEntityRef = Mockito.mock(EntityRef.class);
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "5"))
+                .thenReturn(channelEntityRef);
+        ChannelService channelService = new ChannelService(clusterSharding, channelStoragePort, transactionTemplate);
 
-        // when & then
-        assertThatThrownBy(() -> channelService.changeChannelPolicy(10L, 30L, true, false, true))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널 정책을 변경할 권한이 없습니다.");
+        channelService.changeChannelPolicy(5L, 30L, false, true, false);
 
-        verify(channelStoragePort, never()).update(any(Channel.class));
+        verify(channelEntityRef, times(1)).tell(any(ChangeChannelPolicy.class));
     }
 
     @Test
-    void 권한이_있으면_채널_정책을_변경한다() {
-        // given
+    void 이름_변경은_ChannelEntity에_EditChannelName을_전파한다() {
         ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(30L),
-                ChannelMembership.create(ChannelId.create(10L), UserId.create(30L), ChannelRole.OWNER, createdAt)
-        );
-        Channel channel = Channel.create(
-                10L,
-                "channel-10",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        EntityRef<ChannelEntityCommand> channelEntityRef = Mockito.mock(EntityRef.class);
+        when(clusterSharding.<ChannelEntityCommand>entityRefFor(ChannelEntity.ENTITY_TYPE_KEY, "7"))
+                .thenReturn(channelEntityRef);
+        ChannelService channelService = new ChannelService(clusterSharding, channelStoragePort, transactionTemplate);
 
-        // when
-        channelService.changeChannelPolicy(10L, 30L, false, true, false);
+        channelService.editChannelName(7L, 50L, "new-name");
 
-        // then
-        ArgumentCaptor<Channel> updatedCaptor = ArgumentCaptor.forClass(Channel.class);
-        verify(channelStoragePort).update(updatedCaptor.capture());
-        Channel updatedChannel = updatedCaptor.getValue();
-
-        ChannelPolicy policy = updatedChannel.getChannelPolicy();
-        assertAll(
-                () -> assertThat(policy.canEditOwnMessage()).isFalse(),
-                () -> assertThat(policy.canDeleteOwnMessage()).isTrue(),
-                () -> assertThat(policy.isPublic()).isFalse()
-        );
-    }
-
-    @Test
-    void 권한이_없으면_채널_이름을_변경할_수_없다() {
-        // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(40L),
-                ChannelMembership.create(ChannelId.create(11L), UserId.create(40L), ChannelRole.MEMBER, createdAt)
-        );
-        Channel channel = Channel.create(
-                11L,
-                "channel-11",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
-
-        // when & then
-        assertThatThrownBy(() -> channelService.changeChannelName(11L, 40L, "new-name"))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널 이름을 변경할 권한이 없습니다.");
-
-        verify(channelStoragePort, never()).update(any(Channel.class));
-    }
-
-    @Test
-    void 권한이_있으면_채널_이름을_변경한다() {
-        // given
-        ChannelStoragePort channelStoragePort = mock(ChannelStoragePort.class);
-        Clock clock = Clock.systemUTC();
-        ChannelService channelService = new ChannelService(channelStoragePort);
-        LocalDateTime createdAt = LocalDateTime.now(clock);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(
-                UserId.create(40L),
-                ChannelMembership.create(ChannelId.create(11L), UserId.create(40L), ChannelRole.OWNER, createdAt)
-        );
-        Channel channel = Channel.create(
-                11L,
-                "channel-11",
-                1L,
-                ChannelPolicy.defaultPolicy(),
-                memberships,
-                createdAt
-        );
-        when(channelStoragePort.findChannel(anyLong(), anyLong())).thenReturn(Optional.of(channel));
-
-        // when
-        channelService.changeChannelName(11L, 40L, "new-name");
-
-        // then
-        ArgumentCaptor<Channel> captor = ArgumentCaptor.forClass(Channel.class);
-        verify(channelStoragePort).update(captor.capture());
-        Channel updatedChannel = captor.getValue();
-
-        assertThat(updatedChannel.getName()).isEqualTo("new-name");
+        verify(channelEntityRef, times(1)).tell(any(EditChannelName.class));
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
 import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
@@ -269,5 +270,610 @@ class ChannelMembershipTest {
                 () -> assertThat(demotedMembership.getJoinedAt()).isEqualTo(joinedAt),
                 () -> assertThat(demotedMembership.getPermissions().isEmpty()).isTrue()
         );
+    }
+
+    @Test
+    void 오너는_항상_모든_권한을_가진다() {
+        // given
+        ChannelId channelId = ChannelId.create(10L);
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership ownerMembership = ChannelMembership.create(channelId, userId, role, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(ownerMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue(),
+                () -> assertThat(ownerMembership.hasPermission(ChannelPermissionType.EDIT_CHANNEL_NAME)).isTrue(),
+                () -> assertThat(ownerMembership.hasPermission(ChannelPermissionType.MEMBER_INVITE)).isTrue(),
+                () -> assertThat(ownerMembership.hasPermission(ChannelPermissionType.MESSAGE_DELETE)).isTrue()
+        );
+    }
+
+    @Test
+    void 매니저는_부여된_권한만_가진다() {
+        // given
+        ChannelId channelId = ChannelId.create(10L);
+        UserId userId = UserId.create(1L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+
+        ChannelMembership managerMembership = ChannelMembership.createManager(channelId, userId, permissions, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(managerMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isFalse()
+        );
+    }
+
+    @Test
+    void 멤버는_어떤_관리_권한도_가지지_않는다() {
+        // given
+        ChannelId channelId = ChannelId.create(10L);
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.MEMBER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership memberMembership = ChannelMembership.create(channelId, userId, role, joinedAt);
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isFalse(),
+                () -> assertThat(memberMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isFalse(),
+                () -> assertThat(memberMembership.hasPermission(ChannelPermissionType.EDIT_CHANNEL_NAME)).isFalse()
+        );
+    }
+
+    @Test
+    void 오너는_권한이_없는_상태를_확인할_수_없다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertThat(ownerMembership.lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isFalse();
+    }
+
+    @Test
+    void 매니저는_부여되지_않은_권한이_없음을_확인할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isFalse(),
+                () -> assertThat(managerMembership.lacksPermission(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_모든_관리_권한이_없음을_확인할_수_있다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(memberMembership.lacksPermission(ChannelPermissionType.MEMBER_KICK)).isTrue(),
+                () -> assertThat(memberMembership.lacksPermission(ChannelPermissionType.EDIT_CHANNEL_NAME)).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_채널_이름을_수정할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertThat(ownerMembership.canEditChannelName()).isTrue();
+    }
+
+    @Test
+    void 채널_이름_수정_권한이_있는_매니저는_채널_이름을_수정할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.EDIT_CHANNEL_NAME);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertThat(managerMembership.canEditChannelName()).isTrue();
+    }
+
+    @Test
+    void 채널_이름_수정_권한이_없는_매니저는_채널_이름을_수정할_수_없다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canEditChannelName()).isFalse(),
+                () -> assertThat(managerMembership.cannotEditChannelName()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_채널_이름을_수정할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canEditChannelName()).isFalse(),
+                () -> assertThat(memberMembership.cannotEditChannelName()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_멤버를_강퇴할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertThat(ownerMembership.canKickMember()).isTrue();
+    }
+
+    @Test
+    void 멤버_강퇴_권한이_있는_매니저는_멤버를_강퇴할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MEMBER_KICK);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertThat(managerMembership.canKickMember()).isTrue();
+    }
+
+    @Test
+    void 멤버_강퇴_권한이_없는_매니저는_멤버를_강퇴할_수_없다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canKickMember()).isFalse(),
+                () -> assertThat(managerMembership.cannotKickMember()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_다른_멤버를_강퇴할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canKickMember()).isFalse(),
+                () -> assertThat(memberMembership.cannotKickMember()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_메시지를_삭제할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(ownerMembership.canDeleteMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 메시지_삭제_권한이_있는_매니저는_메시지를_삭제할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_DELETE);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(managerMembership.canDeleteMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 메시지_삭제_권한이_없는_매니저는_메시지를_삭제할_수_없다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(managerMembership.canDeleteMessage(policy)).isFalse();
+    }
+
+    @Test
+    void 채널_정책이_허용하면_멤버는_자신의_메시지를_삭제할_수_있다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+
+        // when & then
+        assertThat(memberMembership.canDeleteMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 채널_정책이_허용하지_않으면_멤버는_자신의_메시지를_삭제할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(memberMembership.canDeleteMessage(policy)).isFalse();
+    }
+
+    @Test
+    void 오너는_메시지를_수정할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(ownerMembership.canEditMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 메시지_수정_권한이_있는_매니저는_메시지를_수정할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(managerMembership.canEditMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 메시지_수정_권한이_없는_매니저는_메시지를_수정할_수_없다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MEMBER_KICK);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(managerMembership.canEditMessage(policy)).isFalse();
+    }
+
+    @Test
+    void 채널_정책이_허용하면_멤버는_자신의_메시지를_수정할_수_있다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+
+        // when & then
+        assertThat(memberMembership.canEditMessage(policy)).isTrue();
+    }
+
+    @Test
+    void 채널_정책이_허용하지_않으면_멤버는_자신의_메시지를_수정할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy()
+                                            .updatePublic(false)
+                                            .updateDeleteOwnMessage(false)
+                                            .updateEditOwnMessage(false);
+
+        // when & then
+        assertThat(memberMembership.canEditMessage(policy)).isFalse();
+    }
+
+    @Test
+    void 오너는_멤버를_초대할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertThat(ownerMembership.canInviteMember()).isTrue();
+    }
+
+    @Test
+    void 멤버_초대_권한이_있는_매니저는_멤버를_초대할_수_있다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MEMBER_INVITE);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertThat(managerMembership.canInviteMember()).isTrue();
+    }
+
+    @Test
+    void 멤버_초대_권한이_없는_매니저는_멤버를_초대할_수_없다() {
+        // given
+        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
+        ChannelMembership managerMembership = ChannelMembership.createManager(
+                ChannelId.create(10L), UserId.create(1L), permissions, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canInviteMember()).isFalse(),
+                () -> assertThat(managerMembership.cannotInviteMember()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_다른_멤버를_초대할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canInviteMember()).isFalse(),
+                () -> assertThat(memberMembership.cannotInviteMember()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_역할을_관리할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.canManageRole()).isTrue(),
+                () -> assertThat(ownerMembership.cannotManageRole()).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_역할을_관리할_수_없다() {
+        // given
+        ChannelMembership managerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MANAGER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canManageRole()).isFalse(),
+                () -> assertThat(managerMembership.cannotManageRole()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_역할을_관리할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canManageRole()).isFalse(),
+                () -> assertThat(memberMembership.cannotManageRole()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_권한을_관리할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.canManagePermission()).isTrue(),
+                () -> assertThat(ownerMembership.cannotManagePermission()).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_권한을_관리할_수_없다() {
+        // given
+        ChannelMembership managerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MANAGER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canManagePermission()).isFalse(),
+                () -> assertThat(managerMembership.cannotManagePermission()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_권한을_관리할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canManagePermission()).isFalse(),
+                () -> assertThat(memberMembership.cannotManagePermission()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_채널을_삭제할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.canDeleteChannel()).isTrue(),
+                () -> assertThat(ownerMembership.cannotDeleteChannel()).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_채널을_삭제할_수_없다() {
+        // given
+        ChannelMembership managerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MANAGER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canDeleteChannel()).isFalse(),
+                () -> assertThat(managerMembership.cannotDeleteChannel()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_채널을_삭제할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canDeleteChannel()).isFalse(),
+                () -> assertThat(memberMembership.cannotDeleteChannel()).isTrue()
+        );
+    }
+
+    @Test
+    void 오너는_채널_정책을_변경할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.canChangeChannelPolicy()).isTrue(),
+                () -> assertThat(ownerMembership.cannotChangeChannelPolicy()).isFalse()
+        );
+    }
+
+    @Test
+    void 매니저는_채널_정책을_변경할_수_없다() {
+        // given
+        ChannelMembership managerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MANAGER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.canChangeChannelPolicy()).isFalse(),
+                () -> assertThat(managerMembership.cannotChangeChannelPolicy()).isTrue()
+        );
+    }
+
+    @Test
+    void 멤버는_채널_정책을_변경할_수_없다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.canChangeChannelPolicy()).isFalse(),
+                () -> assertThat(memberMembership.cannotChangeChannelPolicy()).isTrue()
+        );
+    }
+
+    @Test
+    void 역할이_매니저인지_확인할_수_있다() {
+        // given
+        ChannelMembership managerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MANAGER, LocalDateTime.now());
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(2L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(managerMembership.isManager()).isTrue(),
+                () -> assertThat(ownerMembership.isManager()).isFalse()
+        );
+    }
+
+    @Test
+    void 역할이_멤버인지_확인할_수_있다() {
+        // given
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(2L), ChannelRole.OWNER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(memberMembership.isMember()).isTrue(),
+                () -> assertThat(ownerMembership.isMember()).isFalse()
+        );
+    }
+
+    @Test
+    void 역할이_오너인지_확인할_수_있다() {
+        // given
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(1L), ChannelRole.OWNER, LocalDateTime.now());
+        ChannelMembership memberMembership = ChannelMembership.create(
+                ChannelId.create(10L), UserId.create(2L), ChannelRole.MEMBER, LocalDateTime.now());
+
+        // when & then
+        assertAll(
+                () -> assertThat(ownerMembership.isOwner()).isTrue(),
+                () -> assertThat(memberMembership.isOwner()).isFalse()
+        );
+    }
+
+    @Test
+    void 오너에게는_권한을_업데이트할_수_없다() {
+        // given
+        ChannelId channelId = ChannelId.create(10L);
+        UserId userId = UserId.create(1L);
+        ChannelRole role = ChannelRole.OWNER;
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        ChannelMembership ownerMembership = ChannelMembership.create(channelId, userId, role, joinedAt);
+        ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager();
+
+        // when & then
+        assertThatThrownBy(() -> ownerMembership.updatePermissions(newPermissions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
@@ -1,14 +1,11 @@
 package com.tok.pekko.domain.channel.model;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
+import com.tok.pekko.domain.channel.model.Channel.ChannelMembershipNotFoundException;
+import com.tok.pekko.domain.channel.model.Channel.ChannelMembershipOperationForbiddenException;
 import com.tok.pekko.domain.channel.model.Channel.ChannelOperationForbiddenException;
-import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
@@ -21,6 +18,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ChannelTest {
@@ -30,171 +32,78 @@ class ChannelTest {
         // given
         String name = "general";
         Long creatorId = 1L;
-        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy();
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
         LocalDateTime createdAt = LocalDateTime.now();
 
         // when
-        Channel channel = Channel.create(name, creatorId, channelPolicy, createdAt);
+        Channel channel = Channel.create(name, creatorId, policy, createdAt);
 
         // then
         assertAll(
                 () -> assertThat(channel).isNotNull(),
                 () -> assertThat(channel.getName()).isEqualTo(name),
                 () -> assertThat(channel.getCreatorId()).isEqualTo(UserId.create(creatorId)),
-                () -> assertThat(channel.getChannelPolicy()).isEqualTo(channelPolicy),
-                () -> assertThat(channel.getCreatedAt()).isEqualTo(createdAt),
-                () -> assertThat(channel.getMemberships()).isEmpty()
+                () -> assertThat(channel.getChannelPolicy()).isEqualTo(policy),
+                () -> assertThat(channel.getMemberships()).isEmpty(),
+                () -> assertThat(channel.getCreatedAt()).isEqualTo(createdAt)
         );
     }
 
     @ParameterizedTest(name = "{0}일 때 초기화에 실패한다")
     @NullAndEmptySource
     void 유효하지_않은_채널_이름으로는_초기화할_수_없다(String name) {
+        // given
+        Long creatorId = 1L;
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        LocalDateTime createdAt = LocalDateTime.now();
+
         // when & then
-        assertThatThrownBy(() -> Channel.create(name, 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now()))
+        assertThatThrownBy(() -> Channel.create(name, creatorId, policy, createdAt))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("채널 이름은 필수입니다.");
     }
 
     @Test
-    void 채널을_초기화한다() {
+    void 영속화된_채널을_초기화할_수_있다() {
         // given
         Long channelId = 1L;
         String name = "general";
         Long creatorId = 1L;
-        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy();
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
         LocalDateTime createdAt = LocalDateTime.now();
 
         // when
-        Channel channel = Channel.create(channelId, name, creatorId, channelPolicy, memberships, createdAt);
+        Channel channel = Channel.create(channelId, name, creatorId, policy, memberships, createdAt);
 
         // then
         assertAll(
                 () -> assertThat(channel).isNotNull(),
-                () -> assertThat(channel.getChannelId()).isEqualTo(ChannelId.create(channelId)),
+                () -> assertThat(channel.getChannelId().getValue()).isEqualTo(channelId),
                 () -> assertThat(channel.getName()).isEqualTo(name),
                 () -> assertThat(channel.getCreatorId()).isEqualTo(UserId.create(creatorId))
         );
     }
 
     @Test
-    void 채널_ID를_할당할_수_있다() {
+    void 채널에_ID를_할당할_수_있다() {
         // given
-        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
-        Long assignedId = 10L;
+        String name = "general";
+        Long creatorId = 1L;
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        LocalDateTime createdAt = LocalDateTime.now();
+        Channel channel = Channel.create(name, creatorId, policy, createdAt);
+        Long assignedId = 100L;
 
         // when
-        Channel assignedChannel = channel.withAssignedId(assignedId);
+        Channel channelWithId = channel.withAssignedId(assignedId);
 
         // then
         assertAll(
-                () -> assertThat(assignedChannel.getChannelId()).isEqualTo(ChannelId.create(assignedId)),
-                () -> assertThat(assignedChannel.getName()).isEqualTo(channel.getName()),
-                () -> assertThat(assignedChannel.getCreatorId()).isEqualTo(channel.getCreatorId())
+                () -> assertThat(channelWithId.getChannelId().getValue()).isEqualTo(assignedId),
+                () -> assertThat(channelWithId.getName()).isEqualTo(name),
+                () -> assertThat(channelWithId.getCreatorId()).isEqualTo(UserId.create(creatorId))
         );
-    }
-
-    @Test
-    void 채널의_공개_여부를_확인할_수_있다() {
-        // given
-        Channel publicChannel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
-        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
-        Channel privateChannel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
-
-        // when & then
-        assertAll(
-                () -> assertThat(publicChannel.isPublic()).isTrue(),
-                () -> assertThat(privateChannel.isPublic()).isFalse()
-        );
-    }
-
-    @Test
-    void 공개_채널에_멤버가_참여할_수_있다() {
-        // given
-        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
-        UserId userId = UserId.create(2L);
-
-        // when & then
-        assertDoesNotThrow(() -> channel.validateJoinMember(userId));
-    }
-
-    @Test
-    void 비공개_채널에는_직접_참여할_수_없다() {
-        // given
-        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
-        Channel channel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
-        UserId userId = UserId.create(2L);
-
-        // when & then
-        assertThatThrownBy(() -> channel.validateJoinMember(userId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
-    }
-
-    @Test
-    void 이미_참여한_멤버는_다시_참여할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId userId = UserId.create(2L);
-        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.validateJoinMember(userId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 채널에 참여한 사용자입니다.");
-    }
-
-    @Test
-    void 초대_권한이_있는_사용자는_멤버를_초대할_수_있다() {
-        // given
-        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId inviterId = UserId.create(2L);
-        memberships.put(inviterId, ChannelMembership.create(ChannelId.create(1L), inviterId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "private", 1L, privatePolicy, memberships, createdAt);
-        UserId inviteeId = UserId.create(3L);
-
-        // when & then
-        assertDoesNotThrow(() -> channel.validateInviteMember(inviterId, inviteeId));
-    }
-
-    @Test
-    void 초대_권한이_없는_사용자는_멤버를_초대할_수_없다() {
-        // given
-        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId inviterId = UserId.create(2L);
-        memberships.put(inviterId, ChannelMembership.create(ChannelId.create(1L), inviterId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "private", 1L, privatePolicy, memberships, createdAt);
-        UserId inviteeId = UserId.create(3L);
-
-        // when & then
-        assertThatThrownBy(() -> channel.validateInviteMember(inviterId, inviteeId))
-                .isInstanceOf(Channel.ChannelMembershipOperationForbiddenException.class)
-                .hasMessage("멤버를 초대할 권한이 없습니다.");
-    }
-
-    @Test
-    void 초대된_멤버도_중복으로_초대할_수_없다() {
-        // given
-        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId inviterId = UserId.create(2L);
-        UserId inviteeId = UserId.create(3L);
-        memberships.put(inviterId, ChannelMembership.create(ChannelId.create(1L), inviterId, ChannelRole.OWNER, createdAt));
-        memberships.put(inviteeId, ChannelMembership.create(ChannelId.create(1L), inviteeId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "private", 1L, privatePolicy, memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.validateInviteMember(inviterId, inviteeId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 채널에 참여한 사용자입니다.");
     }
 
     @Test
@@ -202,17 +111,27 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId memberId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership targetMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(memberId, targetMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when
-        ChannelMembership promoted = channel.promoteToManager(executorId, targetUserId);
+        ChannelMembership promotedMembership = channel.promoteToManager(ownerId, memberId);
 
         // then
-        assertThat(promoted.isManager()).isTrue();
+        assertAll(
+                () -> assertThat(promotedMembership).isNotNull(),
+                () -> assertThat(promotedMembership.getRole()).isEqualTo(ChannelRole.MANAGER)
+        );
     }
 
     @Test
@@ -220,16 +139,44 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MEMBER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        UserId targetMemberId = UserId.create(3L);
+
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        ChannelMembership targetMembership = ChannelMembership.create(3L, 1L, targetMemberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(memberId, memberMembership);
+        memberships.put(targetMemberId, targetMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.promoteToManager(executorId, targetUserId))
-                .isInstanceOf(Channel.ChannelMembershipOperationForbiddenException.class)
-                .hasMessage("멤버의 역할을 변경할 권한이 없습니다.");
+        assertThatThrownBy(() -> channel.promoteToManager(memberId, targetMemberId))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("역할을 변경할 권한이 없습니다.");
+    }
+
+    @Test
+    void 채널에_참여하지_않은_사용자는_멤버를_승격할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId nonMemberId = UserId.create(999L);
+        UserId targetMemberId = UserId.create(3L);
+
+        ChannelMembership targetMembership = ChannelMembership.create(3L, 1L, targetMemberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(targetMemberId, targetMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.promoteToManager(nonMemberId, targetMemberId))
+                .isInstanceOf(ChannelMembershipNotFoundException.class)
+                .hasMessage("채널 멤버를 찾을 수 없습니다.");
     }
 
     @Test
@@ -237,32 +184,20 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId nonExistentMemberId = UserId.create(999L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.promoteToManager(executorId, targetUserId))
-                .isInstanceOf(Channel.ChannelMembershipNotFoundException.class)
+        assertThatThrownBy(() -> channel.promoteToManager(ownerId, nonExistentMemberId))
+                .isInstanceOf(ChannelMembershipNotFoundException.class)
                 .hasMessage("채널 멤버를 찾을 수 없습니다.");
-    }
-
-    @Test
-    void 이미_매니저인_멤버는_승격할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MANAGER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.promoteToManager(executorId, targetUserId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 매니저입니다.");
     }
 
     @Test
@@ -270,16 +205,43 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.promoteToManager(executorId, targetUserId))
+        assertThatThrownBy(() -> channel.promoteToManager(ownerId, ownerId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("오너를 매니저로 강등시킬 수 없습니다.");
+                .hasMessage("채널 오너를 매니저로 강등할 수 없습니다.");
+    }
+
+    @Test
+    void 이미_매니저인_멤버를_승격할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.promoteToManager(ownerId, managerId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 매니저입니다.");
     }
 
     @Test
@@ -287,51 +249,51 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MANAGER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when
-        ChannelMembership demoted = channel.demoteToMember(executorId, targetUserId);
+        ChannelMembership demotedMembership = channel.demoteToMember(ownerId, managerId);
 
         // then
-        assertThat(demoted.isMember()).isTrue();
+        assertAll(
+                () -> assertThat(demotedMembership).isNotNull(),
+                () -> assertThat(demotedMembership.getRole()).isEqualTo(ChannelRole.MEMBER)
+        );
     }
 
     @Test
-    void 권한이_없는_사용자는_멤버를_강등할_수_없다() {
+    void 권한이_없는_사용자는_매니저를_강등할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MEMBER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MANAGER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        UserId managerId = UserId.create(3L);
+
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(3L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(memberId, memberMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.demoteToMember(executorId, targetUserId))
-                .isInstanceOf(Channel.ChannelMembershipOperationForbiddenException.class)
-                .hasMessage("멤버의 역할을 변경할 권한이 없습니다.");
-    }
-
-    @Test
-    void 이미_멤버인_경우_강등할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.demoteToMember(executorId, targetUserId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 멤버입니다.");
+        assertThatThrownBy(() -> channel.demoteToMember(memberId, managerId))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("역할을 변경할 권한이 없습니다.");
     }
 
     @Test
@@ -339,32 +301,43 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.demoteToMember(executorId, targetUserId))
+        assertThatThrownBy(() -> channel.demoteToMember(ownerId, ownerId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("오너를 멤버로 강등시킬 수 없습니다.");
+                .hasMessage("채널 오너를 멤버로 강등시킬 수 없습니다.");
     }
 
     @Test
-    void 존재하지_않는_멤버를_강등할_수_없다() {
+    void 이미_멤버인_사용자를_강등할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId memberId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.demoteToMember(executorId, targetUserId))
-                .isInstanceOf(Channel.ChannelMembershipNotFoundException.class)
-                .hasMessage("채널 멤버를 찾을 수 없습니다.");
+        assertThatThrownBy(() -> channel.demoteToMember(ownerId, memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 멤버입니다.");
     }
 
     @Test
@@ -372,14 +345,28 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.OWNER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(ChannelId.create(1L), granteeId, ChannelRole.MANAGER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
-        // when & then
-        assertDoesNotThrow(() -> channel.getValidatedAddTarget(grantorId, granteeId, ChannelPermissionType.MEMBER_KICK));
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when
+        ChannelMembership updatedMembership = channel.addPermission(ownerId, managerId, ChannelPermissionType.MEMBER_KICK);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedMembership).isNotNull(),
+                () -> assertThat(updatedMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
     }
 
     @Test
@@ -387,31 +374,45 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.MEMBER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(ChannelId.create(1L), granteeId, ChannelRole.MANAGER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        UserId managerId = UserId.create(3L);
+
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(3L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(memberId, memberMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedAddTarget(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT))
-                .isInstanceOf(Channel.ChannelMembershipOperationForbiddenException.class)
+        assertThatThrownBy(() -> channel.addPermission(memberId, managerId, ChannelPermissionType.MEMBER_KICK))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
                 .hasMessage("매니저의 권한을 추가할 권한이 없습니다.");
     }
 
     @Test
-    void 멤버에게_권한을_추가할_수_없다() {
+    void 매니저가_아닌_멤버에게는_권한을_추가할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.OWNER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(ChannelId.create(1L), granteeId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId memberId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedAddTarget(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT))
+        assertThatThrownBy(() -> channel.addPermission(ownerId, memberId, ChannelPermissionType.MEMBER_KICK))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 멤버는 매니저가 아닙니다.");
     }
@@ -421,53 +422,76 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MEMBER_KICK);
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.OWNER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(1L, 1L, granteeId.getValue(), ChannelRole.MANAGER, permissions, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT, ChannelPermissionType.MEMBER_KICK);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedAddTarget(grantorId, granteeId, ChannelPermissionType.MEMBER_KICK))
+        assertThatThrownBy(() -> channel.addPermission(ownerId, managerId, ChannelPermissionType.MEMBER_KICK))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이미 해당 권한을 가지고 있습니다.");
     }
 
     @Test
-    void 오너는_매니저에게서_권한을_제거할_수_있다() {
+    void 오너는_매니저의_권한을_제거할_수_있다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.OWNER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(1L, 1L, granteeId.getValue(), ChannelRole.MANAGER, permissions, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
-        // when & then
-        assertDoesNotThrow(() -> channel.getValidatedRemoveTarget(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT));
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT, ChannelPermissionType.MEMBER_KICK);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when
+        ChannelMembership updatedMembership = channel.removePermission(ownerId, managerId, ChannelPermissionType.MEMBER_KICK);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedMembership).isNotNull(),
+                () -> assertThat(updatedMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isFalse()
+        );
     }
 
     @Test
-    void 권한이_없는_사용자는_매니저에게서_권한을_제거할_수_없다() {
+    void 권한이_없는_사용자는_매니저의_권한을_제거할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        Set<ChannelPermissionType> perms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.MEMBER, createdAt));
-        memberships.put(granteeId, ChannelMembership.create(1L, 1L, granteeId.getValue(), ChannelRole.MANAGER, permissions, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        UserId managerId = UserId.create(3L);
+
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(3L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(memberId, memberMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedRemoveTarget(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT))
-                .isInstanceOf(Channel.ChannelMembershipOperationForbiddenException.class)
+        assertThatThrownBy(() -> channel.removePermission(memberId, managerId, ChannelPermissionType.MEMBER_KICK))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
                 .hasMessage("매니저의 권한을 추가할 권한이 없습니다.");
     }
 
@@ -476,37 +500,315 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId grantorId = UserId.create(2L);
-        UserId granteeId = UserId.create(3L);
-        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.OWNER, createdAt));
 
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager();
-        memberships.put(granteeId, ChannelMembership.create(1L, 1L, granteeId.getValue(), ChannelRole.MANAGER, permissions, createdAt));
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
 
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedRemoveTarget(grantorId, granteeId, ChannelPermissionType.MEMBER_INVITE))
+        assertThatThrownBy(() -> channel.removePermission(ownerId, managerId, ChannelPermissionType.MEMBER_KICK))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 권한을 가지고 있지 않습니다.");
     }
 
     @Test
-    void 멤버를_채널에서_제거할_수_있다() {
+    void 오너는_채널을_삭제할_수_있다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId userId = UserId.create(2L);
-        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertDoesNotThrow(() -> channel.validateDeleteChannel(ownerId));
+    }
+
+    @Test
+    void 오너가_아니면_채널을_삭제할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateDeleteChannel(memberId))
+                .isInstanceOf(ChannelOperationForbiddenException.class)
+                .hasMessage("채널을 삭제할 권한이 없습니다.");
+    }
+
+    @Test
+    void 오너는_채널_이름을_변경할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId ownerId = UserId.create(1L);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+        String newName = "new-channel";
 
         // when
-        ChannelMembership actual = channel.getValidatedLeaveMember(userId);
+        Channel editedChannel = channel.editName(ownerId, newName);
+
+        // then
+        assertThat(editedChannel.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    void 채널_이름_변경_권한이_있는_매니저는_채널_이름을_변경할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId managerId = UserId.create(2L);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.EDIT_CHANNEL_NAME);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+        String newName = "new-channel";
+
+        // when
+        Channel editedChannel = channel.editName(managerId, newName);
+
+        // then
+        assertThat(editedChannel.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    void 권한이_없는_사용자는_채널_이름을_변경할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.editName(memberId, "new-channel"))
+                .isInstanceOf(ChannelOperationForbiddenException.class)
+                .hasMessage("채널 이름을 변경할 권한이 없습니다.");
+    }
+
+    @Test
+    void 오너는_채널_정책을_변경할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId ownerId = UserId.create(1L);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy oldPolicy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, oldPolicy, memberships, createdAt);
+
+        ChannelPolicy newPolicy = ChannelPolicy.defaultPolicy().updatePublic(false);
+
+        // when
+        Channel updatedChannel = channel.changeChannelPolicy(ownerId, newPolicy);
+
+        // then
+        assertThat(updatedChannel.getChannelPolicy()).isEqualTo(newPolicy);
+    }
+
+    @Test
+    void 권한이_없는_사용자는_채널_정책을_변경할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChannelPolicy newPolicy = ChannelPolicy.defaultPolicy().updatePublic(false);
+
+        // when & then
+        assertThatThrownBy(() -> channel.changeChannelPolicy(memberId, newPolicy))
+                .isInstanceOf(ChannelOperationForbiddenException.class)
+                .hasMessage("채널 정책을 변경할 권한이 없습니다.");
+    }
+
+    @Test
+    void 공개_채널에는_자유롭게_참여할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        ChannelPolicy publicPolicy = ChannelPolicy.defaultPolicy().updatePublic(true);
+        Channel channel = Channel.create("general", 1L, publicPolicy, createdAt);
+
+        UserId newUserId = UserId.create(2L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when
+        ChannelMembership joinerMembership = channel.joinUser(newUserId, ChannelRole.MEMBER, joinedAt);
 
         // then
         assertAll(
-                () -> assertThat(actual.getUserId().getValue()).isEqualTo(2L),
-                () -> assertThat(actual.getChannelId().getValue()).isEqualTo(1L)
+                () -> assertThat(joinerMembership).isNotNull(),
+                () -> assertThat(joinerMembership.getUserId()).isEqualTo(newUserId),
+                () -> assertThat(joinerMembership.getRole()).isEqualTo(ChannelRole.MEMBER)
+        );
+    }
+
+    @Test
+    void 비공개_채널에는_참여할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        ChannelPolicy privatePolicy = ChannelPolicy.defaultPolicy().updatePublic(false);
+        Channel channel = Channel.create("private-channel", 1L, privatePolicy, createdAt);
+
+        UserId newUserId = UserId.create(2L);
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        // when & then
+        assertThatThrownBy(() -> channel.joinUser(newUserId, ChannelRole.MEMBER, joinedAt))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("비공개 채널입니다. 초대를 통해 참여할 수 있습니다.");
+    }
+
+    @Test
+    void 이미_참여한_사용자는_다시_참여할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId existingUserId = UserId.create(2L);
+        ChannelMembership existingMembership = ChannelMembership.create(2L, 1L, existingUserId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(existingUserId, existingMembership);
+
+        ChannelPolicy publicPolicy = ChannelPolicy.defaultPolicy().updatePublic(true);
+        Channel channel = Channel.create(1L, "general", 1L, publicPolicy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.joinUser(existingUserId, ChannelRole.MEMBER, LocalDateTime.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 채널에 참여한 사용자입니다.");
+    }
+
+    @Test
+    void 권한이_있는_멤버는_다른_사용자를_초대할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId ownerId = UserId.create(1L);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        UserId inviteeId = UserId.create(2L);
+        LocalDateTime invitedAt = LocalDateTime.now();
+
+        // when
+        ChannelMembership inviteeMembership = channel.inviteMember(ownerId, inviteeId, invitedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(inviteeMembership).isNotNull(),
+                () -> assertThat(inviteeMembership.getUserId()).isEqualTo(inviteeId),
+                () -> assertThat(inviteeMembership.getRole()).isEqualTo(ChannelRole.MEMBER)
+        );
+    }
+
+    @Test
+    void 권한이_없는_사용자는_멤버를_초대할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        UserId inviteeId = UserId.create(3L);
+
+        // when & then
+        assertThatThrownBy(() -> channel.inviteMember(memberId, inviteeId, LocalDateTime.now()))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("멤버 초대 권한이 없습니다.");
+    }
+
+    @Test
+    void 이미_참여한_사용자는_초대할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId ownerId = UserId.create(1L);
+        UserId existingMemberId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership existingMembership = ChannelMembership.create(2L, 1L, existingMemberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(existingMemberId, existingMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.inviteMember(ownerId, existingMemberId, LocalDateTime.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 해당 채널에 참여한 사용자입니다.");
+    }
+
+    @Test
+    void 멤버는_채널에서_나갈_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when
+        ChannelMembership leftMembership = channel.leaveMember(memberId);
+
+        // then
+        assertAll(
+                () -> assertThat(leftMembership).isNotNull(),
+                () -> assertThat(channel.getMemberships().containsKey(memberId)).isFalse()
         );
     }
 
@@ -515,217 +817,309 @@ class ChannelTest {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId userId = UserId.create(2L);
-        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId ownerId = UserId.create(1L);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        memberships.put(ownerId, ownerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedLeaveMember(userId))
+        assertThatThrownBy(() -> channel.leaveMember(ownerId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("오너는 채널에서 나갈 수 없습니다.");
+                .hasMessage("채널 오너는 채널에서 나갈 수 없습니다.");
     }
 
     @Test
-    void 오너는_채널을_삭제할_수_있다() {
+    void 권한이_있는_사용자는_멤버를_강퇴할_수_있다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId userId = UserId.create(2L);
-        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
-        // when & then
-        assertDoesNotThrow(() -> channel.validateDeleteChannel(userId));
-    }
+        UserId ownerId = UserId.create(1L);
+        UserId targetMemberId = UserId.create(2L);
 
-    @Test
-    void 오너가_아니면_채널을_삭제할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId userId = UserId.create(2L);
-        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership targetMembership = ChannelMembership.create(2L, 1L, targetMemberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
 
-        // when & then
-        assertThatThrownBy(() -> channel.validateDeleteChannel(userId))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널을 삭제할 권한이 없습니다.");
-    }
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(targetMemberId, targetMembership);
 
-    @Test
-    void 오너가_채널_이름을_변경한다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId changerId = UserId.create(2L);
-        memberships.put(changerId, ChannelMembership.create(ChannelId.create(1L), changerId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-        String newName = "random";
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when
-        Channel changedChannel = channel.changeName(changerId, newName);
+        ChannelMembership kickedMembership = channel.kickMember(ownerId, targetMemberId);
 
         // then
         assertAll(
-                () -> assertThat(changedChannel.getName()).isEqualTo(newName),
-                () -> assertThat(changedChannel.getCreatorId()).isEqualTo(channel.getCreatorId()),
-                () -> assertThat(changedChannel.getChannelPolicy()).isEqualTo(channel.getChannelPolicy())
+                () -> assertThat(kickedMembership).isNotNull(),
+                () -> assertThat(channel.getMemberships().containsKey(targetMemberId)).isFalse()
         );
     }
 
     @Test
-    void 오너가_아니면_채널_이름을_변경할_수_없다() {
+    void 권한이_없는_사용자는_멤버를_강퇴할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId changerId = UserId.create(2L);
-        memberships.put(changerId, ChannelMembership.create(ChannelId.create(1L), changerId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-        String newName = "random";
+
+        UserId memberId = UserId.create(2L);
+        UserId targetMemberId = UserId.create(3L);
+
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        ChannelMembership targetMembership = ChannelMembership.create(3L, 1L, targetMemberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+
+        memberships.put(memberId, memberMembership);
+        memberships.put(targetMemberId, targetMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.changeName(changerId, newName))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널 이름을 변경할 권한이 없습니다.");
-    }
-
-    @Test
-    void 채널_이름_변경_시_유효하지_않은_이름은_거부된다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId changerId = UserId.create(2L);
-        memberships.put(changerId, ChannelMembership.create(ChannelId.create(1L), changerId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.changeName(changerId, ""))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("채널 이름은 필수입니다.");
-    }
-
-    @Test
-    void 권한이_있는_사용자가_채널_정책을_변경한다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId changerId = UserId.create(2L);
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofOwner();
-        memberships.put(changerId, ChannelMembership.create(1L, 1L, changerId.getValue(), ChannelRole.OWNER, permissions, createdAt)); // OWNER 역할로 변경
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-        ChannelPolicy newPolicy = new ChannelPolicy(false, false, false);
-
-        // when
-        Channel actual = channel.changeChannelPolicy(changerId, newPolicy);
-
-        // then
-        assertThat(actual.getChannelPolicy()).isEqualTo(newPolicy);
-    }
-
-    @Test
-    void 권한이_없으면_채널_정책을_변경할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        UserId changerId = UserId.create(2L);
-        memberships.put(changerId, ChannelMembership.create(ChannelId.create(1L), changerId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-        ChannelPolicy newPolicy = new ChannelPolicy(false, false, false);
-
-        // when & then
-        assertThatThrownBy(() -> channel.changeChannelPolicy(changerId, newPolicy))
-                .isInstanceOf(ChannelOperationForbiddenException.class)
-                .hasMessage("채널 정책을 변경할 권한이 없습니다.");
-    }
-
-    @Test
-    void 강퇴_권한이_없는_사용자는_멤버를_강퇴할_수_없다() {
-        // given
-        LocalDateTime createdAt = LocalDateTime.now();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MEMBER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
-
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
-
-        // when & then
-        assertThatThrownBy(() -> channel.getValidatedKickedMember(executorId, targetUserId))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> channel.kickMember(memberId, targetMemberId))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
                 .hasMessage("멤버를 강퇴할 권한이 없습니다.");
     }
 
     @Test
-    void 존재하지_않는_사용자는_강퇴할_수_없다() {
+    void 멤버가_아닌_사용자는_강퇴할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        // executor는 존재하지만 타겟이 없음
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MANAGER, createdAt));
 
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+
+        ChannelMembership ownerMembership = ChannelMembership.create(1L, 1L, ownerId.getValue(), ChannelRole.OWNER, ChannelManagePermissions.ofOwner(), createdAt);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
+
+        memberships.put(ownerId, ownerMembership);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedKickedMember(executorId, targetUserId))
+        assertThatThrownBy(() -> channel.kickMember(ownerId, managerId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("멤버를 강퇴할 권한이 없습니다.");
+                .hasMessage("멤버만 강퇴할 수 있습니다.");
     }
 
     @Test
-    void 자기자신은_강퇴할_수_없다() {
+    void 자신의_메시지는_수정할_수_있다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
-        UserId executorId = UserId.create(2L);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy().updateEditOwnMessage(true);
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, memberId.getValue(), 1L, "test", createdAt, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedKickedMember(executorId, executorId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자기 자신을 강퇴할 수 없습니다.");
+        assertDoesNotThrow(() -> channel.validateMemberEditMessage(memberId, message));
     }
 
     @Test
-    void 오너는_강퇴할_수_없다() {
+    void 권한이_있는_매니저는_다른_사용자의_메시지를_수정할_수_있다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.OWNER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId managerId = UserId.create(2L);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, 999L, 1L, "test", createdAt, createdAt);
 
         // when & then
-        assertThatThrownBy(() -> channel.getValidatedKickedMember(executorId, targetUserId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("오너를 강퇴할 수 없습니다.");
+        assertDoesNotThrow(() -> channel.validateMemberEditMessage(managerId, message));
     }
 
     @Test
-    void 강퇴_권한이_있는_매니저는_멤버를_강퇴할_수_있다() {
+    void 권한이_없는_사용자는_다른_사용자의_메시지를_수정할_수_없다() {
         // given
         LocalDateTime createdAt = LocalDateTime.now();
-        UserId executorId = UserId.create(2L);
-        UserId targetUserId = UserId.create(3L);
-        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MEMBER_KICK));
         Map<UserId, ChannelMembership> memberships = new HashMap<>();
-        memberships.put(executorId, ChannelMembership.create(1L, 1L, 2L, ChannelRole.MANAGER, permissions, createdAt));
-        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
-        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, 999L, 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateMemberEditMessage(memberId, message))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("메시지를 수정할 권한이 없습니다.");
+    }
+
+    @Test
+    void 채널_정책이_허용하지_않으면_자신의_메시지도_수정할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy().updateEditOwnMessage(false);
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, memberId.getValue(), 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateMemberEditMessage(memberId, message))
+                .isInstanceOf(ChannelOperationForbiddenException.class)
+                .hasMessage("자신의 메시지를 수정할 수 없습니다.");
+    }
+
+    @Test
+    void 자신의_메시지는_삭제할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy().updateDeleteOwnMessage(true);
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, memberId.getValue(), 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertDoesNotThrow(() -> channel.validateMemberDeleteMessage(memberId, message));
+    }
+
+    @Test
+    void 권한이_있는_매니저는_다른_사용자의_메시지를_삭제할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId managerId = UserId.create(2L);
+        Set<ChannelPermissionType> managerPermissions = EnumSet.of(ChannelPermissionType.MESSAGE_DELETE);
+        ChannelMembership managerMembership = ChannelMembership.create(2L, 1L, managerId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(managerPermissions), createdAt);
+        memberships.put(managerId, managerMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, 999L, 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertDoesNotThrow(() -> channel.validateMemberDeleteMessage(managerId, message));
+    }
+
+    @Test
+    void 권한이_없는_사용자는_다른_사용자의_메시지를_삭제할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, 999L, 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateMemberDeleteMessage(memberId, message))
+                .isInstanceOf(ChannelMembershipOperationForbiddenException.class)
+                .hasMessage("메시지를 삭제할 권한이 없습니다.");
+    }
+
+    @Test
+    void 채널_정책이_허용하지_않으면_자신의_메시지도_삭제할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy().updateDeleteOwnMessage(false);
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChatMessage message = new ChatMessage(1L, 1L, memberId.getValue(), 1L, "test", createdAt, createdAt);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateMemberDeleteMessage(memberId, message))
+                .isInstanceOf(ChannelOperationForbiddenException.class)
+                .hasMessage("자신의 메시지를 삭제할 수 없습니다.");
+    }
+
+    @Test
+    void 채널에_참여한_멤버는_메시지를_전송할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership memberMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, memberMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        // when & then
+        assertDoesNotThrow(() -> channel.validateMemberSendMessage(memberId));
+    }
+
+    @Test
+    void 채널에_참여하지_않은_사용자는_메시지를_전송할_수_없다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create("general", 1L, policy, createdAt);
+
+        UserId nonMemberId = UserId.create(999L);
+
+        // when & then
+        assertThatThrownBy(() -> channel.validateMemberSendMessage(nonMemberId))
+                .isInstanceOf(ChannelMembershipNotFoundException.class)
+                .hasMessage("채널 멤버를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 멤버십을_동기화할_수_있다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+
+        UserId memberId = UserId.create(2L);
+        ChannelMembership oldMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MEMBER, ChannelManagePermissions.ofMember(), createdAt);
+        memberships.put(memberId, oldMembership);
+
+        ChannelPolicy policy = ChannelPolicy.defaultPolicy();
+        Channel channel = Channel.create(1L, "general", 1L, policy, memberships, createdAt);
+
+        ChannelMembership newMembership = ChannelMembership.create(2L, 1L, memberId.getValue(), ChannelRole.MANAGER, ChannelManagePermissions.ofManager(), createdAt);
 
         // when
-        ChannelMembership actual = channel.getValidatedKickedMember(executorId, targetUserId);
+        channel.syncMembership(newMembership);
 
         // then
-        assertAll(
-                () -> assertThat(actual.getChannelId().getValue()).isEqualTo(1L),
-                () -> assertThat(actual.getUserId()).isEqualTo(targetUserId)
-        );
+        assertThat(channel.getMemberships()).containsEntry(memberId, newMembership);
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
@@ -72,7 +72,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -95,7 +96,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
@@ -156,7 +158,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -185,7 +188,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         Long userId = 100L;
@@ -209,7 +213,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         Long userId = 100L;
@@ -242,7 +247,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 10, 0, 0);
@@ -278,7 +284,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -336,7 +343,8 @@ class ChannelEntityTest {
                 Clock.systemDefaultZone(),
                 channelId,
                 messages,
-                messageStoragePort
+                messageStoragePort,
+                mock(ActorRef.class)
         ));
 
         verify(messageStoragePort, timeout(1000)).findRecentMessages(eq(channelId), eq(50), any());
@@ -355,7 +363,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -391,7 +400,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         Long messageId = 1L;
@@ -414,7 +424,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
@@ -454,7 +465,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
@@ -498,7 +510,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         Long messageId = 1L;
@@ -522,7 +535,8 @@ class ChannelEntityTest {
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
-                        messageStoragePort
+                        messageStoragePort,
+                        mock(ActorRef.class)
                 ));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
@@ -22,11 +22,9 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncStoredMembership;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.UpdateMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
@@ -272,6 +270,26 @@ class ChannelEntityTest {
         Long userId = 100L;
         String messageContent = "Test message";
 
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                userId,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                LocalDateTime.now()
+        );
+        memberships.put(UserId.create(userId), membership);
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                userId,
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                LocalDateTime.now()
+        );
+        channelEntity.tell(new SyncChannel(channel));
+
         // when
         channelEntity.tell(new SendMessage(userId, messageContent));
 
@@ -307,6 +325,26 @@ class ChannelEntityTest {
 
         Long userId = 100L;
         String messageContent = "Test message";
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                userId,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                LocalDateTime.now()
+        );
+        memberships.put(UserId.create(userId), membership);
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                userId,
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                LocalDateTime.now()
+        );
+        channelEntity.tell(new SyncChannel(channel));
 
         // when
         channelEntity.tell(new SendMessage(userId, messageContent));
@@ -528,7 +566,7 @@ class ChannelEntityTest {
     }
 
     @Test
-    void DeleteMessage_메시지를_받으면_MessageStoragePort에_메시지_삭제를_요청한다() {
+    void DeleteMessage_메시지를_받으면_reader에게_SyncDeletion을_전달한다() {
         // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
@@ -552,131 +590,47 @@ class ChannelEntityTest {
                         mock(ActorRef.class)
                 )
         );
-
-        Long messageId = 1L;
-
-        // when
-        channelEntity.tell(new DeleteMessage(messageId));
-
-        // then
-        verify(messageStoragePort, timeout(1000)).delete(eq(messageId), eq(channelEntity));
-    }
-
-    @Test
-    void SyncDeletedMessage_메시지를_받으면_모든_reader에게_SyncDeletion_메시지를_전달한다() {
-        // given
-        Long channelId = 1L;
-        ChatMessages messages = new ChatMessages();
-        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
-        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
-        ClusterSharding clusterSharding = mock(ClusterSharding.class);
-        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
-
-        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
-        doNothing().when(channelActorStoragePort).find(anyLong(), any());
-        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
-
-        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
-                ChannelEntity.create(
-                        Clock.systemDefaultZone(),
-                        channelId,
-                        messages,
-                        clusterSharding,
-                        messageStoragePort,
-                        channelActorStoragePort,
-                        mock(ActorRef.class)
-                )
-        );
-
-        TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
-        TestProbe<ChannelReaderCommand> reader2Probe = testKit.createTestProbe();
-
-        channelEntity.tell(new RegisterReader("reader1", reader1Probe.ref()));
-        channelEntity.tell(new RegisterReader("reader2", reader2Probe.ref()));
-
-        LocalDateTime timestamp = LocalDateTime.of(2025, 10, 17, 12, 0, 0);
-        ChatMessage message = new ChatMessage(1L, channelId, 100L, 1L, "Test", timestamp, timestamp);
-        channelEntity.tell(new SyncPersistedMessage(message));
-
-        reader1Probe.expectMessageClass(SyncNewMessage.class);
-        reader2Probe.expectMessageClass(SyncNewMessage.class);
-
-        Long messageId = 1L;
-
-        // when
-        channelEntity.tell(new SyncDeletedMessage(messageId));
-
-        // then
-        SyncDeletion syncDeletion1 = reader1Probe.expectMessageClass(SyncDeletion.class);
-
-        assertThat(syncDeletion1.messageId()).isEqualTo(messageId);
-
-        SyncDeletion syncDeletion2 = reader2Probe.expectMessageClass(SyncDeletion.class);
-
-        assertThat(syncDeletion2.messageId()).isEqualTo(messageId);
-    }
-
-    @Test
-    void SyncDeletedMessage_메시지를_받으면_messages에서_메시지가_삭제된다() {
-        // given
-        Long channelId = 1L;
-        ChatMessages messages = new ChatMessages();
-        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
-        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
-        ClusterSharding clusterSharding = mock(ClusterSharding.class);
-        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
-
-        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
-        doNothing().when(channelActorStoragePort).find(anyLong(), any());
-        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
-
-        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
-                ChannelEntity.create(
-                        Clock.systemDefaultZone(),
-                        channelId,
-                        messages,
-                        clusterSharding,
-                        messageStoragePort,
-                        channelActorStoragePort,
-                        mock(ActorRef.class)
-                )
-        );
-
-        channelEntity.tell(new SyncRecentMessages(List.of()));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
 
-        LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 12, 0, 0);
-        LocalDateTime timestamp2 = LocalDateTime.of(2025, 10, 17, 12, 0, 1);
-        ChatMessage message1 = new ChatMessage(1L, channelId, 100L, 1L, "Message 1", timestamp1, timestamp1);
-        ChatMessage message2 = new ChatMessage(2L, channelId, 100L, 2L, "Message 2", timestamp2, timestamp2);
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
 
-        channelEntity.tell(new SyncPersistedMessage(message1));
-        readerProbe.expectMessageClass(SyncNewMessage.class);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
 
-        channelEntity.tell(new SyncPersistedMessage(message2));
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+        channelEntity.tell(new SyncChannel(channel));
+
+        ChatMessage message = new ChatMessage(1L, channelId, ownerId.getValue(), 1L, "message", now, now);
+        channelEntity.tell(new SyncPersistedMessage(message));
         readerProbe.expectMessageClass(SyncNewMessage.class);
 
         // when
-        channelEntity.tell(new SyncDeletedMessage(1L));
-        readerProbe.expectMessageClass(SyncDeletion.class);
-
-        TestProbe<ChannelReaderCommand> syncProbe = testKit.createTestProbe();
-        channelEntity.tell(new RequestSyncMessages(syncProbe.ref()));
+        channelEntity.tell(new DeleteMessage(ownerId, message.messageId()));
 
         // then
-        DeliverSyncMessages actual = syncProbe.expectMessageClass(DeliverSyncMessages.class);
-
-        assertAll(
-                () -> assertThat(actual.messages()).hasSize(1),
-                () -> assertThat(actual.messages()).extracting(ChatMessage::messageId)
-                                                      .containsExactly(2L)
-        );
+        readerProbe.expectMessageClass(SyncDeletion.class);
     }
 
     @Test
-    void UpdateMessage_메시지를_받으면_MessageStoragePort에_메시지_수정을_요청한다() {
+    void UpdateMessage_메시지를_받으면_reader에게_SyncUpdate를_전달한다() {
         // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
@@ -700,87 +654,49 @@ class ChannelEntityTest {
                         mock(ActorRef.class)
                 )
         );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+        channelEntity.tell(new SyncChannel(channel));
+
+        ChatMessage message = new ChatMessage(1L, channelId, ownerId.getValue(), 1L, "message", now, now);
+        channelEntity.tell(new SyncPersistedMessage(message));
+        readerProbe.expectMessageClass(SyncNewMessage.class);
 
         Long messageId = 1L;
         String updatedMessage = "Updated message";
 
         // when
-        channelEntity.tell(new UpdateMessage(messageId, updatedMessage));
-
-        // then
-        verify(messageStoragePort, timeout(1000)).update(eq(messageId), eq(updatedMessage), eq(channelEntity));
-    }
-
-    @Test
-    void SyncUpdatedMessage_메시지를_받으면_messages에서_메시지를_수정하고_reader에게_전파한다() {
-        // given
-        Long channelId = 1L;
-        ChatMessages messages = new ChatMessages();
-        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
-        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
-        ClusterSharding clusterSharding = mock(ClusterSharding.class);
-        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
-
-        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
-        doNothing().when(channelActorStoragePort).find(anyLong(), any());
-        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
-
-        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
-                ChannelEntity.create(
-                        Clock.systemDefaultZone(),
-                        channelId,
-                        messages,
-                        clusterSharding,
-                        messageStoragePort,
-                        channelActorStoragePort,
-                        mock(ActorRef.class)
-                )
-        );
-
-        channelEntity.tell(new SyncRecentMessages(List.of()));
-
-        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
-        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
-
-        LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 12, 0, 0);
-        LocalDateTime timestamp2 = LocalDateTime.of(2025, 10, 17, 12, 0, 1);
-        ChatMessage message1 = new ChatMessage(1L, channelId, 100L, 1L, "Message 1", timestamp1, timestamp1);
-        ChatMessage message2 = new ChatMessage(2L, channelId, 100L, 2L, "Message 2", timestamp2, timestamp2);
-
-        channelEntity.tell(new SyncPersistedMessage(message1));
-        readerProbe.expectMessageClass(SyncNewMessage.class);
-
-        channelEntity.tell(new SyncPersistedMessage(message2));
-        readerProbe.expectMessageClass(SyncNewMessage.class);
-
-        // when
-        channelEntity.tell(new SyncUpdatedMessage(1L, "Updated Message 1"));
+        channelEntity.tell(new UpdateMessage(ownerId.getValue(), messageId, updatedMessage));
 
         // then
         SyncUpdate syncUpdate = readerProbe.expectMessageClass(SyncUpdate.class);
-
         assertAll(
-                () -> assertThat(syncUpdate.messageId()).isEqualTo(1L),
-                () -> assertThat(syncUpdate.updatedMessage()).isEqualTo("Updated Message 1"),
-                () -> assertThat(syncUpdate.updatedAt()).isNotNull()
-        );
-
-        TestProbe<ChannelReaderCommand> syncProbe = testKit.createTestProbe();
-
-        channelEntity.tell(new RequestSyncMessages(syncProbe.ref()));
-
-        DeliverSyncMessages deliverSyncMessages = syncProbe.expectMessageClass(DeliverSyncMessages.class);
-
-        assertAll(
-                () -> assertThat(deliverSyncMessages.messages()).hasSize(2),
-                () -> assertThat(deliverSyncMessages.messages())
-                        .filteredOn(msg -> msg.messageId().equals(1L))
-                        .extracting(ChatMessage::message)
-                        .containsExactly("Updated Message 1"),
-                () -> assertThat(deliverSyncMessages.messages())
-                        .filteredOn(msg -> msg.messageId().equals(2L))
-                        .extracting(ChatMessage::message)
-                        .containsExactly("Message 2")
+                () -> assertThat(syncUpdate.messageId()).isEqualTo(messageId),
+                () -> assertThat(syncUpdate.updatedMessage()).isEqualTo(updatedMessage)
         );
     }
 
@@ -1139,7 +1055,6 @@ class ChannelEntityTest {
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
         ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
         ClusterSharding clusterSharding = mock(ClusterSharding.class);
-        @SuppressWarnings("unchecked")
         EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
@@ -843,10 +843,9 @@ class ChannelEntityTest {
 
         UserId inviterId = UserId.create(1L);
         UserId inviteeId = UserId.create(2L);
-        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe();
 
         // when
-        channelEntity.tell(new InviteUser(inviterId, inviteeId, replyProbe.ref()));
+        channelEntity.tell(new InviteUser(inviterId, inviteeId));
 
         readerProbe.expectMessageClass(NotifyMembershipCountChanged.class);
 

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEntityTest.java
@@ -1,49 +1,81 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.DomainEventProcessed;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.actor.ChannelReaderActor.DeliverSyncMessages;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyChangeChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelReaderActor.NotifyEditChannelName;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChangeChannelPolicy;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.DeleteMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.EditChannelName;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.InviteUser;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.JoinUser;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RegisterReader;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.RemoveShutdownReader;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveChannelMetadata;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SendMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
-import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncStoredMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.UpdateMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.InviteUserEventCommand;
+import com.tok.pekko.domain.chat.port.out.InviteUserEventProtocol.Invited;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.actor.typed.internal.pubsub.TopicImpl;
+import org.apache.pekko.actor.typed.pubsub.Topic;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@SuppressWarnings("NonAsciiCharacters")
+@SuppressWarnings({"NonAsciiCharacters", "unchecked"})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ChannelEntityTest {
 
@@ -55,50 +87,70 @@ class ChannelEntityTest {
     }
 
     @AfterAll
-    static void teardown() {
+    static void tearDown() {
         testKit.shutdownTestKit();
     }
 
     @Test
     void RegisterReader_메시지로_새로운_reader를_등록하면_기존_reader에게_메시지를_전달하지_않는다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
 
+        // when
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
 
+        // then
         readerProbe.expectNoMessage(Duration.ofMillis(200));
     }
 
     @Test
-    void SyncPersistedMessage_메시지를_받으면_모든_reader에게_SyncNewCommand_메시지를_전달한다() {
+    void SyncPersistedMessage_메시지를_받으면_모든_reader에게_SyncNewMessage_메시지를_전달한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
         TestProbe<ChannelReaderCommand> reader2Probe = testKit.createTestProbe();
@@ -120,9 +172,12 @@ class ChannelEntityTest {
                 timestamp
         );
 
+        // when
         channelEntity.tell(new SyncPersistedMessage(persistedMessage));
 
+        // then
         SyncNewMessage syncCommand1 = reader1Probe.expectMessageClass(SyncNewMessage.class);
+
         assertThat(syncCommand1.message())
                 .isNotNull()
                 .satisfies(message -> assertAll(
@@ -134,6 +189,7 @@ class ChannelEntityTest {
                 ));
 
         SyncNewMessage syncCommand2 = reader2Probe.expectMessageClass(SyncNewMessage.class);
+
         assertThat(syncCommand2.message())
                 .isNotNull()
                 .satisfies(message -> assertAll(
@@ -146,25 +202,36 @@ class ChannelEntityTest {
     }
 
     @Test
-    void RemoveShutdownReader_메시지를_받으면_해당_reader가_ChatChannelEntity에서_제거되어_메시지를_받지_않는다() {
+    void RemoveShutdownReader_메시지를_받으면_해당_reader가_ChannelEntity에서_제거되어_메시지를_받지_않는다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
 
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        // when
         channelEntity.tell(new RemoveShutdownReader("reader"));
 
         Long senderId = 200L;
@@ -172,56 +239,79 @@ class ChannelEntityTest {
 
         channelEntity.tell(new SendMessage(senderId, messageContent));
 
+        // then
         readerProbe.expectNoMessage(Duration.ofMillis(200));
     }
 
     @Test
     void SendMessage_메시지를_받으면_MessageStoragePort에_채팅_메시지_저장을_요청한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         Long userId = 100L;
-        String messageContent = "Hello, World!";
+        String messageContent = "Test message";
 
+        // when
         channelEntity.tell(new SendMessage(userId, messageContent));
 
+        // then
         verify(messageStoragePort, timeout(1000)).store(any(ChatMessage.class), eq(channelEntity));
     }
 
     @Test
     void SendMessage_메시지를_받으면_유효한_ChatMessage를_생성하고_저장한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         Long userId = 100L;
         String messageContent = "Test message";
 
+        // when
         channelEntity.tell(new SendMessage(userId, messageContent));
 
+        // then
         verify(messageStoragePort, timeout(1000)).store(
                 argThat(message ->
                         message.messageId() == null
@@ -236,20 +326,29 @@ class ChannelEntityTest {
 
     @Test
     void SyncRecentMessages_메시지를_받으면_messages를_동기화한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 10, 0, 0);
         LocalDateTime timestamp2 = LocalDateTime.of(2025, 10, 17, 10, 0, 1);
@@ -258,35 +357,47 @@ class ChannelEntityTest {
                 new ChatMessage(2L, channelId, 101L, 2L, "Message 2", timestamp2, timestamp2)
         );
 
+        // when
         channelEntity.tell(new SyncRecentMessages(recentMessages));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
         channelEntity.tell(new RequestSyncMessages(readerProbe.ref()));
 
-        DeliverSyncMessages delivered = readerProbe.expectMessageClass(DeliverSyncMessages.class);
+        // then
+        DeliverSyncMessages actual = readerProbe.expectMessageClass(DeliverSyncMessages.class);
+
         assertAll(
-                () -> assertThat(delivered.messages()).hasSize(2),
-                () -> assertThat(delivered.messages()).extracting(ChatMessage::message)
+                () -> assertThat(actual.messages()).hasSize(2),
+                () -> assertThat(actual.messages()).extracting(ChatMessage::message)
                                                       .containsExactly("Message 2", "Message 1")
         );
     }
 
     @Test
     void 메시지를_여러_번_동기화하면_messageSequence가_순차적으로_증가한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
@@ -299,12 +410,15 @@ class ChannelEntityTest {
         ChatMessage message2 = new ChatMessage(2L, channelId, 100L, 2L, "Second message", timestamp2, timestamp2);
         ChatMessage message3 = new ChatMessage(3L, channelId, 100L, 3L, "Third message", timestamp3, timestamp3);
 
+        // when
         channelEntity.tell(new SyncPersistedMessage(message1));
         channelEntity.tell(new SyncPersistedMessage(message2));
         channelEntity.tell(new SyncPersistedMessage(message3));
 
-        SyncNewMessage sync1 = readerProbe.expectMessageClass(SyncNewMessage.class);
-        assertThat(sync1.message())
+        // then
+        SyncNewMessage syncNewMessage1 = readerProbe.expectMessageClass(SyncNewMessage.class);
+
+        assertThat(syncNewMessage1.message())
                 .isNotNull()
                 .satisfies(message -> assertAll(
                         () -> assertThat(message.orderSequence()).isEqualTo(1L),
@@ -312,8 +426,9 @@ class ChannelEntityTest {
                         () -> assertThat(message.createdAt()).isEqualTo(timestamp1)
                 ));
 
-        SyncNewMessage sync2 = readerProbe.expectMessageClass(SyncNewMessage.class);
-        assertThat(sync2.message())
+        SyncNewMessage syncNewMessage2 = readerProbe.expectMessageClass(SyncNewMessage.class);
+
+        assertThat(syncNewMessage2.message())
                 .isNotNull()
                 .satisfies(message -> assertAll(
                         () -> assertThat(message.orderSequence()).isEqualTo(2L),
@@ -321,8 +436,9 @@ class ChannelEntityTest {
                         () -> assertThat(message.createdAt()).isEqualTo(timestamp2)
                 ));
 
-        SyncNewMessage sync3 = readerProbe.expectMessageClass(SyncNewMessage.class);
-        assertThat(sync3.message())
+        SyncNewMessage syncNewMessage3 = readerProbe.expectMessageClass(SyncNewMessage.class);
+
+        assertThat(syncNewMessage3.message())
                 .isNotNull()
                 .satisfies(message -> assertAll(
                         () -> assertThat(message.orderSequence()).isEqualTo(3L),
@@ -332,40 +448,61 @@ class ChannelEntityTest {
     }
 
     @Test
-    void 생성_시_findRecentMessages를_호출한다() {
+    void 생성_시_findRecentMessages와_find를_호출한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
+        // when
         testKit.spawn(ChannelEntity.create(
                 Clock.systemDefaultZone(),
                 channelId,
                 messages,
+                clusterSharding,
                 messageStoragePort,
+                channelActorStoragePort,
                 mock(ActorRef.class)
         ));
 
+        // then
         verify(messageStoragePort, timeout(1000)).findRecentMessages(eq(channelId), eq(50), any());
+        verify(channelActorStoragePort, timeout(1000)).find(eq(channelId), any());
     }
 
     @Test
     void RequestSyncMessages_메시지를_받으면_요청한_reader에게_DeliverSyncMessages를_전달한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
 
@@ -374,59 +511,82 @@ class ChannelEntityTest {
         ChatMessage message1 = new ChatMessage(1L, channelId, 100L, 1L, "Message 1", timestamp1, timestamp1);
         ChatMessage message2 = new ChatMessage(2L, channelId, 100L, 2L, "Message 2", timestamp2, timestamp2);
 
-        channelEntity.tell(new SyncPersistedMessage(message1));
-        channelEntity.tell(new SyncPersistedMessage(message2));
+        List<ChatMessage> recentMessages = List.of(message1, message2);
+        channelEntity.tell(new SyncRecentMessages(recentMessages));
 
+        // when
         channelEntity.tell(new RequestSyncMessages(readerProbe.ref()));
 
-        DeliverSyncMessages delivered = readerProbe.expectMessageClass(DeliverSyncMessages.class);
+        // then
+        DeliverSyncMessages actual = readerProbe.expectMessageClass(DeliverSyncMessages.class);
+
         assertAll(
-                () -> assertThat(delivered.messages()).hasSize(2),
-                () -> assertThat(delivered.messages()).extracting(ChatMessage::message)
+                () -> assertThat(actual.messages()).hasSize(2),
+                () -> assertThat(actual.messages()).extracting(ChatMessage::message)
                                                       .containsExactly("Message 2", "Message 1")
         );
     }
 
     @Test
     void DeleteMessage_메시지를_받으면_MessageStoragePort에_메시지_삭제를_요청한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         Long messageId = 1L;
 
+        // when
         channelEntity.tell(new DeleteMessage(messageId));
 
+        // then
         verify(messageStoragePort, timeout(1000)).delete(eq(messageId), eq(channelEntity));
     }
 
     @Test
     void SyncDeletedMessage_메시지를_받으면_모든_reader에게_SyncDeletion_메시지를_전달한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         TestProbe<ChannelReaderCommand> reader1Probe = testKit.createTestProbe();
         TestProbe<ChannelReaderCommand> reader2Probe = testKit.createTestProbe();
@@ -443,31 +603,46 @@ class ChannelEntityTest {
 
         Long messageId = 1L;
 
+        // when
         channelEntity.tell(new SyncDeletedMessage(messageId));
 
-        SyncDeletion deletion1 = reader1Probe.expectMessageClass(SyncDeletion.class);
-        assertThat(deletion1.messageId()).isEqualTo(messageId);
+        // then
+        SyncDeletion syncDeletion1 = reader1Probe.expectMessageClass(SyncDeletion.class);
 
-        SyncDeletion deletion2 = reader2Probe.expectMessageClass(SyncDeletion.class);
-        assertThat(deletion2.messageId()).isEqualTo(messageId);
+        assertThat(syncDeletion1.messageId()).isEqualTo(messageId);
+
+        SyncDeletion syncDeletion2 = reader2Probe.expectMessageClass(SyncDeletion.class);
+
+        assertThat(syncDeletion2.messageId()).isEqualTo(messageId);
     }
 
     @Test
     void SyncDeletedMessage_메시지를_받으면_messages에서_메시지가_삭제된다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
+
+        channelEntity.tell(new SyncRecentMessages(List.of()));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
@@ -483,61 +658,86 @@ class ChannelEntityTest {
         channelEntity.tell(new SyncPersistedMessage(message2));
         readerProbe.expectMessageClass(SyncNewMessage.class);
 
+        // when
         channelEntity.tell(new SyncDeletedMessage(1L));
         readerProbe.expectMessageClass(SyncDeletion.class);
 
         TestProbe<ChannelReaderCommand> syncProbe = testKit.createTestProbe();
         channelEntity.tell(new RequestSyncMessages(syncProbe.ref()));
 
-        DeliverSyncMessages delivered = syncProbe.expectMessageClass(DeliverSyncMessages.class);
+        // then
+        DeliverSyncMessages actual = syncProbe.expectMessageClass(DeliverSyncMessages.class);
+
         assertAll(
-                () -> assertThat(delivered.messages()).hasSize(1),
-                () -> assertThat(delivered.messages()).extracting(ChatMessage::messageId)
+                () -> assertThat(actual.messages()).hasSize(1),
+                () -> assertThat(actual.messages()).extracting(ChatMessage::messageId)
                                                       .containsExactly(2L)
         );
     }
 
     @Test
     void UpdateMessage_메시지를_받으면_MessageStoragePort에_메시지_수정을_요청한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
 
         Long messageId = 1L;
         String updatedMessage = "Updated message";
 
+        // when
         channelEntity.tell(new UpdateMessage(messageId, updatedMessage));
 
+        // then
         verify(messageStoragePort, timeout(1000)).update(eq(messageId), eq(updatedMessage), eq(channelEntity));
     }
 
     @Test
     void SyncUpdatedMessage_메시지를_받으면_messages에서_메시지를_수정하고_reader에게_전파한다() {
+        // given
         Long channelId = 1L;
         ChatMessages messages = new ChatMessages();
         MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
 
         doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
 
-        ActorRef<ChannelEntityCommand> channelEntity =
-                testKit.spawn(ChannelEntity.create(
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
                         Clock.systemDefaultZone(),
                         channelId,
                         messages,
+                        clusterSharding,
                         messageStoragePort,
+                        channelActorStoragePort,
                         mock(ActorRef.class)
-                ));
+                )
+        );
+
+        channelEntity.tell(new SyncRecentMessages(List.of()));
 
         TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
         channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
@@ -553,9 +753,12 @@ class ChannelEntityTest {
         channelEntity.tell(new SyncPersistedMessage(message2));
         readerProbe.expectMessageClass(SyncNewMessage.class);
 
+        // when
         channelEntity.tell(new SyncUpdatedMessage(1L, "Updated Message 1"));
 
+        // then
         SyncUpdate syncUpdate = readerProbe.expectMessageClass(SyncUpdate.class);
+
         assertAll(
                 () -> assertThat(syncUpdate.messageId()).isEqualTo(1L),
                 () -> assertThat(syncUpdate.updatedMessage()).isEqualTo("Updated Message 1"),
@@ -563,19 +766,610 @@ class ChannelEntityTest {
         );
 
         TestProbe<ChannelReaderCommand> syncProbe = testKit.createTestProbe();
+
         channelEntity.tell(new RequestSyncMessages(syncProbe.ref()));
 
-        DeliverSyncMessages delivered = syncProbe.expectMessageClass(DeliverSyncMessages.class);
+        DeliverSyncMessages deliverSyncMessages = syncProbe.expectMessageClass(DeliverSyncMessages.class);
+
         assertAll(
-                () -> assertThat(delivered.messages()).hasSize(2),
-                () -> assertThat(delivered.messages())
+                () -> assertThat(deliverSyncMessages.messages()).hasSize(2),
+                () -> assertThat(deliverSyncMessages.messages())
                         .filteredOn(msg -> msg.messageId().equals(1L))
                         .extracting(ChatMessage::message)
                         .containsExactly("Updated Message 1"),
-                () -> assertThat(delivered.messages())
+                () -> assertThat(deliverSyncMessages.messages())
                         .filteredOn(msg -> msg.messageId().equals(2L))
                         .extracting(ChatMessage::message)
                         .containsExactly("Message 2")
         );
+    }
+
+    @Test
+    void InviteUser_메시지를_받으면_Topic에_Invited_이벤트를_발행한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+        ActorRef<Topic.Command<InviteUserEventCommand>> inviteUserTopic = mock(ActorRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        inviteUserTopic
+                )
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+
+        channelEntity.tell(new SyncChannel(channel));
+
+        readerProbe.expectNoMessage(Duration.ofMillis(200));
+
+        UserId inviterId = UserId.create(1L);
+        UserId inviteeId = UserId.create(2L);
+        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe();
+
+        // when
+        channelEntity.tell(new InviteUser(inviterId, inviteeId, replyProbe.ref()));
+
+        readerProbe.expectMessageClass(NotifyMembershipCountChanged.class);
+
+        // then
+        verify(inviteUserTopic, timeout(1000)).tell(
+                argThat(command ->
+                        command instanceof TopicImpl.Publish &&
+                                ((TopicImpl.Publish<?>) command).message() instanceof Invited &&
+                                ((Invited) ((TopicImpl.Publish<?>) command).message()).channelId().equals(channelId) &&
+                                ((Invited) ((TopicImpl.Publish<?>) command).message()).inviteeId().equals(inviteeId.getValue())
+                )
+        );
+    }
+
+    @Test
+    void JoinUser_메시지를_받으면_ChannelEventHandler에_HandleUserJoined를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        Channel channel = Channel.create("test-channel", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        channelEntity.tell(new SyncChannel(channel));
+
+        UserId joinerId = UserId.create(2L);
+        TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe();
+
+        // when
+        channelEntity.tell(new JoinUser(joinerId, replyProbe.ref()));
+
+        // then
+        verify(entityRef, timeout(1000)).tell(any());
+    }
+
+    @Test
+    void ChangeChannelPolicy_메시지를_받으면_reader에게_NotifyChangeChannelPolicy를_전파한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+
+        channelEntity.tell(new SyncChannel(channel));
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        UserId changerId = UserId.create(1L);
+
+        // when
+        channelEntity.tell(new ChangeChannelPolicy(changerId, true, true, false));
+
+        // then
+        NotifyChangeChannelPolicy actual = readerProbe.expectMessageClass(NotifyChangeChannelPolicy.class);
+
+        assertThat(actual.channelPolicy()).isNotNull();
+    }
+
+    @Test
+    void EditChannelName_메시지를_받으면_reader에게_NotifyEditChannelName을_전파한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+
+        channelEntity.tell(new SyncChannel(channel));
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        UserId changerId = UserId.create(1L);
+        String newName = "new-channel-name";
+
+        // when
+        channelEntity.tell(new EditChannelName(changerId, newName));
+
+        // then
+        NotifyEditChannelName actual = readerProbe.expectMessageClass(NotifyEditChannelName.class);
+
+        assertThat(actual.editedName()).isEqualTo(newName);
+    }
+
+    @Test
+    void SyncChannel_메시지를_받으면_pendingChannelCommands를_처리한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RegisterReader("reader", readerProbe.ref()));
+
+        UserId changerId = UserId.create(1L);
+        String newName = "new-name";
+
+        channelEntity.tell(new EditChannelName(changerId, newName));
+
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                "test-channel",
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+
+        // when
+        channelEntity.tell(new SyncChannel(channel));
+
+        // then
+        NotifyEditChannelName actual = readerProbe.expectMessageClass(NotifyEditChannelName.class);
+
+        assertThat(actual.editedName()).isEqualTo(newName);
+    }
+
+    @Test
+    void RequestSyncMessages_메시지를_받으면_initialMessagesLoaded가_false면_pendingInitialSyncReaders에_추가한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+
+        // when
+        channelEntity.tell(new RequestSyncMessages(readerProbe.ref()));
+
+        // then
+        readerProbe.expectNoMessage(Duration.ofMillis(200));
+    }
+
+    @Test
+    void SyncRecentMessages_메시지를_받으면_pendingInitialSyncReaders에게_DeliverSyncMessages를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        channelEntity.tell(new RequestSyncMessages(readerProbe.ref()));
+
+        LocalDateTime timestamp1 = LocalDateTime.of(2025, 10, 17, 12, 0, 0);
+        ChatMessage message1 = new ChatMessage(1L, channelId, 100L, 1L, "Message 1", timestamp1, timestamp1);
+        List<ChatMessage> recentMessages = List.of(message1);
+
+        // when
+        channelEntity.tell(new SyncRecentMessages(recentMessages));
+
+        // then
+        DeliverSyncMessages actual = readerProbe.expectMessageClass(DeliverSyncMessages.class);
+
+        assertThat(actual.messages()).hasSize(1);
+    }
+
+    @Test
+    void DomainEventProcessed_메시지를_받으면_events에서_해당_이벤트를_제거한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        Channel channel = Channel.create("test-channel", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        channelEntity.tell(new SyncChannel(channel));
+
+        UserId changerId = UserId.create(1L);
+        channelEntity.tell(new EditChannelName(changerId, "new-name"));
+
+        // when
+        channelEntity.tell(new DomainEventProcessed(1L));
+
+        // then
+        testKit.createTestProbe().expectNoMessage(Duration.ofMillis(200));
+    }
+
+    @Test
+    void ResolveChannelMetadata_메시지를_받으면_SyncChannelMetadata를_응답한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        String channelName = "test-channel";
+        UserId ownerId = UserId.create(1L);
+        LocalDateTime now = LocalDateTime.now();
+
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelMembership ownerMembership = ChannelMembership.create(
+                1L,
+                channelId,
+                ownerId.getValue(),
+                ChannelRole.OWNER,
+                ChannelManagePermissions.ofOwner(),
+                now
+        );
+        memberships.put(ownerId, ownerMembership);
+
+        Channel channel = Channel.create(
+                channelId,
+                channelName,
+                ownerId.getValue(),
+                ChannelPolicy.defaultPolicy(),
+                memberships,
+                now
+        );
+
+        channelEntity.tell(new SyncChannel(channel));
+
+        TestProbe<ChannelReaderCommand> replyProbe = testKit.createTestProbe();
+
+        // when
+        channelEntity.tell(new ResolveChannelMetadata(replyProbe.ref()));
+
+        // then
+        SyncChannelMetadata actual = replyProbe.expectMessageClass(SyncChannelMetadata.class);
+
+        assertAll(
+                () -> assertThat(actual.channelId()).isEqualTo(channelId),
+                () -> assertThat(actual.name()).isEqualTo(channelName),
+                () -> assertThat(actual.channelPolicy()).isNotNull()
+        );
+    }
+
+    @Test
+    void ResolveMembership_메시지를_받으면_SyncMembership을_응답한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        Channel channel = Channel.create("test-channel", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        channelEntity.tell(new SyncChannel(channel));
+
+        UserId userId = UserId.create(2L);
+        TestProbe<ChannelEntityCommand> joinReplyProbe = testKit.createTestProbe();
+        channelEntity.tell(new JoinUser(userId, joinReplyProbe.ref()));
+
+        TestProbe<ChannelReaderCommand> replyProbe = testKit.createTestProbe();
+
+        // when
+        channelEntity.tell(new ResolveMembership(userId, replyProbe.ref()));
+
+        // then
+        SyncMembership actual = replyProbe.expectMessageClass(SyncMembership.class);
+
+        assertAll(
+                () -> assertThat(actual.userId()).isEqualTo(userId.getValue()),
+                () -> assertThat(actual.membership()).isNotNull()
+        );
+    }
+
+    @Test
+    void SyncStoredMembership_메시지를_받으면_Channel의_membership을_업데이트한다() {
+        // given
+        Long channelId = 1L;
+        ChatMessages messages = new ChatMessages();
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEventHandlerCommand> entityRef = mock(EntityRef.class);
+
+        doNothing().when(messageStoragePort).findRecentMessages(anyLong(), anyInt(), any());
+        doNothing().when(channelActorStoragePort).find(anyLong(), any());
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(entityRef);
+
+        ActorRef<ChannelEntityCommand> channelEntity = testKit.spawn(
+                ChannelEntity.create(
+                        Clock.systemDefaultZone(),
+                        channelId,
+                        messages,
+                        clusterSharding,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        mock(ActorRef.class)
+                )
+        );
+
+        Channel channel = Channel.create("test-channel", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        channelEntity.tell(new SyncChannel(channel));
+
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                2L,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                LocalDateTime.now()
+        );
+
+        // when
+        channelEntity.tell(new SyncStoredMembership(membership));
+
+        // then
+        testKit.createTestProbe().expectNoMessage(Duration.ofMillis(200));
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntityTest.java
@@ -1,0 +1,793 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.ChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.DemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.MessageEdited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.PromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelDomainEvent.UserJoined;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.DomainEventProcessed;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleDemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageEdited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserJoined;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelEventHandlerEntityTest {
+
+    private static ActorTestKit testKit;
+
+    @BeforeAll
+    static void setup() {
+        testKit = ActorTestKit.create();
+    }
+
+    @AfterAll
+    static void teardown() {
+        testKit.shutdownTestKit();
+    }
+
+    @Test
+    void HandleChannelPolicyChanged_메시지를_받으면_ChannelActorStoragePort에_채널_업데이트를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelPolicy newPolicy = ChannelPolicy.defaultPolicy().updatePublic(false);
+        Channel channel = Channel.create("test", 1L, newPolicy, LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelPolicyChanged event = new ChannelPolicyChanged(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelPolicyChanged(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+
+    @Test
+    void HandleChannelNameEdited_메시지를_받으면_ChannelActorStoragePort에_채널_업데이트를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("edited-name", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited event = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelNameEdited(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+
+    @Test
+    void HandleUserJoined_메시지를_받으면_ChannelMembershipActorStoragePort에_join을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).join(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        UserJoined event = new UserJoined(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleUserJoined(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).join(
+                eq(1L),
+                eq(membership.getChannelId()),
+                eq(membership),
+                any()
+        );
+    }
+
+    @Test
+    void HandleMemberLeft_메시지를_받으면_ChannelMembershipActorStoragePort에_leave를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).leave(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MemberLeft event = new MemberLeft(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleMemberLeft(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).leave(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleUserInvited_메시지를_받으면_ChannelMembershipActorStoragePort에_inviteUser를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).inviteUser(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(3L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        UserInvited event = new UserInvited(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleUserInvited(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).inviteUser(
+                eq(1L),
+                eq(membership.getChannelId()),
+                eq(membership),
+                any()
+        );
+    }
+
+    @Test
+    void HandlePromotedToManager_메시지를_받으면_ChannelMembershipActorStoragePort에_promoteToManager를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).promoteToManager(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                2L,
+                ChannelRole.MANAGER,
+                ChannelManagePermissions.ofManager(),
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PromotedToManager event = new PromotedToManager(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandlePromotedToManager(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).promoteToManager(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleDemotedToMember_메시지를_받으면_ChannelMembershipActorStoragePort에_demoteToMember를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).demoteToMember(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        DemotedToMember event = new DemotedToMember(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleDemotedToMember(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).demoteToMember(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandlePermissionAdded_메시지를_받으면_ChannelMembershipActorStoragePort에_addPermission을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).addPermission(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+        ChannelPermissionType permission = ChannelPermissionType.MESSAGE_EDIT;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PermissionAdded event = new PermissionAdded(channelId, 1L, occurredAt, membership, permission);
+
+        // when
+        eventHandler.tell(new HandlePermissionAdded(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).addPermission(
+                eq(1L),
+                eq(membership),
+                eq(permission),
+                any()
+        );
+    }
+
+    @Test
+    void HandlePermissionRemoved_메시지를_받으면_ChannelMembershipActorStoragePort에_removePermission을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).removePermission(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+        ChannelPermissionType permission = ChannelPermissionType.MEMBER_KICK;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PermissionRemoved event = new PermissionRemoved(channelId, 1L, occurredAt, membership, permission);
+
+        // when
+        eventHandler.tell(new HandlePermissionRemoved(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).removePermission(
+                eq(1L),
+                eq(membership),
+                eq(permission),
+                any()
+        );
+    }
+
+    @Test
+    void HandleMemberKicked_메시지를_받으면_ChannelMembershipActorStoragePort에_kickMember를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).kickMember(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MemberKicked event = new MemberKicked(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleMemberKicked(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).kickMember(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleMessageEdited_메시지를_받으면_MessageStoragePort에_update를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(messageStoragePort).update(anyLong(), any(ChatMessage.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChatMessage updatedMessage = new ChatMessage(
+                1L,
+                channelId,
+                100L,
+                1L,
+                "Updated message",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MessageEdited event = new MessageEdited(channelId, 1L, occurredAt, updatedMessage);
+
+        // when
+        eventHandler.tell(new HandleMessageEdited(event));
+
+        // then
+        verify(messageStoragePort, timeout(1000)).update(eq(1L), eq(updatedMessage), any());
+    }
+
+    @Test
+    void HandleMessageDeleted_메시지를_받으면_MessageStoragePort에_delete를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(messageStoragePort).delete(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Long deletedMessageId = 10L;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MessageDeleted event = new MessageDeleted(channelId, 1L, occurredAt, deletedMessageId);
+
+        // when
+        eventHandler.tell(new HandleMessageDeleted(event));
+
+        // then
+        verify(messageStoragePort, timeout(1000)).delete(eq(1L), eq(deletedMessageId), any());
+    }
+
+    @Test
+    void EventSucceeded_메시지를_받으면_ChannelEntity에_DomainEventProcessed를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited domainEvent = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+        eventHandler.tell(new HandleChannelNameEdited(domainEvent));
+
+        // when
+        eventHandler.tell(new EventSucceeded(1L));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(DomainEventProcessed.class));
+    }
+
+    @Test
+    void EventFailed_메시지를_받으면_ChannelEntity에_DomainEventProcessed를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited domainEvent = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+        eventHandler.tell(new HandleChannelNameEdited(domainEvent));
+
+        Throwable error = new RuntimeException("Storage failed");
+
+        // when
+        eventHandler.tell(new EventFailed(1L, error));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(DomainEventProcessed.class));
+    }
+
+    @Test
+    void NotifyStoredMembership_메시지를_받으면_ChannelEntity에_SyncStoredMembership을_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                2L,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                LocalDateTime.now()
+        );
+
+        // when
+        eventHandler.tell(new NotifyStoredMembership(membership));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(SyncStoredMembership.class));
+    }
+
+    @Test
+    void Shutdown_메시지를_받으면_ChannelEventHandlerEntity가_종료된다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        TestProbe<ChannelEventHandlerCommand> probe = testKit.createTestProbe();
+        probe.expectNoMessage(Duration.ofMillis(100));
+
+        // when
+        eventHandler.tell(new Shutdown());
+
+        // then
+        probe.expectTerminated(eventHandler, Duration.ofSeconds(3));
+    }
+
+    @Test
+    void 동일한_eventId로_여러_번_메시지를_받으면_중복_처리하지_않는다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited event = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelNameEdited(event));
+        eventHandler.tell(new HandleChannelNameEdited(event));
+        eventHandler.tell(new HandleChannelNameEdited(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -1,13 +1,22 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChannelEntity.RequestSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ResolveHistory;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyFailure;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.NotifyMembershipCountChanged;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RegisterClientSession;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHistory;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncChannelMetadata;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncDeletion;
+import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncMembership;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncNewMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.SyncUpdate;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
@@ -17,6 +26,15 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMe
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel;
+import java.util.EnumSet;
+import java.util.Set;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -456,6 +474,354 @@ class ChannelReaderActorTest {
 
         DeliverNewMessage delivered = clientSessionProbe.expectMessageClass(DeliverNewMessage.class);
         assertThat(delivered.message()).isEqualTo(pendingMessage);
+    }
+
+    @Test
+    void NotifyChangeChannelPolicy_메시지를_받으면_모든_ClientSessionActor에게_채널_정책_변경을_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
+        readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
+
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
+                                                   .updatePublic(false)
+                                                   .updateEditOwnMessage(true)
+                                                   .updateDeleteOwnMessage(false);
+
+        // when
+        readerActor.tell(new ChannelReaderActor.NotifyChangeChannelPolicy(channelPolicy));
+
+        // then
+        PropagateChangeChannelPolicy propagatedMessage1 = clientSessionProbe1.expectMessageClass(
+                PropagateChangeChannelPolicy.class,
+                Duration.ofSeconds(3)
+        );
+        PropagateChangeChannelPolicy propagatedMessage2 = clientSessionProbe2.expectMessageClass(
+                PropagateChangeChannelPolicy.class,
+                Duration.ofSeconds(3)
+        );
+
+        assertAll(
+                () -> assertThat(propagatedMessage1.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage1.channelPolicy()).isEqualTo(channelPolicy),
+                () -> assertThat(propagatedMessage2.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage2.channelPolicy()).isEqualTo(channelPolicy)
+        );
+    }
+
+    @Test
+    void NotifyMemberLeft_메시지를_받으면_해당_ClientSessionActor에게_채널_탈퇴를_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        Long userId = 100L;
+        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+
+        // when
+        readerActor.tell(new ChannelReaderActor.NotifyMemberLeft(userId));
+
+        // then
+        SyncLeaveChannel syncLeaveChannel = clientSessionProbe.expectMessageClass(
+                SyncLeaveChannel.class,
+                Duration.ofSeconds(3)
+        );
+        assertThat(syncLeaveChannel.channelId()).isEqualTo(1L);
+    }
+
+    @Test
+    void NotifyKickedMember_메시지를_받으면_해당_ClientSessionActor에게_강퇴_알림을_전송하고_clientSessions에서_제거한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        Long userId = 100L;
+        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+
+        completeInitialSync(readerActor);
+
+        // when
+        readerActor.tell(new ChannelReaderActor.NotifyKickedMember(userId));
+
+        // then
+        PropagateKickedMember propagateKickedMember = clientSessionProbe.expectMessageClass(
+                PropagateKickedMember.class,
+                Duration.ofSeconds(3)
+        );
+        assertThat(propagateKickedMember.channelId()).isEqualTo(1L);
+
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage newMessage = ChatMessage.create(1L, 1001L, 1L, "Test", timestamp, timestamp);
+        readerActor.tell(new SyncNewMessage(newMessage));
+
+        clientSessionProbe.expectNoMessage(Duration.ofMillis(100));
+    }
+
+    @Test
+    void NotifyFailure_메시지를_받으면_해당_ClientSessionActor에게_에러를_전송한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        Long userId = 100L;
+        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+
+        String errorReason = "권한이 없습니다";
+
+        // when
+        readerActor.tell(new NotifyFailure(userId, errorReason));
+
+        // then
+        PropagateFailure propagateFailure = clientSessionProbe.expectMessageClass(
+                PropagateFailure.class,
+                Duration.ofSeconds(3)
+        );
+        assertAll(
+                () -> assertThat(propagateFailure.channelId()).isEqualTo(1L),
+                () -> assertThat(propagateFailure.reason()).isEqualTo(errorReason)
+        );
+    }
+
+    @Test
+    void NotifyEditChannelName_메시지를_받으면_모든_ClientSessionActor에게_채널_이름_변경을_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
+        readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
+
+        String editedName = "새로운 채널명";
+
+        // when
+        readerActor.tell(new ChannelReaderActor.NotifyEditChannelName(editedName));
+
+        // then
+        PropagateEditChannelName propagatedMessage1 = clientSessionProbe1.expectMessageClass(
+                PropagateEditChannelName.class,
+                Duration.ofSeconds(3)
+        );
+        PropagateEditChannelName propagatedMessage2 = clientSessionProbe2.expectMessageClass(
+                PropagateEditChannelName.class,
+                Duration.ofSeconds(3)
+        );
+
+        assertAll(
+                () -> assertThat(propagatedMessage1.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage1.editedName()).isEqualTo(editedName),
+                () -> assertThat(propagatedMessage2.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage2.editedName()).isEqualTo(editedName)
+        );
+    }
+
+    @Test
+    void NotifyChangeChannelMembership_메시지를_받으면_해당_ClientSessionActor에게_멤버십_변경을_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        Long userId = 100L;
+        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+
+        ChannelMembership membership = createManagerMembership(1L, 1L, userId);
+        int membershipCount = 5;
+
+        // when
+        readerActor.tell(new ChannelReaderActor.NotifyChangeChannelMembership(userId, membership, membershipCount));
+
+        // then
+        PropagateChangeChannelMembership propagatedMessage = clientSessionProbe.expectMessageClass(
+                PropagateChangeChannelMembership.class,
+                Duration.ofSeconds(3)
+        );
+        assertAll(
+                () -> assertThat(propagatedMessage.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage.channelMembership()).isEqualTo(membership),
+                () -> assertThat(propagatedMessage.membershipCount()).isEqualTo(membershipCount)
+        );
+    }
+
+    @Test
+    void NotifyMembershipCountChanged_메시지를_받으면_모든_ClientSessionActor에게_멤버십_카운트_변경을_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe1 = testKit.createTestProbe(ClientSessionCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe2 = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        readerActor.tell(new RegisterClientSession(100L, clientSessionProbe1.ref()));
+        readerActor.tell(new RegisterClientSession(101L, clientSessionProbe2.ref()));
+
+        int membershipCount = 10;
+
+        // when
+        readerActor.tell(new NotifyMembershipCountChanged(membershipCount));
+
+        // then
+        PropagateMembershipCount propagatedMessage1 = clientSessionProbe1.expectMessageClass(
+                PropagateMembershipCount.class,
+                Duration.ofSeconds(3)
+        );
+        PropagateMembershipCount propagatedMessage2 = clientSessionProbe2.expectMessageClass(
+                PropagateMembershipCount.class,
+                Duration.ofSeconds(3)
+        );
+
+        assertAll(
+                () -> assertThat(propagatedMessage1.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage1.membershipCount()).isEqualTo(membershipCount),
+                () -> assertThat(propagatedMessage2.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage2.membershipCount()).isEqualTo(membershipCount)
+        );
+    }
+
+    @Test
+    void SyncMembership_메시지를_받으면_해당_ClientSessionActor에게_멤버십_정보를_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        Long userId = 100L;
+        readerActor.tell(new RegisterClientSession(userId, clientSessionProbe.ref()));
+
+        ChannelMembership membership = createManagerMembership(1L, 1L, userId);
+        int membershipCount = 7;
+
+        // when
+        readerActor.tell(new SyncMembership(userId, membership, membershipCount));
+
+        // then
+        PropagateChangeChannelMembership propagatedMessage = clientSessionProbe.expectMessageClass(
+                PropagateChangeChannelMembership.class,
+                Duration.ofSeconds(3)
+        );
+        assertAll(
+                () -> assertThat(propagatedMessage.channelId()).isEqualTo(1L),
+                () -> assertThat(propagatedMessage.channelMembership()).isEqualTo(membership),
+                () -> assertThat(propagatedMessage.membershipCount()).isEqualTo(membershipCount)
+        );
+    }
+
+    @Test
+    void SyncChannelMetadata_메시지를_받으면_모든_ClientSessionActor에게_채널_메타데이터를_전파한다() {
+        // given
+        ChatMessages mockMessages = mock(ChatMessages.class);
+        @SuppressWarnings("unchecked")
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+        TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
+        TestProbe<ClientSessionCommand> clientSessionProbe = testKit.createTestProbe(ClientSessionCommand.class);
+
+        ActorRef<ChannelReaderCommand> readerActor = testKit.spawn(
+                ChannelReaderActor.create(1L, mockMessages, channelEntity, registryProbe.ref())
+        );
+
+        readerActor.tell(new RegisterClientSession(100L, clientSessionProbe.ref()));
+
+        String channelName = "테스트 채널";
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy();
+        int membershipCount = 15;
+
+        // when
+        readerActor.tell(new SyncChannelMetadata(1L, channelName, channelPolicy, membershipCount));
+
+        // then
+        PropagateEditChannelName propagateEditChannelName = clientSessionProbe.expectMessageClass(
+                PropagateEditChannelName.class,
+                Duration.ofSeconds(3)
+        );
+        PropagateChangeChannelPolicy propagateChangeChannelPolicy = clientSessionProbe.expectMessageClass(
+                PropagateChangeChannelPolicy.class,
+                Duration.ofSeconds(3)
+        );
+        PropagateMembershipCount propagateMembershipCount = clientSessionProbe.expectMessageClass(
+                PropagateMembershipCount.class,
+                Duration.ofSeconds(3)
+        );
+
+        assertAll(
+                () -> assertThat(propagateEditChannelName.channelId()).isEqualTo(1L),
+                () -> assertThat(propagateEditChannelName.editedName()).isEqualTo(channelName),
+                () -> assertThat(propagateChangeChannelPolicy.channelId()).isEqualTo(1L),
+                () -> assertThat(propagateChangeChannelPolicy.channelPolicy()).isEqualTo(channelPolicy),
+                () -> assertThat(propagateMembershipCount.channelId()).isEqualTo(1L),
+                () -> assertThat(propagateMembershipCount.membershipCount()).isEqualTo(membershipCount)
+        );
+    }
+
+    private ChannelMembership createManagerMembership(Long membershipId, Long channelId, Long userId) {
+        Set<ChannelPermissionType> permissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+        return ChannelMembership.create(
+                membershipId,
+                channelId,
+                userId,
+                ChannelRole.MANAGER,
+                managePermissions,
+                LocalDateTime.now()
+        );
     }
 
     private void completeInitialSync(ActorRef<ChannelReaderCommand> readerActor) {

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderActorTest.java
@@ -78,7 +78,7 @@ class ChannelReaderActorTest {
     @Test
     void SyncNewMessage_메시지를_받으면_채팅_메시지를_ChatMessages에_추가하고_모든_ClientSessionActor에_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -128,7 +128,7 @@ class ChannelReaderActorTest {
     @Test
     void GetHistory_메시지를_받았을_때_히스토리가_존재하면_ClientSession에_DeliverHistory를_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -173,7 +173,7 @@ class ChannelReaderActorTest {
     @Test
     void GetHistory_메시지를_받았을_때_히스토리가_비어있으면_ChannelEntity에_ResolveHistory를_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -212,7 +212,7 @@ class ChannelReaderActorTest {
     @Test
     void SyncDeletion_메시지를_받으면_ChatMessages에서_메시지를_삭제하고_모든_ClientSessionActor에_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -266,7 +266,7 @@ class ChannelReaderActorTest {
     @Test
     void SyncUpdate_메시지를_받으면_ChatMessages에서_메시지를_수정하고_모든_ClientSessionActor에_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -321,7 +321,7 @@ class ChannelReaderActorTest {
     @Test
     void RegisterClientSession_메시지를_받으면_clientSessions에_등록된다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -361,7 +361,7 @@ class ChannelReaderActorTest {
     @Test
     void RequestInitialHistory_메시지를_받으면_채팅_히스토리를_ClientSessionActor에게_전달한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
@@ -392,7 +392,7 @@ class ChannelReaderActorTest {
     @Test
     void RequestInitialHistory_메시지를_받았을_때_채팅_히스토리가_동기화되지_않았다면_별도로_관리된다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
@@ -415,7 +415,7 @@ class ChannelReaderActorTest {
     @Test
     void DeliverSyncMessages_이전까지_대기중이던_RequestInitialHistory에게_히스토리를_전달한다() {
         // given
-        ChatMessages chatMessages = new ChatMessages();
+        ChannelReaderMessages chatMessages = new ChannelReaderMessages();
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
@@ -449,7 +449,7 @@ class ChannelReaderActorTest {
     @Test
     void 초기_동기화_전_도착한_SyncNewMessage는_대기하다가_동기화_완료_후에_전파된다() {
         // given
-        ChatMessages chatMessages = new ChatMessages();
+        ChannelReaderMessages chatMessages = new ChannelReaderMessages();
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> mockChannelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe();
@@ -479,7 +479,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyChangeChannelPolicy_메시지를_받으면_모든_ClientSessionActor에게_채널_정책_변경을_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -522,7 +522,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyMemberLeft_메시지를_받으면_해당_ClientSessionActor에게_채널_탈퇴를_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -549,7 +549,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyKickedMember_메시지를_받으면_해당_ClientSessionActor에게_강퇴_알림을_전송하고_clientSessions에서_제거한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -584,7 +584,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyFailure_메시지를_받으면_해당_ClientSessionActor에게_에러를_전송한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -616,7 +616,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyEditChannelName_메시지를_받으면_모든_ClientSessionActor에게_채널_이름_변경을_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -656,7 +656,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyChangeChannelMembership_메시지를_받으면_해당_ClientSessionActor에게_멤버십_변경을_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -690,7 +690,7 @@ class ChannelReaderActorTest {
     @Test
     void NotifyMembershipCountChanged_메시지를_받으면_모든_ClientSessionActor에게_멤버십_카운트_변경을_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -730,7 +730,7 @@ class ChannelReaderActorTest {
     @Test
     void SyncMembership_메시지를_받으면_해당_ClientSessionActor에게_멤버십_정보를_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);
@@ -764,7 +764,7 @@ class ChannelReaderActorTest {
     @Test
     void SyncChannelMetadata_메시지를_받으면_모든_ClientSessionActor에게_채널_메타데이터를_전파한다() {
         // given
-        ChatMessages mockMessages = mock(ChatMessages.class);
+        ChannelReaderMessages mockMessages = mock(ChannelReaderMessages.class);
         @SuppressWarnings("unchecked")
         EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
         TestProbe<ChannelReaderRegistryCommand> registryProbe = testKit.createTestProbe(ChannelReaderRegistryCommand.class);

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderMessagesTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelReaderMessagesTest.java
@@ -1,0 +1,338 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.chat.actor.ChannelReaderMessages.MessageNotFoundException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelReaderMessagesTest {
+
+    @Test
+    void 새로운_메시지를_추가할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage message = ChatMessage.create(1L, 100L, 1L, "Test Message", timestamp, timestamp);
+
+        // when
+        messages.add(message);
+
+        // then
+        List<ChatMessage> allMessages = messages.getMessages();
+        assertAll(
+                () -> assertThat(allMessages).hasSize(1),
+                () -> assertThat(allMessages.get(0)).isEqualTo(message)
+        );
+    }
+
+    @Test
+    void 메시지_ID로_메시지를_삭제할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage message = ChatMessage.create(1L, 100L, 1L, "Test Message", timestamp, timestamp);
+        messages.add(message);
+
+        // when
+        ChatMessage deletedMessage = messages.delete(message.messageId());
+
+        // then
+        assertAll(
+                () -> assertThat(deletedMessage).isEqualTo(message),
+                () -> assertThat(messages.getMessages()).isEmpty()
+        );
+    }
+
+    @Test
+    void 존재하지_않는_메시지를_삭제하면_예외가_발생한다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+
+        // when & then
+        assertThatThrownBy(() -> messages.delete(999L))
+                .isInstanceOf(MessageNotFoundException.class)
+                .hasMessage("존재하지 않는 메시지입니다.");
+    }
+
+    @Test
+    void 메시지를_수정할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage message = ChatMessage.create(1L, 100L, 1L, "Original Message", timestamp, timestamp);
+        messages.add(message);
+
+        String updatedContent = "Updated Message";
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        // when
+        ChatMessage updatedMessage = messages.update(message.messageId(), updatedContent, updatedAt);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedMessage.message()).isEqualTo(updatedContent),
+                () -> assertThat(updatedMessage.updatedAt()).isEqualTo(updatedAt)
+        );
+    }
+
+    @Test
+    void 존재하지_않는_메시지를_수정하면_예외가_발생한다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        // when & then
+        assertThatThrownBy(() -> messages.update(999L, "Updated", updatedAt))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 채팅 메시지입니다.");
+    }
+
+    @Test
+    void 특정_시퀀스_이전의_메시지_히스토리를_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        messages.add(ChatMessage.create(1L, 100L, 10L, "Message 10", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 101L, 20L, "Message 20", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 102L, 30L, "Message 30", timestamp, timestamp));
+
+        // when
+        List<ChatMessage> history = messages.getHistory(25L, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(history).hasSize(2),
+                () -> assertThat(history.get(0).orderSequence()).isEqualTo(20L),
+                () -> assertThat(history.get(1).orderSequence()).isEqualTo(10L)
+        );
+    }
+
+    @Test
+    void 최근_메시지를_지정한_개수만큼_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        messages.add(ChatMessage.create(1L, 100L, 10L, "Message 1", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 101L, 20L, "Message 2", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 102L, 30L, "Message 3", timestamp, timestamp));
+
+        // when
+        List<ChatMessage> recentMessages = messages.getRecentMessages(2);
+
+        // then
+        assertAll(
+                () -> assertThat(recentMessages).hasSize(2),
+                () -> assertThat(recentMessages.get(0).orderSequence()).isEqualTo(30L),
+                () -> assertThat(recentMessages.get(1).orderSequence()).isEqualTo(20L)
+        );
+    }
+
+    @Test
+    void 특정_시퀀스_이후의_메시지를_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        messages.add(ChatMessage.create(1L, 100L, 10L, "Message 10", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 101L, 20L, "Message 20", timestamp, timestamp));
+        messages.add(ChatMessage.create(1L, 102L, 30L, "Message 30", timestamp, timestamp));
+
+        // when
+        List<ChatMessage> messagesAfter = messages.getMessagesAfter(15L);
+
+        // then
+        assertAll(
+                () -> assertThat(messagesAfter).hasSize(2),
+                () -> assertThat(messagesAfter.get(0).orderSequence()).isEqualTo(30L),
+                () -> assertThat(messagesAfter.get(1).orderSequence()).isEqualTo(20L)
+        );
+    }
+
+    @Test
+    void 메시지_ID로_특정_메시지를_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+        ChatMessage message = ChatMessage.create(1L, 100L, 1L, "Test Message", timestamp, timestamp);
+        messages.add(message);
+
+        // when
+        ChatMessage retrievedMessage = messages.getMessage(message.messageId());
+
+        // then
+        assertThat(retrievedMessage).isEqualTo(message);
+    }
+
+    @Test
+    void 모든_메시지를_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        ChatMessage message1 = ChatMessage.create(1L, 100L, 10L, "Message 1", timestamp, timestamp);
+        ChatMessage message2 = ChatMessage.create(1L, 101L, 20L, "Message 2", timestamp, timestamp);
+        ChatMessage message3 = ChatMessage.create(1L, 102L, 30L, "Message 3", timestamp, timestamp);
+
+        messages.add(message1);
+        messages.add(message2);
+        messages.add(message3);
+
+        // when
+        List<ChatMessage> allMessages = messages.getMessages();
+
+        // then
+        assertAll(
+                () -> assertThat(allMessages).hasSize(3),
+                () -> assertThat(allMessages).containsExactly(message3, message2, message1)
+        );
+    }
+
+    @Test
+    void 최대_크기를_초과하면_가장_오래된_메시지가_제거된다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        for (int i = 1; i <= 101; i++) {
+            messages.add(ChatMessage.create(1L, (long) i, i, "Message " + i, timestamp, timestamp));
+        }
+
+        // when
+        List<ChatMessage> allMessages = messages.getMessages();
+
+        // then
+        assertAll(
+                () -> assertThat(allMessages).hasSize(100),
+                () -> assertThat(allMessages.get(0).orderSequence()).isEqualTo(101L),
+                () -> assertThat(allMessages.get(99).orderSequence()).isEqualTo(2L)
+        );
+    }
+
+    @Test
+    void syncMessages로_새로운_메시지_목록과_동기화할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        ChatMessage oldMessage = new ChatMessage(1L, 100L, 100L, 10L, "Old Message", timestamp, timestamp);
+        messages.add(oldMessage);
+
+        List<ChatMessage> newMessages = List.of(
+                new ChatMessage(2L, 1L, 101L, 20L, "New Message 1", timestamp, timestamp),
+                new ChatMessage(3L, 1L, 102L, 30L, "New Message 2", timestamp, timestamp)
+        );
+
+        // when
+        messages.syncMessages(newMessages);
+
+        // then
+        List<ChatMessage> allMessages = messages.getMessages();
+        assertAll(
+                () -> assertThat(allMessages).hasSize(3),
+                () -> assertThat(allMessages.get(0).orderSequence()).isEqualTo(30L),
+                () -> assertThat(allMessages.get(1).orderSequence()).isEqualTo(20L),
+                () -> assertThat(allMessages.get(2).orderSequence()).isEqualTo(10L)
+        );
+    }
+
+    @Test
+    void syncMessages로_중복된_메시지는_제거된다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        ChatMessage originalMessage = new ChatMessage(1L, 1L, 100L, 10L, "Original", timestamp, timestamp);
+        messages.add(originalMessage);
+
+        ChatMessage updatedMessage = new ChatMessage(1L, 1L, 100L, 10L, "Updated", timestamp, timestamp);
+        List<ChatMessage> newMessages = List.of(updatedMessage);
+
+        // when
+        messages.syncMessages(newMessages);
+
+        // then
+        List<ChatMessage> allMessages = messages.getMessages();
+        assertAll(
+                () -> assertThat(allMessages).hasSize(1),
+                () -> assertThat(allMessages.get(0).message()).isEqualTo("Updated")
+        );
+    }
+
+    @Test
+    void syncMessages에_빈_리스트를_전달하면_아무_동작도_하지_않는다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        ChatMessage message = ChatMessage.create(1L, 100L, 10L, "Message", timestamp, timestamp);
+        messages.add(message);
+
+        // when
+        messages.syncMessages(List.of());
+
+        // then
+        List<ChatMessage> allMessages = messages.getMessages();
+        assertAll(
+                () -> assertThat(allMessages).hasSize(1),
+                () -> assertThat(allMessages.get(0)).isEqualTo(message)
+        );
+    }
+
+    @Test
+    void 조회하려는_메시지_개수가_0_이하면_예외가_발생한다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+
+        // when & then
+        assertThatThrownBy(() -> messages.getHistory(10L, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("조회하려는 메시지 개수는 양수여야 합니다.");
+    }
+
+    @Test
+    void 조회하려는_메시지_개수가_최대값을_초과하면_예외가_발생한다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+
+        // when & then
+        assertThatThrownBy(() -> messages.getRecentMessages(101))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("조회하려는 메시지 개수는 100개를 넘을 수 없습니다.");
+    }
+
+    @Test
+    void 여러_메시지를_추가하고_순서대로_조회할_수_있다() {
+        // given
+        ChannelReaderMessages messages = new ChannelReaderMessages();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        ChatMessage message1 = ChatMessage.create(1L, 100L, 10L, "First", timestamp, timestamp);
+        ChatMessage message2 = ChatMessage.create(1L, 101L, 20L, "Second", timestamp, timestamp);
+        ChatMessage message3 = ChatMessage.create(1L, 102L, 30L, "Third", timestamp, timestamp);
+
+        // when
+        messages.add(message1);
+        messages.add(message2);
+        messages.add(message3);
+
+        // then
+        List<ChatMessage> allMessages = messages.getMessages();
+        assertAll(
+                () -> assertThat(allMessages).hasSize(3),
+                () -> assertThat(allMessages.get(0).orderSequence()).isEqualTo(30L),
+                () -> assertThat(allMessages.get(1).orderSequence()).isEqualTo(20L),
+                () -> assertThat(allMessages.get(2).orderSequence()).isEqualTo(10L)
+        );
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChatMessagesTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChatMessagesTest.java
@@ -3,7 +3,12 @@ package com.tok.pekko.domain.chat.actor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,6 +26,8 @@ class ChatMessagesTest {
     @Test
     void 빈_ChatMessages를_생성한다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
 
         assertThat(chatMessages.getRecentMessages(10)).isEmpty();
     }
@@ -343,6 +350,8 @@ class ChatMessagesTest {
     @Test
     void 메시지를_삭제한다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         LocalDateTime timestamp3 = LocalDateTime.now();
@@ -354,7 +363,7 @@ class ChatMessagesTest {
         chatMessages.add(message2);
         chatMessages.add(message3);
 
-        ChatMessage deleted = chatMessages.delete(2L);
+        ChatMessage deleted = chatMessages.delete(channel, UserId.create(999L), 2L);
 
         List<ChatMessage> result = chatMessages.getRecentMessages(10);
         assertAll(
@@ -368,6 +377,8 @@ class ChatMessagesTest {
     @Test
     void 첫번째_메시지를_삭제한다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         LocalDateTime timestamp3 = LocalDateTime.now();
@@ -379,7 +390,7 @@ class ChatMessagesTest {
         chatMessages.add(message2);
         chatMessages.add(message3);
 
-        ChatMessage deleted = chatMessages.delete(3L);
+        ChatMessage deleted = chatMessages.delete(channel, UserId.create(999L), 3L);
 
         List<ChatMessage> result = chatMessages.getRecentMessages(10);
         assertAll(
@@ -392,6 +403,8 @@ class ChatMessagesTest {
     @Test
     void 마지막_메시지를_삭제한다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         LocalDateTime timestamp3 = LocalDateTime.now();
@@ -403,7 +416,7 @@ class ChatMessagesTest {
         chatMessages.add(message2);
         chatMessages.add(message3);
 
-        ChatMessage deleted = chatMessages.delete(1L);
+        ChatMessage deleted = chatMessages.delete(channel, UserId.create(999L), 1L);
 
         List<ChatMessage> result = chatMessages.getRecentMessages(10);
         assertAll(
@@ -416,27 +429,33 @@ class ChatMessagesTest {
     @Test
     void 존재하지_않는_메시지는_삭제할_수_없다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage message = new ChatMessage(1L, 10L, 100L, 1000L, "Message", timestamp, timestamp);
         chatMessages.add(message);
 
-        assertThatThrownBy(() -> chatMessages.delete(999L))
+        assertThatThrownBy(() -> chatMessages.delete(channel, UserId.create(999L), 999L))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 메시지입니다: 999");
+                .hasMessage("존재하지 않는 채팅 메시지입니다.");
     }
 
     @Test
     void 메시지_ID로_null을_전달하면_메시지를_삭제할_수_없다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
 
-        assertThatThrownBy(() -> chatMessages.delete(null))
+        assertThatThrownBy(() -> chatMessages.delete(channel, UserId.create(1L), null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("메시지 ID는 null 일 수 없습니다.");
+                .hasMessage("존재하지 않는 채팅 메시지입니다.");
     }
 
     @Test
     void 모든_메시지를_삭제할_수_있다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         ChatMessage message1 = new ChatMessage(1L, 10L, 100L, 1000L, "Message 1", timestamp1, timestamp1);
@@ -445,8 +464,8 @@ class ChatMessagesTest {
         chatMessages.add(message1);
         chatMessages.add(message2);
 
-        ChatMessage deleted1 = chatMessages.delete(1L);
-        ChatMessage deleted2 = chatMessages.delete(2L);
+        ChatMessage deleted1 = chatMessages.delete(channel, UserId.create(999L), 1L);
+        ChatMessage deleted2 = chatMessages.delete(channel, UserId.create(999L), 2L);
 
         assertAll(
                 () -> assertThat(deleted1).isEqualTo(message1),
@@ -457,6 +476,7 @@ class ChatMessagesTest {
 
     @Test
     void 메시지_히스토리_조회_시_삭제된_메시지는_포함되지_않는다() {
+        Channel channel = mock(Channel.class);
         ChatMessages chatMessages = new ChatMessages();
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
@@ -467,7 +487,7 @@ class ChatMessagesTest {
         chatMessages.add(new ChatMessage(3L, 30L, 300L, 3000L, "Message 3", timestamp3, timestamp3));
         chatMessages.add(new ChatMessage(4L, 40L, 400L, 4000L, "Message 4", timestamp4, timestamp4));
 
-        ChatMessage deleted = chatMessages.delete(2L);
+        ChatMessage deleted = chatMessages.delete(channel, UserId.create(999L), 2L);
         List<ChatMessage> history = chatMessages.getHistory(3500L, 10);
 
         assertAll(
@@ -482,6 +502,8 @@ class ChatMessagesTest {
     @Test
     void 특정_시점_이후_메시지_조회_시_삭제된_메시지는_포함되지_않는다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberDeleteMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         LocalDateTime timestamp3 = LocalDateTime.now();
@@ -489,7 +511,7 @@ class ChatMessagesTest {
         chatMessages.add(new ChatMessage(2L, 20L, 200L, 2000L, "Message 2", timestamp2, timestamp2));
         chatMessages.add(new ChatMessage(3L, 30L, 300L, 3000L, "Message 3", timestamp3, timestamp3));
 
-        ChatMessage deleted = chatMessages.delete(2L);
+        ChatMessage deleted = chatMessages.delete(channel, UserId.create(999L), 2L);
         List<ChatMessage> messagesAfter = chatMessages.getMessagesAfter(1500L);
 
         assertAll(
@@ -504,11 +526,13 @@ class ChatMessagesTest {
     @Test
     void 메시지를_수정한다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberEditMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage original = new ChatMessage(1L, 10L, 100L, 1000L, "Original", timestamp, timestamp);
         chatMessages.add(original);
 
-        ChatMessage updated = chatMessages.update(1L, "Updated", LocalDateTime.now());
+        ChatMessage updated = chatMessages.update(channel, 100L, 1L, "Updated", LocalDateTime.now());
 
         List<ChatMessage> result = chatMessages.getRecentMessages(10);
         assertAll(
@@ -529,7 +553,10 @@ class ChatMessagesTest {
         ChatMessage message = new ChatMessage(1L, 10L, 100L, 1000L, "Message", timestamp, timestamp);
         chatMessages.add(message);
 
-        assertThatThrownBy(() -> chatMessages.update(999L, "Updated", LocalDateTime.now()))
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberEditMessage(any(UserId.class), any(ChatMessage.class));
+
+        assertThatThrownBy(() -> chatMessages.update(channel, 100L, 999L, "Updated", LocalDateTime.now()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 채팅 메시지입니다.");
     }
@@ -537,12 +564,14 @@ class ChatMessagesTest {
     @Test
     void null_메시지로는_수정할_수_없다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberEditMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage message = new ChatMessage(1L, 10L, 100L, 1000L, "Message", timestamp, timestamp);
 
         chatMessages.add(message);
 
-        assertThatThrownBy(() -> chatMessages.update(1L, null, LocalDateTime.now()))
+        assertThatThrownBy(() -> chatMessages.update(channel, 100L, 1L, null, LocalDateTime.now()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("메시지는 비어 있을 수 없습니다.");
     }
@@ -550,6 +579,8 @@ class ChatMessagesTest {
     @Test
     void 채팅_히스토리_조회_시_수정된_메시지가_올바르게_조회된다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberEditMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp1 = LocalDateTime.now();
         LocalDateTime timestamp2 = LocalDateTime.now();
         LocalDateTime timestamp3 = LocalDateTime.now();
@@ -557,7 +588,7 @@ class ChatMessagesTest {
         chatMessages.add(new ChatMessage(2L, 20L, 200L, 2000L, "Message 2", timestamp2, timestamp2));
         chatMessages.add(new ChatMessage(3L, 30L, 300L, 3000L, "Message 3", timestamp3, timestamp3));
 
-        ChatMessage updated = chatMessages.update(2L, "Updated Message 2", LocalDateTime.now());
+        ChatMessage updated = chatMessages.update(channel, 100L, 2L, "Updated Message 2", LocalDateTime.now());
         List<ChatMessage> history = chatMessages.getHistory(2500L, 10);
 
         assertAll(
@@ -574,11 +605,13 @@ class ChatMessagesTest {
     @Test
     void 채팅_메시지_복제_시_수정된_메시지가_올바르게_동기화된다() {
         ChatMessages chatMessages = new ChatMessages();
+        Channel channel = mock(Channel.class);
+        doNothing().when(channel).validateMemberEditMessage(any(UserId.class), any(ChatMessage.class));
         LocalDateTime timestamp = LocalDateTime.now();
         ChatMessage message = new ChatMessage(1L, 10L, 100L, 1000L, "Original", timestamp, timestamp);
         chatMessages.add(message);
 
-        ChatMessage updated = chatMessages.update(1L, "Updated", LocalDateTime.now());
+        ChatMessage updated = chatMessages.update(channel, 100L, 1L, "Updated", LocalDateTime.now());
 
         ChatMessages copy = chatMessages.deepCopy();
 

--- a/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
@@ -1,7 +1,6 @@
 package com.tok.pekko.global.actor;
 
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
-import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
@@ -50,8 +49,7 @@ class GuardianActorTest {
                         Clock.systemDefaultZone(),
                         mock(MessageStoragePort.class),
                         mock(ChannelActorStoragePort.class),
-                        mock(ChannelMembershipActorStoragePort.class),
-                        mock(ClientSessionActorManagementService.class)
+                        mock(ChannelMembershipActorStoragePort.class)
                 ),
                 "test-system",
                 config
@@ -65,8 +63,7 @@ class GuardianActorTest {
                         Clock.systemDefaultZone(),
                         mock(MessageStoragePort.class),
                         mock(ChannelActorStoragePort.class),
-                        mock(ChannelMembershipActorStoragePort.class),
-                        mock(ClientSessionActorManagementService.class)
+                        mock(ChannelMembershipActorStoragePort.class)
                 )
         );
         responseProbe = testKit.createTestProbe();

--- a/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/global/actor/GuardianActorTest.java
@@ -1,13 +1,17 @@
 package com.tok.pekko.global.actor;
 
 import com.tok.pekko.adapter.out.websocket.ClientMessageSender;
+import com.tok.pekko.application.actor.ClientSessionActorManagementService;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import com.tok.pekko.global.actor.GuardianActor.GuardianCommand;
 import com.tok.pekko.global.actor.GuardianActor.SpawnClientSession;
 import com.tok.pekko.global.actor.GuardianActor.SpawnedClientSession;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Clock;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -42,7 +46,13 @@ class GuardianActorTest {
     @BeforeEach
     void beforeEach() {
         ActorSystem<GuardianCommand> system = ActorSystem.create(
-                GuardianActor.create(),
+                GuardianActor.create(
+                        Clock.systemDefaultZone(),
+                        mock(MessageStoragePort.class),
+                        mock(ChannelActorStoragePort.class),
+                        mock(ChannelMembershipActorStoragePort.class),
+                        mock(ClientSessionActorManagementService.class)
+                ),
                 "test-system",
                 config
         );
@@ -50,7 +60,15 @@ class GuardianActorTest {
         Cluster cluster = Cluster.get(system);
         cluster.manager().tell(new Join(cluster.selfMember().address()));
 
-        guardianActor = testKit.spawn(GuardianActor.create());
+        guardianActor = testKit.spawn(
+                GuardianActor.create(
+                        Clock.systemDefaultZone(),
+                        mock(MessageStoragePort.class),
+                        mock(ChannelActorStoragePort.class),
+                        mock(ChannelMembershipActorStoragePort.class),
+                        mock(ClientSessionActorManagementService.class)
+                )
+        );
         responseProbe = testKit.createTestProbe();
     }
 


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #23 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
### 비즈니스 로직 수행 위치 변경 

- ChannelEntity를 통한 비즈니스 로직 수행
  - Channel 관련 비즈니스 로직을 ChannelEntity 내부 필드 및 메서드로 구현
- 도메인 이벤트 기반 상태 변경 전파
  - ChannelEntity에서 수행된 비즈니스 로직의 결과를 도메인 이벤트로 변환
  - 생성된 도메인 이벤트를 ChannelEventHandlerEntity에게 전달
  - ChannelEventHandlerEntity는 Port를 통해 도메인 이벤트를 영속화