### PR TITLE
클라이언트에게 채널 변경사항을 실시간으로 반영할 수 있는 기능 추가

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageType;
 import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
@@ -17,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
 import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
@@ -32,15 +32,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
-@Slf4j
 @Profile("dev")
 @Component
 @RequiredArgsConstructor
 public class DevChatWebSocketHandler implements WebSocketHandler {
 
-    private static final String HEARTBEAT_PING_MESSAGE_TYPE = "PING";
-    private static final String HEARTBEAT_PONG_MESSAGE_TYPE = "PONG";
-    private static final String SESSION_HEALTH_PONG_MESSAGE_TYPE = "WS_PONG";
     private static final String MESSAGE_SCHEMA_TYPE = "type";
 
     private final ObjectMapper objectMapper;
@@ -138,10 +134,10 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     ) {
         try {
             JsonNode node = objectMapper.readTree(payload);
-            String type = node.path("type").asText();
+            String type = node.path(MESSAGE_SCHEMA_TYPE).asText();
 
-            if (HEARTBEAT_PING_MESSAGE_TYPE.equalsIgnoreCase(type)) {
-                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload(HEARTBEAT_PONG_MESSAGE_TYPE, null));
+            if (WebSocketMessageType.HEARTBEAT_PING.isSameType(type)) {
+                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageType.HEARTBEAT_PONG, null));
                 return true;
             }
         } catch (Exception ignored) {
@@ -158,7 +154,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
             JsonNode node = objectMapper.readTree(payload);
             String type = node.path(MESSAGE_SCHEMA_TYPE).asText();
 
-            if (SESSION_HEALTH_PONG_MESSAGE_TYPE.equalsIgnoreCase(type)) {
+            if (WebSocketMessageType.SESSION_HEALTH_PONG.isSameType(type)) {
                 clientSession.thenAccept(actorRef -> actorRef.tell(new SessionPongReceived()));
                 return true;
             }

--- a/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/in/websocket/DevChatWebSocketHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender;
 import com.tok.pekko.adapter.out.websocket.WebSocketMessageType;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketOutboundMessage;
 import com.tok.pekko.application.actor.ClientSessionActorManagementService;
 import com.tok.pekko.domain.chat.actor.ChannelEntity;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
@@ -47,7 +48,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     @Override
     public Mono<Void> handle(WebSocketSession session) {
         WebSocketConnectionContext context = extractConnectionContext(session);
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> messageSink = createMessageSink();
+        Sinks.Many<WebSocketOutboundMessage> messageSink = createMessageSink();
         WebSocketMessageSender messageSender = getOrCreateMessageSender(context, messageSink);
 
         CompletionStage<ActorRef<ClientSessionCommand>> clientSession =
@@ -65,7 +66,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
         return WebSocketConnectionContext.from(session);
     }
 
-    private Sinks.Many<WebSocketMessageSender.WebSocketPayload> createMessageSink() {
+    private Sinks.Many<WebSocketOutboundMessage> createMessageSink() {
         return Sinks.many()
                     .unicast()
                     .onBackpressureBuffer();
@@ -73,7 +74,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private WebSocketMessageSender getOrCreateMessageSender(
             WebSocketConnectionContext context,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+            Sinks.Many<WebSocketOutboundMessage> sink
     ) {
         return clientMessageSenders.compute(
                 context.userId(),
@@ -101,7 +102,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
     private Mono<Void> handleInboundMessages(
             WebSocketSession session,
             WebSocketConnectionContext context,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink,
+            Sinks.Many<WebSocketOutboundMessage> sink,
             CompletionStage<ActorRef<ClientSessionCommand>> clientSession
     ) {
         return session.receive()
@@ -111,7 +112,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private Mono<Void> processInboundMessage(
             WebSocketConnectionContext context,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink,
+            Sinks.Many<WebSocketOutboundMessage> sink,
             CompletionStage<ActorRef<ClientSessionCommand>> clientSession,
             WebSocketMessage message
     ) {
@@ -130,14 +131,14 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private boolean handlePingMessage(
             String payload,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+            Sinks.Many<WebSocketOutboundMessage> sink
     ) {
         try {
             JsonNode node = objectMapper.readTree(payload);
             String type = node.path(MESSAGE_SCHEMA_TYPE).asText();
 
             if (WebSocketMessageType.HEARTBEAT_PING.isSameType(type)) {
-                sink.tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageType.HEARTBEAT_PONG, null));
+                sink.tryEmitNext(WebSocketOutboundMessage.withoutPayload(WebSocketMessageType.HEARTBEAT_PONG));
                 return true;
             }
         } catch (Exception ignored) {
@@ -176,7 +177,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private Flux<WebSocketMessage> handleOutboundMessages(
             WebSocketSession session,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+            Sinks.Many<WebSocketOutboundMessage> sink
     ) {
         return sink.asFlux()
                    .flatMap(payload -> serializeMessage(session, payload));
@@ -184,7 +185,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private Mono<WebSocketMessage> serializeMessage(
             WebSocketSession session,
-            WebSocketMessageSender.WebSocketPayload payload
+            WebSocketOutboundMessage payload
     ) {
         try {
             String json = objectMapper.writeValueAsString(payload);
@@ -197,7 +198,7 @@ public class DevChatWebSocketHandler implements WebSocketHandler {
 
     private void cleanupConnection(
             WebSocketMessageSender messageSender,
-            Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink
+            Sinks.Many<WebSocketOutboundMessage> sink
     ) {
         messageSender.detachSink(sink);
         sink.tryEmitComplete();

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientMessageSender.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.adapter.out.websocket;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
 
@@ -16,4 +18,18 @@ public interface ClientMessageSender {
     void sendWebSocketPing();
 
     void requestSessionReconnect();
+
+    void sendChangedChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount);
+
+    void sendChangedMembershipCount(Long channelId, int membershipCount);
+
+    void sendInvitedChannel(Long channelId);
+
+    void sendEditedChannelName(Long channelId, String editedName);
+
+    void sendKickedFromChannel(Long channelId);
+
+    void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy);
+
+    void sendError(Long channelId, String reason);
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/ClientSessionActor.java
@@ -16,6 +16,13 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
@@ -63,6 +70,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                         userId,
                                         clientMessageSender,
                                         messageStoragePort,
+                                        channelMembershipActorMessagePort,
                                         readerRegistry
                                 );
                             }
@@ -74,6 +82,7 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
     private final Long userId;
     private final ClientMessageSender clientMessageSender;
     private final MessageStoragePort messageStoragePort;
+    private final ChannelMembershipActorMessagePort channelMembershipActorMessagePort;
     private final ActorRef<ChannelReaderRegistryCommand> readerRegistry;
     private final Map<Long, ActorRef<ChannelReaderCommand>> readers;
     private final Map<Long, RequestHistory> pendingRequestHistory;
@@ -84,12 +93,14 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             Long userId,
             ClientMessageSender clientMessageSender,
             MessageStoragePort messageStoragePort,
+            ChannelMembershipActorMessagePort channelMembershipActorMessagePort,
             ActorRef<ChannelReaderRegistryCommand> readerRegistry
     ) {
         super(context);
 
         this.userId = userId;
         this.messageStoragePort = messageStoragePort;
+        this.channelMembershipActorMessagePort = channelMembershipActorMessagePort;
         this.clientMessageSender = clientMessageSender;
         this.readerRegistry = readerRegistry;
         this.readers = new HashMap<>();
@@ -112,6 +123,13 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
                                   .onMessage(Shutdown.class, this::onShutdown)
                                   .onMessage(SessionPongReceived.class, this::onSessionPongReceived)
                                   .onMessage(SessionHealthCheck.class, this::onSessionHealthCheck)
+                                  .onMessage(PropagateChangeChannelMembership.class, this::onPropagateChangeChannelMembership)
+                                  .onMessage(PropagateMembershipCount.class, this::onPropagateMembershipCount)
+                                  .onMessage(PropagateChangeChannelPolicy.class, this::onPropagateChangeChannelPolicy)
+                                  .onMessage(PropagateEditChannelName.class, this::onPropagateEditChannelName)
+                                  .onMessage(PropagateKickedMember.class, this::onPropagateKickedMember)
+                                  .onMessage(ReSyncSession.class, this::onReSyncSession)
+                                  .onMessage(PropagateFailure.class, this::onPropagateFailure)
                                   .build();
     }
 
@@ -242,6 +260,49 @@ public class ClientSessionActor extends AbstractBehavior<ClientSessionCommand> {
             clientMessageSender.requestSessionReconnect();
             missedSessionPongs = 0;
         }
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateChangeChannelMembership(PropagateChangeChannelMembership command) {
+        clientMessageSender.sendChangedChannelMembership(command.channelId(), command.channelMembership(), command.membershipCount());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateMembershipCount(PropagateMembershipCount command) {
+        clientMessageSender.sendChangedMembershipCount(command.channelId(), command.membershipCount());
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateChangeChannelPolicy(PropagateChangeChannelPolicy command) {
+        clientMessageSender.sendChangedChannelPolicy(command.channelId(), command.channelPolicy());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateEditChannelName(PropagateEditChannelName command) {
+        clientMessageSender.sendEditedChannelName(command.channelId(), command.editedName());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateKickedMember(PropagateKickedMember command) {
+        clientMessageSender.sendKickedFromChannel(command.channelId());
+        readers.remove(command.channelId());
+        readerRegistry.tell(new ReleaseClientSessionActor(userId, List.of(command.channelId())));
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onReSyncSession(ReSyncSession command) {
+        channelMembershipActorMessagePort.sendParticipatingChannels(userId, getContext().getSelf());
+
+        return this;
+    }
+
+    private Behavior<ClientSessionCommand> onPropagateFailure(PropagateFailure command) {
+        clientMessageSender.sendError(command.channelId(), command.reason());
 
         return this;
     }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
@@ -1,7 +1,11 @@
 package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import reactor.core.publisher.Sinks;
 
@@ -12,6 +16,13 @@ public class WebSocketMessageSender implements ClientMessageSender {
     public static final String EVENT_DELETED = "DELETED";
     public static final String EVENT_WS_PING = "WS_HEALTH_PING";
     public static final String EVENT_WS_RECONNECT = "WS_RECONNECT";
+    public static final String EVENT_CHANNEL_MEMBERSHIP_CHANGED = "CHANNEL_MEMBERSHIP_CHANGED";
+    public static final String EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED = "CHANNEL_MEMBERSHIP_COUNT_CHANGED";
+    public static final String EVENT_INVITED_CHANNEL = "CHANNEL_INVITED";
+    public static final String EVENT_CHANNEL_NAME_EDITED = "CHANNEL_NAME_EDITED";
+    public static final String EVENT_CHANNEL_KICKED = "CHANNEL_KICKED";
+    public static final String EVENT_CHANNEL_POLICY_CHANGED = "CHANNEL_POLICY_CHANGED";
+    public static final String EVENT_ERROR = "ERROR";
 
     private final AtomicReference<Sinks.Many<WebSocketPayload>> sinkHolder;
 
@@ -33,7 +44,9 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendMessage(ChatMessage message) {
-        emit(new WebSocketPayload(EVENT_NEW, message));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_NEW, message);
+
+        emit(webSocketPayload);
     }
 
     @Override
@@ -43,22 +56,92 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendDeletedMessage(ChatMessage deletedMessage) {
-        emit(new WebSocketPayload(EVENT_DELETED, deletedMessage));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_DELETED, deletedMessage);
+
+        emit(webSocketPayload);
     }
 
     @Override
     public void sendUpdatedMessage(ChatMessage updatedMessage) {
-        emit(new WebSocketPayload(EVENT_UPDATED, updatedMessage));
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_UPDATED, updatedMessage);
+
+        emit(webSocketPayload);
     }
 
     @Override
     public void sendWebSocketPing() {
-        emit(new WebSocketPayload(EVENT_WS_PING, null));
+        emit(WebSocketPayload.PING_PAYLOAD);
     }
 
     @Override
     public void requestSessionReconnect() {
-        emit(new WebSocketPayload(EVENT_WS_RECONNECT, null));
+        emit(WebSocketPayload.RECONNECT_PAYLOAD);
+    }
+
+    @Override
+    public void sendChangedChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount) {
+        ChannelMembershipPayload channelMembershipPayload = ChannelMembershipPayload.from(
+                channelId,
+                channelMembership,
+                membershipCount
+        );
+        WebSocketPayload webSocketPayload = new WebSocketPayload(
+                EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                channelMembershipPayload
+        );
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendChangedMembershipCount(Long channelId, int membershipCount) {
+        ChannelMembershipCountPayload channelMembershipCountPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(
+                EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                channelMembershipCountPayload
+        );
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendInvitedChannel(Long channelId) {
+        ChannelInvitePayload channelInvitePayload = new ChannelInvitePayload(channelId);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_INVITED_CHANNEL, channelInvitePayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendEditedChannelName(Long channelId, String editedName) {
+        ChannelNamePayload channelNamePayload = new ChannelNamePayload(channelId, editedName);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_NAME_EDITED, channelNamePayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendKickedFromChannel(Long channelId) {
+        ChannelKickedPayload channelKickedPayload = new ChannelKickedPayload(channelId);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_KICKED, channelKickedPayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy) {
+        ChannelPolicyPayload channelPolicyPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_POLICY_CHANGED, channelPolicyPayload);
+
+        emit(webSocketPayload);
+    }
+
+    @Override
+    public void sendError(Long channelId, String reason) {
+        ErrorPayload errorPayload = new ErrorPayload(channelId, reason);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_ERROR, errorPayload);
+
+        emit(webSocketPayload);
     }
 
     private void emit(WebSocketPayload payload) {
@@ -69,5 +152,53 @@ public class WebSocketMessageSender implements ClientMessageSender {
         }
     }
 
-    public record WebSocketPayload(String type, ChatMessage message) { }
+    public record WebSocketPayload(String type, Object message) {
+
+        static final WebSocketPayload PING_PAYLOAD = new WebSocketPayload(EVENT_WS_PING, null);
+        static final WebSocketPayload RECONNECT_PAYLOAD = new WebSocketPayload(EVENT_WS_RECONNECT, null);
+    }
+
+    public record ChannelMembershipPayload(
+            Long channelId,
+            Long memberId,
+            String role,
+            Set<ChannelPermissionType> permissions,
+            int membershipCount
+    ) {
+        static ChannelMembershipPayload from(Long channelId, ChannelMembership channelMembership, int membershipCount) {
+            return new ChannelMembershipPayload(
+                    channelId,
+                    channelMembership.getUserId().getValue(),
+                    channelMembership.getRole().name(),
+                    channelMembership.getPermissions().getAll(),
+                    membershipCount
+            );
+        }
+    }
+
+    public record ChannelNamePayload(Long channelId, String name) { }
+
+    public record ChannelInvitePayload(Long channelId) { }
+
+    public record ChannelKickedPayload(Long channelId) { }
+
+    public record ChannelMembershipCountPayload(Long channelId, int membershipCount) { }
+
+    public record ChannelPolicyPayload(
+            Long channelId,
+            boolean canEditOwnMessage,
+            boolean canDeleteOwnMessage,
+            boolean isPublic
+    ) {
+        static ChannelPolicyPayload from(Long channelId, ChannelPolicy policy) {
+            return new ChannelPolicyPayload(
+                    channelId,
+                    policy.canEditOwnMessage(),
+                    policy.canDeleteOwnMessage(),
+                    policy.isPublic()
+            );
+        }
+    }
+
+    public record ErrorPayload(Long channelId, String reason) { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
@@ -11,19 +11,6 @@ import reactor.core.publisher.Sinks;
 
 public class WebSocketMessageSender implements ClientMessageSender {
 
-    public static final String EVENT_NEW = "NEW";
-    public static final String EVENT_UPDATED = "UPDATED";
-    public static final String EVENT_DELETED = "DELETED";
-    public static final String EVENT_WS_PING = "WS_HEALTH_PING";
-    public static final String EVENT_WS_RECONNECT = "WS_RECONNECT";
-    public static final String EVENT_CHANNEL_MEMBERSHIP_CHANGED = "CHANNEL_MEMBERSHIP_CHANGED";
-    public static final String EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED = "CHANNEL_MEMBERSHIP_COUNT_CHANGED";
-    public static final String EVENT_INVITED_CHANNEL = "CHANNEL_INVITED";
-    public static final String EVENT_CHANNEL_NAME_EDITED = "CHANNEL_NAME_EDITED";
-    public static final String EVENT_CHANNEL_KICKED = "CHANNEL_KICKED";
-    public static final String EVENT_CHANNEL_POLICY_CHANGED = "CHANNEL_POLICY_CHANGED";
-    public static final String EVENT_ERROR = "ERROR";
-
     private final AtomicReference<Sinks.Many<WebSocketPayload>> sinkHolder;
 
     public WebSocketMessageSender() {
@@ -44,7 +31,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendMessage(ChatMessage message) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_NEW, message);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.NEW, message);
 
         emit(webSocketPayload);
     }
@@ -56,14 +43,14 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendDeletedMessage(ChatMessage deletedMessage) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_DELETED, deletedMessage);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.DELETED, deletedMessage);
 
         emit(webSocketPayload);
     }
 
     @Override
     public void sendUpdatedMessage(ChatMessage updatedMessage) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_UPDATED, updatedMessage);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.UPDATED, updatedMessage);
 
         emit(webSocketPayload);
     }
@@ -86,7 +73,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
                 membershipCount
         );
         WebSocketPayload webSocketPayload = new WebSocketPayload(
-                EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                WebSocketMessageType.CHANNEL_MEMBERSHIP_CHANGED,
                 channelMembershipPayload
         );
 
@@ -97,7 +84,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     public void sendChangedMembershipCount(Long channelId, int membershipCount) {
         ChannelMembershipCountPayload channelMembershipCountPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
         WebSocketPayload webSocketPayload = new WebSocketPayload(
-                EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                WebSocketMessageType.CHANNEL_MEMBERSHIP_COUNT_CHANGED,
                 channelMembershipCountPayload
         );
 
@@ -107,7 +94,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendInvitedChannel(Long channelId) {
         ChannelInvitePayload channelInvitePayload = new ChannelInvitePayload(channelId);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_INVITED_CHANNEL, channelInvitePayload);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_INVITED, channelInvitePayload);
 
         emit(webSocketPayload);
     }
@@ -115,7 +102,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendEditedChannelName(Long channelId, String editedName) {
         ChannelNamePayload channelNamePayload = new ChannelNamePayload(channelId, editedName);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_NAME_EDITED, channelNamePayload);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_NAME_EDITED, channelNamePayload);
 
         emit(webSocketPayload);
     }
@@ -123,7 +110,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendKickedFromChannel(Long channelId) {
         ChannelKickedPayload channelKickedPayload = new ChannelKickedPayload(channelId);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_KICKED, channelKickedPayload);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_KICKED, channelKickedPayload);
 
         emit(webSocketPayload);
     }
@@ -131,7 +118,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy) {
         ChannelPolicyPayload channelPolicyPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_CHANNEL_POLICY_CHANGED, channelPolicyPayload);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_POLICY_CHANGED, channelPolicyPayload);
 
         emit(webSocketPayload);
     }
@@ -139,7 +126,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendError(Long channelId, String reason) {
         ErrorPayload errorPayload = new ErrorPayload(channelId, reason);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(EVENT_ERROR, errorPayload);
+        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.ERROR, errorPayload);
 
         emit(webSocketPayload);
     }
@@ -152,10 +139,10 @@ public class WebSocketMessageSender implements ClientMessageSender {
         }
     }
 
-    public record WebSocketPayload(String type, Object message) {
+    public record WebSocketPayload(WebSocketMessageType type, Object message) {
 
-        static final WebSocketPayload PING_PAYLOAD = new WebSocketPayload(EVENT_WS_PING, null);
-        static final WebSocketPayload RECONNECT_PAYLOAD = new WebSocketPayload(EVENT_WS_RECONNECT, null);
+        static final WebSocketPayload PING_PAYLOAD = new WebSocketPayload(WebSocketMessageType.WS_HEALTH_PING, null);
+        static final WebSocketPayload RECONNECT_PAYLOAD = new WebSocketPayload(WebSocketMessageType.WS_RECONNECT, null);
     }
 
     public record ChannelMembershipPayload(

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSender.java
@@ -1,37 +1,47 @@
 package com.tok.pekko.adapter.out.websocket;
 
-import com.tok.pekko.domain.chat.actor.ChatMessage;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelInvitePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelKickedPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelMembershipCountPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelMembershipPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelNamePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelPolicyPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChatMessagePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ErrorPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketOutboundMessage;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
-import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import reactor.core.publisher.Sinks;
 
 public class WebSocketMessageSender implements ClientMessageSender {
 
-    private final AtomicReference<Sinks.Many<WebSocketPayload>> sinkHolder;
+    private final AtomicReference<Sinks.Many<WebSocketOutboundMessage>> sinkHolder;
 
     public WebSocketMessageSender() {
         this(null);
     }
 
-    public WebSocketMessageSender(Sinks.Many<WebSocketPayload> sink) {
+    public WebSocketMessageSender(Sinks.Many<WebSocketOutboundMessage> sink) {
         this.sinkHolder = new AtomicReference<>(sink);
     }
 
-    public void attachSink(Sinks.Many<WebSocketPayload> sink) {
+    public void attachSink(Sinks.Many<WebSocketOutboundMessage> sink) {
         sinkHolder.set(sink);
     }
 
-    public void detachSink(Sinks.Many<WebSocketPayload> sink) {
+    public void detachSink(Sinks.Many<WebSocketOutboundMessage> sink) {
         sinkHolder.compareAndSet(sink, null);
     }
 
     @Override
     public void sendMessage(ChatMessage message) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.NEW, message);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.NEW,
+                new ChatMessagePayload(message)
+        );
 
         emit(webSocketPayload);
     }
@@ -43,26 +53,32 @@ public class WebSocketMessageSender implements ClientMessageSender {
 
     @Override
     public void sendDeletedMessage(ChatMessage deletedMessage) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.DELETED, deletedMessage);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.DELETED,
+                new ChatMessagePayload(deletedMessage)
+        );
 
         emit(webSocketPayload);
     }
 
     @Override
     public void sendUpdatedMessage(ChatMessage updatedMessage) {
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.UPDATED, updatedMessage);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.UPDATED,
+                new ChatMessagePayload(updatedMessage)
+        );
 
         emit(webSocketPayload);
     }
 
     @Override
     public void sendWebSocketPing() {
-        emit(WebSocketPayload.PING_PAYLOAD);
+        emit(WebSocketOutboundMessage.PING_MESSAGE);
     }
 
     @Override
     public void requestSessionReconnect() {
-        emit(WebSocketPayload.RECONNECT_PAYLOAD);
+        emit(WebSocketOutboundMessage.RECONNECT_MESSAGE);
     }
 
     @Override
@@ -72,7 +88,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
                 channelMembership,
                 membershipCount
         );
-        WebSocketPayload webSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_MEMBERSHIP_CHANGED,
                 channelMembershipPayload
         );
@@ -83,7 +99,7 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendChangedMembershipCount(Long channelId, int membershipCount) {
         ChannelMembershipCountPayload channelMembershipCountPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_MEMBERSHIP_COUNT_CHANGED,
                 channelMembershipCountPayload
         );
@@ -94,7 +110,10 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendInvitedChannel(Long channelId) {
         ChannelInvitePayload channelInvitePayload = new ChannelInvitePayload(channelId);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_INVITED, channelInvitePayload);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.CHANNEL_INVITED,
+                channelInvitePayload
+        );
 
         emit(webSocketPayload);
     }
@@ -102,7 +121,10 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendEditedChannelName(Long channelId, String editedName) {
         ChannelNamePayload channelNamePayload = new ChannelNamePayload(channelId, editedName);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_NAME_EDITED, channelNamePayload);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.CHANNEL_NAME_EDITED,
+                channelNamePayload
+        );
 
         emit(webSocketPayload);
     }
@@ -110,7 +132,10 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendKickedFromChannel(Long channelId) {
         ChannelKickedPayload channelKickedPayload = new ChannelKickedPayload(channelId);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_KICKED, channelKickedPayload);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.CHANNEL_KICKED,
+                channelKickedPayload
+        );
 
         emit(webSocketPayload);
     }
@@ -118,7 +143,10 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendChangedChannelPolicy(Long channelId, ChannelPolicy channelPolicy) {
         ChannelPolicyPayload channelPolicyPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.CHANNEL_POLICY_CHANGED, channelPolicyPayload);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.CHANNEL_POLICY_CHANGED,
+                channelPolicyPayload
+        );
 
         emit(webSocketPayload);
     }
@@ -126,66 +154,19 @@ public class WebSocketMessageSender implements ClientMessageSender {
     @Override
     public void sendError(Long channelId, String reason) {
         ErrorPayload errorPayload = new ErrorPayload(channelId, reason);
-        WebSocketPayload webSocketPayload = new WebSocketPayload(WebSocketMessageType.ERROR, errorPayload);
+        WebSocketOutboundMessage webSocketPayload = new WebSocketOutboundMessage(
+                WebSocketMessageType.ERROR,
+                errorPayload
+        );
 
         emit(webSocketPayload);
     }
 
-    private void emit(WebSocketPayload payload) {
-        Sinks.Many<WebSocketPayload> sink = sinkHolder.get();
+    private void emit(WebSocketOutboundMessage payload) {
+        Sinks.Many<WebSocketOutboundMessage> sink = sinkHolder.get();
 
         if (sink != null) {
             sink.tryEmitNext(payload);
         }
     }
-
-    public record WebSocketPayload(WebSocketMessageType type, Object message) {
-
-        static final WebSocketPayload PING_PAYLOAD = new WebSocketPayload(WebSocketMessageType.WS_HEALTH_PING, null);
-        static final WebSocketPayload RECONNECT_PAYLOAD = new WebSocketPayload(WebSocketMessageType.WS_RECONNECT, null);
-    }
-
-    public record ChannelMembershipPayload(
-            Long channelId,
-            Long memberId,
-            String role,
-            Set<ChannelPermissionType> permissions,
-            int membershipCount
-    ) {
-        static ChannelMembershipPayload from(Long channelId, ChannelMembership channelMembership, int membershipCount) {
-            return new ChannelMembershipPayload(
-                    channelId,
-                    channelMembership.getUserId().getValue(),
-                    channelMembership.getRole().name(),
-                    channelMembership.getPermissions().getAll(),
-                    membershipCount
-            );
-        }
-    }
-
-    public record ChannelNamePayload(Long channelId, String name) { }
-
-    public record ChannelInvitePayload(Long channelId) { }
-
-    public record ChannelKickedPayload(Long channelId) { }
-
-    public record ChannelMembershipCountPayload(Long channelId, int membershipCount) { }
-
-    public record ChannelPolicyPayload(
-            Long channelId,
-            boolean canEditOwnMessage,
-            boolean canDeleteOwnMessage,
-            boolean isPublic
-    ) {
-        static ChannelPolicyPayload from(Long channelId, ChannelPolicy policy) {
-            return new ChannelPolicyPayload(
-                    channelId,
-                    policy.canEditOwnMessage(),
-                    policy.canDeleteOwnMessage(),
-                    policy.isPublic()
-            );
-        }
-    }
-
-    public record ErrorPayload(Long channelId, String reason) { }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageType.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageType.java
@@ -1,0 +1,45 @@
+package com.tok.pekko.adapter.out.websocket;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum WebSocketMessageType {
+
+    NEW("NEW"),
+    UPDATED("UPDATED"),
+    DELETED("DELETED"),
+    WS_HEALTH_PING("WS_HEALTH_PING"),
+    WS_RECONNECT("WS_RECONNECT"),
+    CHANNEL_MEMBERSHIP_CHANGED("CHANNEL_MEMBERSHIP_CHANGED"),
+    CHANNEL_MEMBERSHIP_COUNT_CHANGED("CHANNEL_MEMBERSHIP_COUNT_CHANGED"),
+    CHANNEL_INVITED("CHANNEL_INVITED"),
+    CHANNEL_NAME_EDITED("CHANNEL_NAME_EDITED"),
+    CHANNEL_KICKED("CHANNEL_KICKED"),
+    CHANNEL_POLICY_CHANGED("CHANNEL_POLICY_CHANGED"),
+    ERROR("ERROR"),
+    HEARTBEAT_PING("PING"),
+    HEARTBEAT_PONG("PONG"),
+    SESSION_HEALTH_PONG("WS_PONG");
+
+    private final String type;
+
+    WebSocketMessageType(String type) {
+        this.type = type;
+    }
+
+    @JsonValue
+    public String type() {
+        return type;
+    }
+
+    public boolean isSameType(String rawType) {
+        return type.equalsIgnoreCase(rawType);
+    }
+
+    public static Optional<WebSocketMessageType> from(String rawType) {
+        return Arrays.stream(values())
+                     .filter(value -> value.isSameType(rawType))
+                     .findFirst();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/message/WebSocketMessagePayload.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/message/WebSocketMessagePayload.java
@@ -1,0 +1,67 @@
+package com.tok.pekko.adapter.out.websocket.message;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChatMessage;
+import java.util.Set;
+
+public interface WebSocketMessagePayload {
+
+    enum WebSocketEmptyPayload implements WebSocketMessagePayload {
+        INSTANCE;
+
+        @JsonValue
+        public Object value() {
+            return null;
+        }
+    }
+
+    record ChannelInvitePayload(Long channelId) implements WebSocketMessagePayload { }
+    record ChannelKickedPayload(Long channelId) implements WebSocketMessagePayload { }
+    record ChannelMembershipCountPayload(Long channelId, int membershipCount) implements WebSocketMessagePayload { }
+    record ChannelNamePayload(Long channelId, String name) implements WebSocketMessagePayload { }
+    record ChatMessagePayload(ChatMessage message) implements WebSocketMessagePayload { }
+    record ErrorPayload(Long channelId, String reason) implements WebSocketMessagePayload { }
+
+    record ChannelMembershipPayload(
+            Long channelId,
+            Long memberId,
+            String role,
+            Set<ChannelPermissionType> permissions,
+            int membershipCount
+    ) implements WebSocketMessagePayload {
+
+        public static ChannelMembershipPayload from(
+                Long channelId,
+                ChannelMembership channelMembership,
+                int membershipCount
+        ) {
+            return new ChannelMembershipPayload(
+                    channelId,
+                    channelMembership.getUserId().getValue(),
+                    channelMembership.getRole().name(),
+                    channelMembership.getPermissions().getAll(),
+                    membershipCount
+            );
+        }
+    }
+
+    record ChannelPolicyPayload(
+            Long channelId,
+            boolean canEditOwnMessage,
+            boolean canDeleteOwnMessage,
+            boolean isPublic
+    ) implements WebSocketMessagePayload {
+
+        public static ChannelPolicyPayload from(Long channelId, ChannelPolicy policy) {
+            return new ChannelPolicyPayload(
+                    channelId,
+                    policy.canEditOwnMessage(),
+                    policy.canDeleteOwnMessage(),
+                    policy.isPublic()
+            );
+        }
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/message/WebSocketOutboundMessage.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/websocket/message/WebSocketOutboundMessage.java
@@ -1,0 +1,20 @@
+package com.tok.pekko.adapter.out.websocket.message;
+
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.WebSocketEmptyPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageType;
+
+public record WebSocketOutboundMessage(WebSocketMessageType type, WebSocketMessagePayload payload) {
+
+    public static WebSocketOutboundMessage PING_MESSAGE = new WebSocketOutboundMessage(
+            WebSocketMessageType.WS_HEALTH_PING,
+            WebSocketEmptyPayload.INSTANCE
+    );
+    public static WebSocketOutboundMessage RECONNECT_MESSAGE = new WebSocketOutboundMessage(
+            WebSocketMessageType.WS_RECONNECT,
+            WebSocketEmptyPayload.INSTANCE
+    );
+
+    public static WebSocketOutboundMessage withoutPayload(WebSocketMessageType type) {
+        return new WebSocketOutboundMessage(type, WebSocketEmptyPayload.INSTANCE);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ClientSessionProtocol.java
@@ -1,5 +1,7 @@
 package com.tok.pekko.domain.chat.port.out;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.util.List;
@@ -40,4 +42,25 @@ public interface ClientSessionProtocol {
 
     // Client Session인 WebSocketSession으로부터 Pong을 전달하기 위한 메시지 : WebSocketHandler -> ClientSessionActor
     record SessionPongReceived() implements ClientSessionCommand { }
+
+    // 채널 정책이 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateChangeChannelPolicy(Long channelId, ChannelPolicy channelPolicy) implements ClientSessionCommand { }
+
+    // 채널 이름이 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateEditChannelName(Long channelId, String editedName) implements ClientSessionCommand { }
+
+    // 채널 참여자가 강퇴되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateKickedMember(Long channelId) implements ClientSessionCommand { }
+
+    // 채널 멤버 수 변경을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateMembershipCount(Long channelId, int membershipCount) implements ClientSessionCommand { }
+
+    // 채널 참여자의 정보가 변경되었음을 전파받기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateChangeChannelMembership(Long channelId, ChannelMembership channelMembership, int membershipCount) implements ClientSessionCommand { }
+
+    // WebSocket 재연결 시 참여 채널/히스토리를 다시 동기화하기 위한 메시지 : WebSocketHandler -> ClientSessionActor
+    record ReSyncSession() implements ClientSessionCommand { }
+
+    // 요청 실패를 클라이언트로 전달하기 위한 메시지 : ChannelReaderActor -> ClientSessionActor
+    record PropagateFailure(Long channelId, String reason) implements ClientSessionCommand { }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/ClientSessionActorTest.java
@@ -2,6 +2,11 @@ package com.tok.pekko.adapter.out.websocket;
 
 import com.tok.pekko.adapter.out.websocket.ChannelReaderRegistryActor.GetChannelReaderActor;
 import com.tok.pekko.adapter.out.websocket.ClientSessionActor.FoundChannelReaders;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.ChannelReaderCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.GetHistory;
@@ -10,6 +15,7 @@ import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.RequestInitialHis
 import com.tok.pekko.domain.chat.port.in.ChannelReaderProtocol.UnregisterClientSession;
 import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorMessagePort;
 import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ChannelReaderRegistryCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelReaderRegistryProtocol.ReleaseClientSessionActor;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverNewMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverDeletedMessage;
@@ -17,6 +23,13 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.DeliverUpdatedMessage;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundRegisteredChannelIds;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateFailure;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelMembership;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateChangeChannelPolicy;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateEditChannelName;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateKickedMember;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.PropagateMembershipCount;
+import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ReSyncSession;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.RequestHistory;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.Shutdown;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncJoinChannel;
@@ -24,8 +37,10 @@ import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.SyncLeaveChannel
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -42,7 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("NonAsciiCharacters")
+@SuppressWarnings({"NonAsciiCharacters", "unchecked"})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ClientSessionActorTest {
 
@@ -433,5 +448,204 @@ class ClientSessionActorTest {
 
         // then
         readerProbe.expectMessageClass(UnregisterClientSession.class);
+    }
+
+    @Test
+    void PropagateChangeChannelMembership_메시지를_받으면_ClientMessageSender로_채널_멤버십_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        ChannelMembership membership = createManagerMembership(1L, channelId, 100L);
+        int membershipCount = 5;
+
+        // when
+        clientSessionActor.tell(new PropagateChangeChannelMembership(channelId, membership, membershipCount));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedChannelMembership(channelId, membership, membershipCount);
+    }
+
+    @Test
+    void PropagateMembershipCount_메시지를_받으면_ClientMessageSender로_멤버십_카운트_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        int membershipCount = 10;
+
+        // when
+        clientSessionActor.tell(new PropagateMembershipCount(channelId, membershipCount));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedMembershipCount(channelId, membershipCount);
+    }
+
+    @Test
+    void PropagateChangeChannelPolicy_메시지를_받으면_ClientMessageSender로_채널_정책_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
+                                                   .updatePublic(false)
+                                                   .updateEditOwnMessage(true)
+                                                   .updateDeleteOwnMessage(false);
+
+        // when
+        clientSessionActor.tell(new PropagateChangeChannelPolicy(channelId, channelPolicy));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendChangedChannelPolicy(channelId, channelPolicy);
+    }
+
+    @Test
+    void PropagateEditChannelName_메시지를_받으면_ClientMessageSender로_채널_이름_변경을_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        String editedName = "새로운 채널명";
+
+        // when
+        clientSessionActor.tell(new PropagateEditChannelName(channelId, editedName));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendEditedChannelName(channelId, editedName);
+    }
+
+    @Test
+    void PropagateKickedMember_메시지를_받으면_ClientMessageSender로_강퇴_알림을_전송하고_reader를_제거한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        TestProbe<ChannelReaderCommand> readerProbe = testKit.createTestProbe();
+        Map<Long, ActorRef<ChannelReaderCommand>> readers = Map.of(1L, readerProbe.ref());
+
+        clientSessionActor.tell(new FoundChannelReaders(readers));
+        readerProbe.expectMessageClass(RegisterClientSession.class);
+        readerProbe.expectMessageClass(RequestInitialHistory.class);
+
+        Long channelId = 1L;
+
+        // when
+        clientSessionActor.tell(new PropagateKickedMember(channelId));
+
+        // then
+        assertAll(
+                () -> verify(mockClientMessageSender, timeout(1000)).sendKickedFromChannel(channelId),
+                () -> {
+                    ReleaseClientSessionActor message = readerRegistryProbe.expectMessageClass(ReleaseClientSessionActor.class);
+                    assertThat(message.channelIds()).contains(channelId);
+                }
+        );
+    }
+
+    @Test
+    void ReSyncSession_메시지를_받으면_ChannelMembershipActorMessagePort로_참여_채널_조회를_요청한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        // when
+        clientSessionActor.tell(new ReSyncSession());
+
+        // then
+        verify(mockChannelMembershipActorMessagePort, timeout(1000).times(2))
+                .sendParticipatingChannels(eq(100L), any(ActorRef.class));
+    }
+
+    @Test
+    void NotifyFailure_메시지를_받으면_ClientMessageSender로_에러를_전송한다() {
+        // given
+        ClientMessageSender mockClientMessageSender = mock(ClientMessageSender.class);
+        MessageStoragePort mockMessageStoragePort = mock(MessageStoragePort.class);
+        ChannelMembershipActorMessagePort mockChannelMembershipActorMessagePort = mock(
+                ChannelMembershipActorMessagePort.class);
+        TestProbe<ChannelReaderRegistryCommand> readerRegistryProbe = testKit.createTestProbe();
+
+        ActorRef<ClientSessionCommand> clientSessionActor = testKit.spawn(
+                ClientSessionActor.create(100L, mockClientMessageSender, mockMessageStoragePort,
+                        mockChannelMembershipActorMessagePort, readerRegistryProbe.ref())
+        );
+
+        Long channelId = 1L;
+        String reason = "권한이 없습니다";
+
+        // when
+        clientSessionActor.tell(new PropagateFailure(channelId, reason));
+
+        // then
+        verify(mockClientMessageSender, timeout(1000)).sendError(channelId, reason);
+    }
+
+    private ChannelMembership createManagerMembership(Long membershipId, Long channelId, Long userId) {
+        Set<ChannelPermissionType> permissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+        return ChannelMembership.create(
+                membershipId,
+                channelId,
+                userId,
+                ChannelRole.MANAGER,
+                managePermissions,
+                LocalDateTime.now()
+        );
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
@@ -1,8 +1,23 @@
 package com.tok.pekko.adapter.out.websocket;
 
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelInvitePayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelKickedPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipCountPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelNamePayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelPolicyPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ErrorPayload;
+import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.WebSocketPayload;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -14,15 +29,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@SuppressWarnings("NonAsciiCharacters")
+@SuppressWarnings({"NonAsciiCharacters", "unchecked"})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class WebSocketMessageSenderTest {
 
     @Test
     void 단일_메시지를_클라이언트에게_전송한다() {
         // given
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage message = createMessage(1L, "테스트 메시지");
 
@@ -30,14 +44,13 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
     }
 
     @Test
     void 여러_메시지를_클라이언트에게_전송한다() {
         // given
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         List<ChatMessage> messages = List.of(
                 createMessage(1L, "메시지1"),
@@ -50,17 +63,16 @@ class WebSocketMessageSenderTest {
 
         // then
         assertAll(
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
-                () -> verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
         );
     }
 
     @Test
     void 삭제된_메시지를_클라이언트에게_전송한다() {
         // given
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage deletedMessage = createMessage(1L, "삭제된 메시지");
 
@@ -68,14 +80,13 @@ class WebSocketMessageSenderTest {
         sender.sendDeletedMessage(deletedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
     }
 
     @Test
     void 수정된_메시지를_클라이언트에게_전송한다() {
         // given
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage updatedMessage = createMessage(1L, "수정된 메시지");
 
@@ -83,58 +94,214 @@ class WebSocketMessageSenderTest {
         sender.sendUpdatedMessage(updatedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
     }
 
     @Test
     void 웹소켓_헬스체크_핑을_전송한다() {
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.sendWebSocketPing();
 
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
+        // then
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
     }
 
     @Test
     void 재연결을_요청한다() {
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.requestSessionReconnect();
 
-        verify(sink).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
+        // then
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
     }
 
     @Test
     void sink를_교체하면_새로운_sink로_메시지를_전송한다() {
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> firstSink = mock(Sinks.Many.class);
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> secondSink = mock(Sinks.Many.class);
+        // given
+        Sinks.Many<WebSocketPayload> firstSink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketPayload> secondSink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(firstSink);
         ChatMessage message = createMessage(10L, "hello");
 
+        // when
         sender.sendMessage(message);
         sender.attachSink(secondSink);
         sender.sendMessage(message);
 
-        verify(firstSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
-        verify(secondSink, times(1)).tryEmitNext(new WebSocketMessageSender.WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        // then
+        verify(firstSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(secondSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
     }
 
     @Test
     void sink를_detach하면_추가_메시지가_전송되지_않는다() {
-        @SuppressWarnings("unchecked")
-        Sinks.Many<WebSocketMessageSender.WebSocketPayload> sink = mock(Sinks.Many.class);
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
+        // when
         sender.detachSink(sink);
         sender.requestSessionReconnect();
 
+        // then
         verifyNoInteractions(sink);
+    }
+
+    @Test
+    void 채널_멤버십_변경_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        ChannelMembership membership = createManagerMembership(1L, channelId, 100L);
+        int membershipCount = 5;
+
+        ChannelMembershipPayload expectedPayload = ChannelMembershipPayload.from(channelId, membership, membershipCount);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedChannelMembership(channelId, membership, membershipCount);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_멤버십_카운트_변경_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        int membershipCount = 7;
+
+        ChannelMembershipCountPayload expectedPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedMembershipCount(channelId, membershipCount);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_초대_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+
+        ChannelInvitePayload expectedPayload = new ChannelInvitePayload(channelId);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_INVITED_CHANNEL,
+                expectedPayload
+        );
+
+        // when
+        sender.sendInvitedChannel(channelId);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_이름_변경_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        String editedName = "새로운 채널명";
+
+        ChannelNamePayload expectedPayload = new ChannelNamePayload(channelId, editedName);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_NAME_EDITED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendEditedChannelName(channelId, editedName);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_강퇴_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+
+        ChannelKickedPayload expectedPayload = new ChannelKickedPayload(channelId);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_KICKED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendKickedFromChannel(channelId);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 채널_정책_변경_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
+                                                   .updatePublic(false)
+                                                   .updateEditOwnMessage(true)
+                                                   .updateDeleteOwnMessage(false);
+
+        ChannelPolicyPayload expectedPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_CHANNEL_POLICY_CHANGED,
+                expectedPayload
+        );
+
+        // when
+        sender.sendChangedChannelPolicy(channelId, channelPolicy);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
+    }
+
+    @Test
+    void 에러_이벤트를_전송한다() {
+        // given
+        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        WebSocketMessageSender sender = new WebSocketMessageSender(sink);
+        Long channelId = 10L;
+        String reason = "권한이 없습니다";
+
+        ErrorPayload expectedPayload = new ErrorPayload(channelId, reason);
+        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+                WebSocketMessageSender.EVENT_ERROR,
+                expectedPayload
+        );
+
+        // when
+        sender.sendError(channelId, reason);
+
+        // then
+        verify(sink).tryEmitNext(expectedWebSocketPayload);
     }
 
     private ChatMessage createMessage(Long messageId, String content) {
@@ -144,6 +311,23 @@ class WebSocketMessageSenderTest {
                 messageId,
                 content,
                 LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    private ChannelMembership createManagerMembership(Long membershipId, Long channelId, Long userId) {
+        Set<ChannelPermissionType> permissions = EnumSet.of(
+                ChannelPermissionType.MESSAGE_EDIT,
+                ChannelPermissionType.MEMBER_KICK
+        );
+        ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+        return ChannelMembership.create(
+                membershipId,
+                channelId,
+                userId,
+                ChannelRole.MANAGER,
+                managePermissions,
                 LocalDateTime.now()
         );
     }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
@@ -1,13 +1,14 @@
 package com.tok.pekko.adapter.out.websocket;
 
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelInvitePayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelKickedPayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipCountPayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelMembershipPayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelNamePayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ChannelPolicyPayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.ErrorPayload;
-import com.tok.pekko.adapter.out.websocket.WebSocketMessageSender.WebSocketPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelInvitePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelKickedPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelMembershipCountPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelMembershipPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelNamePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChannelPolicyPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ChatMessagePayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketMessagePayload.ErrorPayload;
+import com.tok.pekko.adapter.out.websocket.message.WebSocketOutboundMessage;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.ChannelRole;
@@ -36,7 +37,7 @@ class WebSocketMessageSenderTest {
     @Test
     void 단일_메시지를_클라이언트에게_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage message = createMessage(1L, "테스트 메시지");
 
@@ -44,13 +45,13 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
+        verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(message)));
     }
 
     @Test
     void 여러_메시지를_클라이언트에게_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         List<ChatMessage> messages = List.of(
                 createMessage(1L, "메시지1"),
@@ -63,16 +64,16 @@ class WebSocketMessageSenderTest {
 
         // then
         assertAll(
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(0))),
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(1))),
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(2)))
+                () -> verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(messages.get(0)))),
+                () -> verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(messages.get(1)))),
+                () -> verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(messages.get(2))))
         );
     }
 
     @Test
     void 삭제된_메시지를_클라이언트에게_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage deletedMessage = createMessage(1L, "삭제된 메시지");
 
@@ -80,13 +81,13 @@ class WebSocketMessageSenderTest {
         sender.sendDeletedMessage(deletedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.DELETED, deletedMessage));
+        verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.DELETED, new ChatMessagePayload(deletedMessage)));
     }
 
     @Test
     void 수정된_메시지를_클라이언트에게_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         ChatMessage updatedMessage = createMessage(1L, "수정된 메시지");
 
@@ -94,40 +95,40 @@ class WebSocketMessageSenderTest {
         sender.sendUpdatedMessage(updatedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.UPDATED, updatedMessage));
+        verify(sink).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.UPDATED, new ChatMessagePayload(updatedMessage)));
     }
 
     @Test
     void 웹소켓_헬스체크_핑을_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
         // when
         sender.sendWebSocketPing();
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.WS_HEALTH_PING, null));
+        verify(sink).tryEmitNext(WebSocketOutboundMessage.PING_MESSAGE);
     }
 
     @Test
     void 재연결을_요청한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
         // when
         sender.requestSessionReconnect();
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.WS_RECONNECT, null));
+        verify(sink).tryEmitNext(WebSocketOutboundMessage.RECONNECT_MESSAGE);
     }
 
     @Test
     void sink를_교체하면_새로운_sink로_메시지를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> firstSink = mock(Sinks.Many.class);
-        Sinks.Many<WebSocketPayload> secondSink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> firstSink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> secondSink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(firstSink);
         ChatMessage message = createMessage(10L, "hello");
 
@@ -137,14 +138,14 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(firstSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
-        verify(secondSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
+        verify(firstSink, times(1)).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(message)));
+        verify(secondSink, times(1)).tryEmitNext(new WebSocketOutboundMessage(WebSocketMessageType.NEW, new ChatMessagePayload(message)));
     }
 
     @Test
     void sink를_detach하면_추가_메시지가_전송되지_않는다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
 
         // when
@@ -158,14 +159,14 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_멤버십_변경_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
         ChannelMembership membership = createManagerMembership(1L, channelId, 100L);
         int membershipCount = 5;
 
         ChannelMembershipPayload expectedPayload = ChannelMembershipPayload.from(channelId, membership, membershipCount);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_MEMBERSHIP_CHANGED,
                 expectedPayload
         );
@@ -180,13 +181,13 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_멤버십_카운트_변경_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
         int membershipCount = 7;
 
         ChannelMembershipCountPayload expectedPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_MEMBERSHIP_COUNT_CHANGED,
                 expectedPayload
         );
@@ -201,12 +202,12 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_초대_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
 
         ChannelInvitePayload expectedPayload = new ChannelInvitePayload(channelId);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_INVITED,
                 expectedPayload
         );
@@ -221,13 +222,13 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_이름_변경_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
         String editedName = "새로운 채널명";
 
         ChannelNamePayload expectedPayload = new ChannelNamePayload(channelId, editedName);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_NAME_EDITED,
                 expectedPayload
         );
@@ -242,12 +243,12 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_강퇴_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
 
         ChannelKickedPayload expectedPayload = new ChannelKickedPayload(channelId);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_KICKED,
                 expectedPayload
         );
@@ -262,7 +263,7 @@ class WebSocketMessageSenderTest {
     @Test
     void 채널_정책_변경_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
         ChannelPolicy channelPolicy = ChannelPolicy.defaultPolicy()
@@ -271,7 +272,7 @@ class WebSocketMessageSenderTest {
                                                    .updateDeleteOwnMessage(false);
 
         ChannelPolicyPayload expectedPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.CHANNEL_POLICY_CHANGED,
                 expectedPayload
         );
@@ -286,13 +287,13 @@ class WebSocketMessageSenderTest {
     @Test
     void 에러_이벤트를_전송한다() {
         // given
-        Sinks.Many<WebSocketPayload> sink = mock(Sinks.Many.class);
+        Sinks.Many<WebSocketOutboundMessage> sink = mock(Sinks.Many.class);
         WebSocketMessageSender sender = new WebSocketMessageSender(sink);
         Long channelId = 10L;
         String reason = "권한이 없습니다";
 
         ErrorPayload expectedPayload = new ErrorPayload(channelId, reason);
-        WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
+        WebSocketOutboundMessage expectedWebSocketPayload = new WebSocketOutboundMessage(
                 WebSocketMessageType.ERROR,
                 expectedPayload
         );

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/websocket/WebSocketMessageSenderTest.java
@@ -44,7 +44,7 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
     }
 
     @Test
@@ -63,9 +63,9 @@ class WebSocketMessageSenderTest {
 
         // then
         assertAll(
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(0))),
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(1))),
-                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, messages.get(2)))
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(0))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(1))),
+                () -> verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, messages.get(2)))
         );
     }
 
@@ -80,7 +80,7 @@ class WebSocketMessageSenderTest {
         sender.sendDeletedMessage(deletedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_DELETED, deletedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.DELETED, deletedMessage));
     }
 
     @Test
@@ -94,7 +94,7 @@ class WebSocketMessageSenderTest {
         sender.sendUpdatedMessage(updatedMessage);
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_UPDATED, updatedMessage));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.UPDATED, updatedMessage));
     }
 
     @Test
@@ -107,7 +107,7 @@ class WebSocketMessageSenderTest {
         sender.sendWebSocketPing();
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_PING, null));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.WS_HEALTH_PING, null));
     }
 
     @Test
@@ -120,7 +120,7 @@ class WebSocketMessageSenderTest {
         sender.requestSessionReconnect();
 
         // then
-        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_WS_RECONNECT, null));
+        verify(sink).tryEmitNext(new WebSocketPayload(WebSocketMessageType.WS_RECONNECT, null));
     }
 
     @Test
@@ -137,8 +137,8 @@ class WebSocketMessageSenderTest {
         sender.sendMessage(message);
 
         // then
-        verify(firstSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
-        verify(secondSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageSender.EVENT_NEW, message));
+        verify(firstSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
+        verify(secondSink, times(1)).tryEmitNext(new WebSocketPayload(WebSocketMessageType.NEW, message));
     }
 
     @Test
@@ -166,7 +166,7 @@ class WebSocketMessageSenderTest {
 
         ChannelMembershipPayload expectedPayload = ChannelMembershipPayload.from(channelId, membership, membershipCount);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_CHANGED,
+                WebSocketMessageType.CHANNEL_MEMBERSHIP_CHANGED,
                 expectedPayload
         );
 
@@ -187,7 +187,7 @@ class WebSocketMessageSenderTest {
 
         ChannelMembershipCountPayload expectedPayload = new ChannelMembershipCountPayload(channelId, membershipCount);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_CHANNEL_MEMBERSHIP_COUNT_CHANGED,
+                WebSocketMessageType.CHANNEL_MEMBERSHIP_COUNT_CHANGED,
                 expectedPayload
         );
 
@@ -207,7 +207,7 @@ class WebSocketMessageSenderTest {
 
         ChannelInvitePayload expectedPayload = new ChannelInvitePayload(channelId);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_INVITED_CHANNEL,
+                WebSocketMessageType.CHANNEL_INVITED,
                 expectedPayload
         );
 
@@ -228,7 +228,7 @@ class WebSocketMessageSenderTest {
 
         ChannelNamePayload expectedPayload = new ChannelNamePayload(channelId, editedName);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_CHANNEL_NAME_EDITED,
+                WebSocketMessageType.CHANNEL_NAME_EDITED,
                 expectedPayload
         );
 
@@ -248,7 +248,7 @@ class WebSocketMessageSenderTest {
 
         ChannelKickedPayload expectedPayload = new ChannelKickedPayload(channelId);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_CHANNEL_KICKED,
+                WebSocketMessageType.CHANNEL_KICKED,
                 expectedPayload
         );
 
@@ -272,7 +272,7 @@ class WebSocketMessageSenderTest {
 
         ChannelPolicyPayload expectedPayload = ChannelPolicyPayload.from(channelId, channelPolicy);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_CHANNEL_POLICY_CHANGED,
+                WebSocketMessageType.CHANNEL_POLICY_CHANGED,
                 expectedPayload
         );
 
@@ -293,7 +293,7 @@ class WebSocketMessageSenderTest {
 
         ErrorPayload expectedPayload = new ErrorPayload(channelId, reason);
         WebSocketPayload expectedWebSocketPayload = new WebSocketPayload(
-                WebSocketMessageSender.EVENT_ERROR,
+                WebSocketMessageType.ERROR,
                 expectedPayload
         );
 


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #27 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
### 웹소켓 관련 
- 웹소켓 메시지 이벤트 타입을 상수에서 enum으로 관리 
- Channel 비즈니스 로직 발생으로 인한 변경 사항 전파를 위한 웹소켓 메시지 타입 핸들링 기능 추가
- 기존 웹소켓 메시지를 외부로 분리 및 네이밍 변경

### Actor 관련 
- ClientSessionActor : Channel 비즈니스 로직 발생으로 인한 변경 사항 전파를 위한 메시지 추가 