### PR TITLE
도메인 이벤트 핸들링 Entity 추가

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelActorStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelActorStorageAdapter.java
@@ -1,0 +1,45 @@
+package com.tok.pekko.adapter.out.persistence;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncChannel;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import lombok.RequiredArgsConstructor;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelActorStorageAdapter implements ChannelActorStoragePort {
+
+    private final Scheduler databaseScheduler;
+    private final ChannelRepository channelRepository;
+
+    @Override
+    public void find(Long channelId, ActorRef<ChannelEntityCommand> replyTo) {
+        Mono.fromCallable(() -> channelRepository.findById(channelId))
+            .subscribeOn(databaseScheduler)
+            .doOnNext(
+                    target -> target.ifPresentOrElse(
+                            channel -> replyTo.tell(new SyncChannel(channel)),
+                            () -> replyTo.tell(new Shutdown())
+                    )
+            )
+            .subscribe();
+    }
+
+    @Override
+    public void update(Channel channel, Long eventId, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> channelRepository.update(channel))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipActorStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipActorStorageAdapter.java
@@ -1,0 +1,133 @@
+package com.tok.pekko.adapter.out.persistence;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import lombok.RequiredArgsConstructor;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelMembershipActorStorageAdapter implements ChannelMembershipActorStoragePort {
+
+    private final Scheduler databaseScheduler;
+    private final ChannelMembershipRepository channelMembershipRepository;
+
+    @Override
+    public void join(
+            Long eventId,
+            ChannelId channelId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromCallable(() -> channelMembershipRepository.joinChannel(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(stored -> {
+                replyTo.tell(new NotifyStoredMembership(stored));
+                replyTo.tell(new EventSucceeded(eventId));
+            })
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void leave(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> channelMembershipRepository.leaveChannel(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void inviteUser(
+            Long eventId,
+            ChannelId channelId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromCallable(() -> channelMembershipRepository.joinChannel(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(stored -> {
+                replyTo.tell(new NotifyStoredMembership(stored));
+                replyTo.tell(new EventSucceeded(eventId));
+            })
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void promoteToManager(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.promoteToManager(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void demoteToMember(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.demoteToMember(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void addPermission(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ChannelPermissionType permission,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.addManagerPermission(channelMembership.getId(), permission))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void removePermission(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ChannelPermissionType permission,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.deleteManagerPermission(channelMembership.getId(), permission))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void kickMember(
+            Long eventId,
+            ChannelMembership channelMembership,
+            ActorRef<ChannelEventHandlerCommand> replyTo
+    ) {
+        Mono.fromRunnable(() -> channelMembershipRepository.leaveChannel(channelMembership))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipRepository.java
@@ -1,16 +1,25 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
 import com.tok.pekko.domain.user.model.vo.UserId;
 
 public interface ChannelMembershipRepository {
 
-    void joinChannel(ChannelMembership channelMembership);
+    ChannelMembership joinChannel(ChannelMembership channelMembership);
 
-    void leaveChannel(ChannelId channelId, UserId userId);
+    void leaveChannel(ChannelMembership channelMembership);
 
-    void updateRole(ChannelMembership channelMembership);
+    void promoteToManager(ChannelMembership channelMembership);
+
+    void demoteToMember(ChannelMembership channelMembership);
 
     void delete(ChannelId channelId, UserId userId);
+
+    void addManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission);
+
+    void deleteManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission);
 }
+

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
@@ -24,19 +24,16 @@ public class ChannelMembershipStorageAdapter implements ChannelMembershipStorage
     @Override
     public void leaveChannel(ChannelMembership channelMembership) {
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
-        channelMembershipRepository.leaveChannel(channelMembership.getChannelId(), channelMembership.getUserId());
         channelRepository.decrementMemberCount(channelMembership.getChannelId());
     }
 
     @Override
     public void promoteToManager(ChannelMembership channelMembership) {
-        channelMembershipRepository.updateRole(channelMembership);
         channelManagePermissionRepository.saveAll(channelMembership);
     }
 
     @Override
     public void demoteToMember(ChannelMembership channelMembership) {
-        channelMembershipRepository.updateRole(channelMembership);
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
     }
 

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelMembershipStorageAdapter.java
@@ -18,13 +18,11 @@ public class ChannelMembershipStorageAdapter implements ChannelMembershipStorage
     @Override
     public void joinChannel(ChannelId channelId, ChannelMembership channelMembership) {
         channelMembershipRepository.joinChannel(channelMembership);
-        channelRepository.incrementMemberCount(channelId);
     }
 
     @Override
     public void leaveChannel(ChannelMembership channelMembership) {
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
-        channelRepository.decrementMemberCount(channelMembership.getChannelId());
     }
 
     @Override
@@ -51,6 +49,5 @@ public class ChannelMembershipStorageAdapter implements ChannelMembershipStorage
     public void kickMember(ChannelMembership channelMembership) {
         channelMembershipRepository.delete(channelMembership.getChannelId(), channelMembership.getUserId());
         channelManagePermissionRepository.deleteAll(channelMembership.getId());
-        channelRepository.decrementMemberCount(channelMembership.getChannelId());
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/ChannelRepository.java
@@ -10,11 +10,9 @@ public interface ChannelRepository {
 
     Optional<Channel> findByIdWithMembership(Long channelId, Long... memberIds);
 
+    Optional<Channel> findById(Long channelId);
+
     void update(Channel channel);
 
     void deleteById(ChannelId channelId);
-
-    void incrementMemberCount(ChannelId channelId);
-
-    void decrementMemberCount(ChannelId channelId);
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
@@ -5,10 +5,12 @@ import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
 import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
 import com.tok.pekko.domain.user.model.vo.UserId;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +34,8 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
                 .addValue("channelRole", channelMembership.getRole().name())
                 .addValue("joinedAt", channelMembership.getJoinedAt());
 
-        var keyHolder = new org.springframework.jdbc.support.GeneratedKeyHolder();
+        KeyHolder keyHolder = new org.springframework.jdbc.support.GeneratedKeyHolder();
+
         jdbcTemplate.update(sql, params, keyHolder, new String[]{"id"});
 
         Number generatedId = keyHolder.getKey();
@@ -85,7 +88,8 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
                 .addValue("membershipId", channelMembership.getId().getValue());
         jdbcTemplate.update(deletePermSql, deleteParams);
 
-        var permissions = channelMembership.getPermissions().getAll();
+        Set<ChannelPermissionType> permissions = channelMembership.getPermissions()
+                                                                  .getAll();
         if (permissions != null && !permissions.isEmpty()) {
             String insertPermSql = """
                     INSERT INTO channel_manager_permissions (manager_membership_id, permission)

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelMembershipRepository.java
@@ -1,11 +1,14 @@
 package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelMembershipId;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +20,7 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
 
     @Override
     @Transactional
-    public void joinChannel(ChannelMembership channelMembership) {
+    public ChannelMembership joinChannel(ChannelMembership channelMembership) {
         String sql = """
                 INSERT INTO channel_memberships (channel_id, user_id, channel_role, joined_at)
                 VALUES (:channelId, :userId, :channelRole, :joinedAt)
@@ -29,37 +32,93 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
                 .addValue("channelRole", channelMembership.getRole().name())
                 .addValue("joinedAt", channelMembership.getJoinedAt());
 
-        jdbcTemplate.update(sql, params);
+        var keyHolder = new org.springframework.jdbc.support.GeneratedKeyHolder();
+        jdbcTemplate.update(sql, params, keyHolder, new String[]{"id"});
+
+        Number generatedId = keyHolder.getKey();
+        if (generatedId == null) {
+            throw new IllegalStateException("채널 멤버십 ID를 생성하지 못했습니다.");
+        }
+
+        return channelMembership.withAssignedId(generatedId.longValue());
     }
 
     @Override
     @Transactional
-    public void leaveChannel(ChannelId channelId, UserId userId) {
-        String sql = """
+    public void leaveChannel(ChannelMembership channelMembership) {
+        String deletePermissionSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deletePermParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermissionSql, deletePermParams);
+
+        String deleteMembershipSql = """
                 DELETE FROM channel_memberships
-                WHERE channel_id = :channelId AND user_id = :userId
+                WHERE id = :membershipId
                 """;
 
         MapSqlParameterSource params = new MapSqlParameterSource()
-                .addValue("channelId", channelId.getValue())
-                .addValue("userId", userId.getValue());
+                .addValue("membershipId", channelMembership.getId().getValue());
 
-        jdbcTemplate.update(sql, params);
+        jdbcTemplate.update(deleteMembershipSql, params);
     }
 
     @Override
     @Transactional
-    public void updateRole(ChannelMembership channelMembership) {
-        String sql = """
+    public void promoteToManager(ChannelMembership channelMembership) {
+        String roleSql = """
                 UPDATE channel_memberships
-                SET channel_role = :role
+                SET channel_role = 'MANAGER'
                 WHERE id = :membershipId
                 """;
-        MapSqlParameterSource parameter = new MapSqlParameterSource()
-                .addValue("role", channelMembership.getRole().name())
+        MapSqlParameterSource roleParams = new MapSqlParameterSource()
                 .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(roleSql, roleParams);
 
-        jdbcTemplate.update(sql, parameter);
+        String deletePermSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deleteParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermSql, deleteParams);
+
+        var permissions = channelMembership.getPermissions().getAll();
+        if (permissions != null && !permissions.isEmpty()) {
+            String insertPermSql = """
+                    INSERT INTO channel_manager_permissions (manager_membership_id, permission)
+                    VALUES (:membershipId, :permission)
+                    """;
+            SqlParameterSource[] batchParams = permissions.stream()
+                                                          .map(permission -> new MapSqlParameterSource()
+                                                                  .addValue("membershipId", channelMembership.getId().getValue())
+                                                                  .addValue("permission", permission.name()))
+                                                          .toArray(SqlParameterSource[]::new);
+            jdbcTemplate.batchUpdate(insertPermSql, batchParams);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void demoteToMember(ChannelMembership channelMembership) {
+        String roleSql = """
+                UPDATE channel_memberships
+                SET channel_role = 'MEMBER'
+                WHERE id = :membershipId
+                """;
+        MapSqlParameterSource roleParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(roleSql, roleParams);
+
+        String deletePermSql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                """;
+        MapSqlParameterSource deleteParams = new MapSqlParameterSource()
+                .addValue("membershipId", channelMembership.getId().getValue());
+        jdbcTemplate.update(deletePermSql, deleteParams);
     }
 
     @Override
@@ -76,5 +135,37 @@ public class JdbcChannelMembershipRepository implements ChannelMembershipReposit
 
         jdbcTemplate.update(sql, parameter);
     }
-}
 
+    @Override
+    @Transactional
+    public void addManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission) {
+        if (permission == null) {
+            return;
+        }
+        String sql = """
+                INSERT INTO channel_manager_permissions (manager_membership_id, permission)
+                VALUES (:membershipId, :permission)
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("membershipId", membershipId.getValue())
+                .addValue("permission", permission.name());
+        jdbcTemplate.update(sql, params);
+    }
+
+    @Override
+    @Transactional
+    public void deleteManagerPermission(ChannelMembershipId membershipId, ChannelPermissionType permission) {
+        if (permission == null) {
+            return;
+        }
+        String sql = """
+                DELETE FROM channel_manager_permissions
+                WHERE manager_membership_id = :membershipId
+                AND permission = :permission
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("membershipId", membershipId.getValue())
+                .addValue("permission", permission.name());
+        jdbcTemplate.update(sql, params);
+    }
+}

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/JdbcChannelRepository.java
@@ -2,18 +2,23 @@ package com.tok.pekko.adapter.out.persistence;
 
 import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
 import com.tok.pekko.domain.channel.model.ChannelRole;
 import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
 import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
 import com.tok.pekko.domain.user.model.vo.UserId;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.RowMapper;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -24,33 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 @RequiredArgsConstructor
 public class JdbcChannelRepository implements ChannelRepository {
-
-    private static final RowMapper<Channel> channelRowMapper = (rs, rowNum) -> {
-        ChannelPolicy channelPolicy = new ChannelPolicy(
-                rs.getBoolean("can_edit_own_message"),
-                rs.getBoolean("can_delete_own_message"),
-                rs.getBoolean("is_public")
-        );
-        LocalDateTime createdAt = rs.getObject("created_at", LocalDateTime.class);
-        ChannelRole role = ChannelRole.find(rs.getString("channel_role"));
-        UserId membershipUserId = UserId.create(rs.getLong("membership_user_id"));
-        LocalDateTime membershipJoinedAt = rs.getObject("membership_joined_at", LocalDateTime.class);
-        Long channelId = rs.getLong("channel_id");
-        ChannelMembership membership = ChannelMembership.create(ChannelId.create(channelId), membershipUserId, role, membershipJoinedAt)
-                                                        .withAssignedId(rs.getLong("membership_id"));
-        Map<UserId, ChannelMembership> memberships = new HashMap<>();
-
-        memberships.put(membership.getUserId(), membership);
-
-        return Channel.create(
-                channelId,
-                rs.getString("name"),
-                rs.getLong("creator_id"),
-                channelPolicy,
-                memberships,
-                createdAt
-        );
-    };
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -65,8 +43,7 @@ public class JdbcChannelRepository implements ChannelRepository {
                     can_delete_own_message,
                     is_public,
                     is_deleted,
-                    created_at,
-                    membership_count
+                    created_at
                 )
                 VALUES (
                     :name,
@@ -75,8 +52,7 @@ public class JdbcChannelRepository implements ChannelRepository {
                     :canDeleteOwnMessage,
                     :isPublic,
                     :isDeleted,
-                    :createdAt,
-                    :membershipCount
+                    :createdAt
                 )
                 """;
         MapSqlParameterSource parameters = new MapSqlParameterSource()
@@ -86,10 +62,9 @@ public class JdbcChannelRepository implements ChannelRepository {
                 .addValue("canDeleteOwnMessage", channel.getChannelPolicy().canDeleteOwnMessage())
                 .addValue("isPublic", channel.getChannelPolicy().isPublic())
                 .addValue("isDeleted", false)
-                .addValue("createdAt", channel.getCreatedAt())
-                .addValue("membershipCount", channel.getMemberships().size());
-        KeyHolder keyHolder = new GeneratedKeyHolder();
+                .addValue("createdAt", channel.getCreatedAt());
 
+        KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(sql, parameters, keyHolder, new String[]{"id"});
 
         Number generatedId = keyHolder.getKey();
@@ -110,6 +85,10 @@ public class JdbcChannelRepository implements ChannelRepository {
 
     @Override
     public Optional<Channel> findByIdWithMembership(Long channelId, Long... memberIds) {
+        if (memberIds == null || memberIds.length == 0) {
+            return findById(channelId);
+        }
+
         String sql = """
                 SELECT
                     c.id AS channel_id,
@@ -122,22 +101,51 @@ public class JdbcChannelRepository implements ChannelRepository {
                     cm.id AS membership_id,
                     cm.user_id AS membership_user_id,
                     cm.channel_role,
-                    cm.joined_at AS membership_joined_at
+                    cm.joined_at AS membership_joined_at,
+                    cmp.permission AS manager_permission
                 FROM channels c
                 INNER JOIN channel_memberships cm ON cm.channel_id = c.id
+                LEFT JOIN channel_manager_permissions cmp ON cmp.manager_membership_id = cm.id
                 WHERE c.id = :channelId AND c.is_deleted = false AND cm.user_id IN (:memberIds)
                 """;
+
         MapSqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("channelId", channelId)
                 .addValue("memberIds", List.of(memberIds));
 
-        try {
-            Channel channel = jdbcTemplate.queryForObject(sql, parameters, channelRowMapper);
+        Channel channel = jdbcTemplate.query(sql, parameters, new ChannelWithMembershipsExtractor());
 
-            return Optional.ofNullable(channel);
-        } catch (EmptyResultDataAccessException ex) {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(channel);
+    }
+
+    @Override
+    public Optional<Channel> findById(Long channelId) {
+        String sql = """
+                SELECT
+                    c.id AS channel_id,
+                    c.name,
+                    c.creator_id,
+                    c.can_edit_own_message,
+                    c.can_delete_own_message,
+                    c.is_public,
+                    c.created_at,
+                    cm.id AS membership_id,
+                    cm.user_id AS membership_user_id,
+                    cm.channel_role,
+                    cm.joined_at AS membership_joined_at,
+                    cmp.permission AS manager_permission
+                FROM channels c
+                LEFT JOIN channel_memberships cm ON c.id = cm.channel_id
+                LEFT JOIN channel_manager_permissions cmp ON cmp.manager_membership_id = cm.id
+                WHERE c.id = :channelId AND c.is_deleted = false
+                """;
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("channelId", channelId);
+
+        Channel channel = jdbcTemplate.query(sql, parameters, new ChannelWithMembershipsExtractor());
+
+        return Optional.ofNullable(channel);
     }
 
     @Override
@@ -175,29 +183,79 @@ public class JdbcChannelRepository implements ChannelRepository {
         jdbcTemplate.update(sql, parameters);
     }
 
-    @Override
-    @Transactional
-    public void incrementMemberCount(ChannelId channelId) {
-        String sql = """
-                UPDATE channels
-                SET membership_count = membership_count + 1
-                WHERE id = :channelId AND is_deleted = false
-                """;
-        MapSqlParameterSource parameters = new MapSqlParameterSource("channelId", channelId.getValue());
+    private static class ChannelWithMembershipsExtractor implements ResultSetExtractor<Channel> {
 
-        jdbcTemplate.update(sql, parameters);
-    }
+        @Override
+        public Channel extractData(ResultSet rs) throws SQLException, DataAccessException {
+            if (!rs.next()) {
+                return null;
+            }
 
-    @Override
-    @Transactional
-    public void decrementMemberCount(ChannelId channelId) {
-        String sql = """
-                UPDATE channels
-                SET membership_count = membership_count - 1
-                WHERE id = :channelId AND is_deleted = false
-                """;
-        MapSqlParameterSource parameters = new MapSqlParameterSource("channelId", channelId.getValue());
+            Long channelId = rs.getLong("channel_id");
+            String name = rs.getString("name");
+            Long creatorId = rs.getLong("creator_id");
+            ChannelPolicy channelPolicy = new ChannelPolicy(
+                    rs.getBoolean("can_edit_own_message"),
+                    rs.getBoolean("can_delete_own_message"),
+                    rs.getBoolean("is_public")
+            );
+            LocalDateTime createdAt = rs.getTimestamp("created_at").toLocalDateTime();
+            Map<UserId, ChannelMembership> memberships = new HashMap<>();
 
-        jdbcTemplate.update(sql, parameters);
+            Map<Long, EnumSet<ChannelPermissionType>> managerPermissions = new HashMap<>();
+
+            do {
+                Long membershipId = rs.getLong("membership_id");
+                if (rs.wasNull()) {
+                    continue;
+                }
+
+                Long userIdValue = rs.getLong("membership_user_id");
+                UserId userId = UserId.create(userIdValue);
+                ChannelRole role = ChannelRole.find(rs.getString("channel_role"));
+                LocalDateTime joinedAt = rs.getTimestamp("membership_joined_at").toLocalDateTime();
+
+                String managerPermission = rs.getString("manager_permission");
+                if (managerPermission != null) {
+                    managerPermissions.computeIfAbsent(membershipId, ignored -> EnumSet.noneOf(ChannelPermissionType.class))
+                                      .add(ChannelPermissionType.valueOf(managerPermission));
+                }
+
+                ChannelMembership membership = createMembership(
+                        ChannelId.create(channelId),
+                        membershipId,
+                        userId,
+                        role,
+                        joinedAt,
+                        managerPermissions.get(membershipId)
+                );
+                memberships.put(userId, membership);
+            } while (rs.next());
+
+            return Channel.create(channelId, name, creatorId, channelPolicy, memberships, createdAt);
+        }
+
+        private ChannelMembership createMembership(
+                ChannelId channelId,
+                Long membershipId,
+                UserId userId,
+                ChannelRole role,
+                LocalDateTime joinedAt,
+                EnumSet<ChannelPermissionType> permissions
+        ) {
+            if (role.isManager() && permissions != null && !permissions.isEmpty()) {
+                return ChannelMembership.create(
+                        membershipId,
+                        channelId.getValue(),
+                        userId.getValue(),
+                        role,
+                        ChannelManagePermissions.ofManager(permissions),
+                        joinedAt
+                );
+            }
+
+            return ChannelMembership.create(channelId, userId, role, joinedAt)
+                                    .withAssignedId(membershipId);
+        }
     }
 }

--- a/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
+++ b/pekko/src/main/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapter.java
@@ -4,8 +4,11 @@ import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncDeletedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncPersistedMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncRecentMessages;
-import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.SyncUpdatedMessage;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.FoundHistory;
 import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
@@ -13,26 +16,45 @@ import lombok.RequiredArgsConstructor;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
+import reactor.core.scheduler.Scheduler;
 
 @Component
 @RequiredArgsConstructor
 public class MessageStorageAdapter implements MessageStoragePort {
 
+    private final Scheduler databaseScheduler;
     private final MessageRepository messageRepository;
 
     @Override
     public void store(ChatMessage message, ActorRef<ChannelEntityCommand> replyTo) {
         Mono.fromCallable(() -> messageRepository.save(message))
-            .subscribeOn(Schedulers.boundedElastic())
+            .subscribeOn(databaseScheduler)
             .doOnNext(persistedMessage -> replyTo.tell(new SyncPersistedMessage(persistedMessage)))
+            .subscribe();
+    }
+
+    @Override
+    public void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> messageRepository.update(updatedMessage.messageId(), updatedMessage.message()))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
+            .subscribe();
+    }
+
+    @Override
+    public void delete(Long eventId, Long messageId, ActorRef<ChannelEventHandlerCommand> replyTo) {
+        Mono.fromRunnable(() -> messageRepository.delete(messageId))
+            .subscribeOn(databaseScheduler)
+            .doOnSuccess(ignored -> replyTo.tell(new EventSucceeded(eventId)))
+            .doOnError(throwable -> replyTo.tell(new EventFailed(eventId, throwable)))
             .subscribe();
     }
 
     @Override
     public void update(Long messageId, String updatedMessage, ActorRef<ChannelEntityCommand> replyTo) {
         Mono.fromRunnable(() -> messageRepository.update(messageId, updatedMessage))
-            .subscribeOn(Schedulers.boundedElastic())
+            .subscribeOn(databaseScheduler)
             .doOnSuccess(ignored -> replyTo.tell(new SyncUpdatedMessage(messageId, updatedMessage)))
             .subscribe();
     }
@@ -40,7 +62,7 @@ public class MessageStorageAdapter implements MessageStoragePort {
     @Override
     public void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo) {
         Mono.fromRunnable(() -> messageRepository.delete(messageId))
-            .subscribeOn(Schedulers.boundedElastic())
+            .subscribeOn(databaseScheduler)
             .doOnSuccess(ignored -> replyTo.tell(new SyncDeletedMessage(messageId)))
             .subscribe();
     }
@@ -53,7 +75,7 @@ public class MessageStorageAdapter implements MessageStoragePort {
             ActorRef<ClientSessionCommand> replyTo
     ) {
         Mono.fromCallable(() -> messageRepository.findHistory(channelId, messageSequence, size))
-            .subscribeOn(Schedulers.boundedElastic())
+            .subscribeOn(databaseScheduler)
             .doOnNext(history -> replyTo.tell(new FoundHistory(history)))
             .subscribe();
     }
@@ -61,8 +83,9 @@ public class MessageStorageAdapter implements MessageStoragePort {
     @Override
     public void findRecentMessages(Long channelId, int size, ActorRef<ChannelEntityCommand> replyTo) {
         Mono.fromCallable(() -> messageRepository.findLatest(channelId, size))
-            .subscribeOn(Schedulers.boundedElastic())
+            .subscribeOn(databaseScheduler)
             .doOnNext(messages -> replyTo.tell(new SyncRecentMessages(messages)))
             .subscribe();
     }
 }
+

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEntity.java
@@ -1,5 +1,6 @@
 package com.tok.pekko.domain.chat.actor;
 
+import com.tok.pekko.domain.channel.model.ChannelMembership;
 import com.tok.pekko.domain.chat.actor.ChannelReaderActor.DeliverSyncMessages;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.DeleteMessage;
@@ -195,4 +196,10 @@ public class ChannelEntity extends AbstractBehavior<ChannelEntityCommand> {
 
     // 채팅 히스토리 동기화를 요청하는 메시지 : ChannelReaderActor -> ChannelEntity
     record RequestSyncMessages(ActorRef<ChannelReaderCommand> secondary) implements ChannelEntityCommand { }
+
+    // 이벤트 처리가 완료되었음을 전파받는 메시지 : ChannelEventHandlerEntity -> ChannelEntity
+    record DomainEventProcessed(Long eventId) implements ChannelEntityCommand { }
+
+    // 영속화된 채널 참여자를 동기화하기 위한 메시지 : ChannelEventHandlerEntity -> ChannelEntity
+    record SyncStoredMembership(ChannelMembership channelMembership) implements ChannelEntityCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntity.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntity.java
@@ -1,0 +1,363 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.chat.actor.ChannelEntity.DomainEventProcessed;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.SyncStoredMembership;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.ChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.ChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.DemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MemberKicked;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MessageEdited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.UserInvited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.UserJoined;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.javadsl.AbstractBehavior;
+import org.apache.pekko.actor.typed.javadsl.ActorContext;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+import org.apache.pekko.actor.typed.javadsl.Receive;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
+
+public class ChannelEventHandlerEntity extends AbstractBehavior<ChannelEventHandlerCommand> {
+
+    public static final EntityTypeKey<ChannelEventHandlerCommand> ENTITY_TYPE_KEY =
+            EntityTypeKey.create(ChannelEventHandlerCommand.class, "ChannelEventHandler");
+
+    public static Behavior<ChannelEventHandlerCommand> create(
+            ClusterSharding clusterSharding,
+            Long channelId,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
+    ) {
+        return Behaviors.setup(
+                context -> {
+                    EntityRef<ChannelEntityCommand> channelEntity = clusterSharding.entityRefFor(
+                            ChannelEntity.ENTITY_TYPE_KEY,
+                            String.valueOf(channelId)
+                    );
+
+                    return new ChannelEventHandlerEntity(
+                            context,
+                            channelEntity,
+                            messageStoragePort,
+                            channelActorStoragePort,
+                            channelMembershipActorStoragePort
+                    );
+                }
+
+        );
+    }
+
+    private final Map<Long, EventHolder> events;
+    private final EntityRef<ChannelEntityCommand> channelEntity;
+    private final MessageStoragePort messageStoragePort;
+    private final ChannelActorStoragePort channelActorStoragePort;
+    private final ChannelMembershipActorStoragePort channelMembershipActorStoragePort;
+
+    private ChannelEventHandlerEntity(
+            ActorContext<ChannelEventHandlerCommand> context,
+            EntityRef<ChannelEntityCommand> channelEntity,
+            MessageStoragePort messageStoragePort,
+            ChannelActorStoragePort channelActorStoragePort,
+            ChannelMembershipActorStoragePort channelMembershipActorStoragePort
+    ) {
+        super(context);
+        this.events = new HashMap<>();
+        this.channelEntity = channelEntity;
+        this.messageStoragePort = messageStoragePort;
+        this.channelActorStoragePort = channelActorStoragePort;
+        this.channelMembershipActorStoragePort = channelMembershipActorStoragePort;
+    }
+
+    @Override
+    public Receive<ChannelEventHandlerCommand> createReceive() {
+        return newReceiveBuilder().onMessage(HandleChannelPolicyChanged.class, this::onHandleChannelPolicyChanged)
+                                  .onMessage(HandleChannelNameEdited.class, this::onHandleChannelNameChanged)
+                                  .onMessage(HandleUserJoined.class, this::onHandleUserJoined)
+                                  .onMessage(HandleMemberLeft.class, this::onHandleMemberLeft)
+                                  .onMessage(HandleUserInvited.class, this::onHandleUserInvited)
+                                  .onMessage(HandlePromotedToManager.class, this::onHandlePromotedToManager)
+                                  .onMessage(HandleDemotedToMember.class, this::onHandleDemotedToMember)
+                                  .onMessage(HandlePermissionAdded.class, this::onHandlePermissionAdded)
+                                  .onMessage(HandlePermissionRemoved.class, this::onHandlePermissionRemoved)
+                                  .onMessage(HandleMemberKicked.class, this::onHandleMemberKicked)
+                                  .onMessage(HandleMessageEdited.class, this::onHandleMessageEdited)
+                                  .onMessage(EventSucceeded.class, this::onEventSucceeded)
+                                  .onMessage(EventFailed.class, this::onEventFailed)
+                                  .onMessage(NotifyStoredMembership.class, this::onNotifyMembershipStored)
+                                  .onMessage(HandleMessageDeleted.class, this::onHandleMessageDeleted)
+                                  .onMessage(Shutdown.class, this::onShutdown)
+                                  .build();
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleChannelPolicyChanged(HandleChannelPolicyChanged command) {
+        ChannelPolicyChanged event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelActorStoragePort.update(event.channel(), event.eventId(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleChannelNameChanged(HandleChannelNameEdited command) {
+        ChannelNameEdited event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelActorStoragePort.update(event.channel(), event.eventId(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleUserJoined(HandleUserJoined command) {
+        UserJoined event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.join(
+                event.eventId(),
+                event.channelMembership().getChannelId(),
+                event.channelMembership(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMemberLeft(HandleMemberLeft command) {
+        MemberLeft event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.leave(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleUserInvited(HandleUserInvited command) {
+        UserInvited event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.inviteUser(
+                event.eventId(),
+                event.channelMembership().getChannelId(),
+                event.channelMembership(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePromotedToManager(HandlePromotedToManager command) {
+        PromotedToManager event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.promoteToManager(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleDemotedToMember(HandleDemotedToMember command) {
+        DemotedToMember event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.demoteToMember(event.eventId(), event.channelMembership(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePermissionAdded(HandlePermissionAdded command) {
+        PermissionAdded event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.addPermission(
+                event.eventId(),
+                event.channelMembership(),
+                event.permissionType(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandlePermissionRemoved(HandlePermissionRemoved command) {
+        PermissionRemoved event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.removePermission(
+                event.eventId(),
+                event.channelMembership(),
+                event.permissionType(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMemberKicked(HandleMemberKicked command) {
+        MemberKicked event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        channelMembershipActorStoragePort.kickMember(
+                event.eventId(),
+                event.channelMembership(),
+                getContext().getSelf()
+        );
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMessageEdited(HandleMessageEdited command) {
+        MessageEdited event = command.event;
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        messageStoragePort.update(event.eventId(), event.updatedMessage(), getContext().getSelf());
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onHandleMessageDeleted(HandleMessageDeleted command) {
+        MessageDeleted event = command.event();
+
+        if (events.containsKey(event.eventId())) {
+            return this;
+        }
+
+        events.put(event.eventId(), new EventHolder(event));
+        messageStoragePort.delete(event.eventId(), event.deletedMessageId(), getContext().getSelf());
+        return this;
+    }
+    
+    private Behavior<ChannelEventHandlerCommand> onEventSucceeded(EventSucceeded command) {
+        EventHolder eventHolder = events.get(command.eventId());
+        
+        if (eventHolder == null) {
+            return this;
+        }
+
+        eventHolder.eventStatus = EventStatus.SUCCEEDED;
+        channelEntity.tell(new DomainEventProcessed(command.eventId()));
+        return this;
+    }
+    
+    private Behavior<ChannelEventHandlerCommand> onEventFailed(EventFailed command) {
+        EventHolder eventHolder = events.get(command.eventId());
+
+        if (eventHolder == null) {
+            return this;
+        }
+
+        eventHolder.eventStatus = EventStatus.FAILED;
+        eventHolder.throwable = command.throwable();
+        channelEntity.tell(new DomainEventProcessed(command.eventId()));
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onNotifyMembershipStored(NotifyStoredMembership command) {
+        channelEntity.tell(new SyncStoredMembership(command.channelMembership()));
+        return this;
+    }
+
+    private Behavior<ChannelEventHandlerCommand> onShutdown(Shutdown command) {
+        return Behaviors.stopped();
+    }
+
+    private static class EventHolder {
+
+        private final ChatDomainEvent event;
+        private EventStatus eventStatus;
+        private Throwable throwable = null;
+
+        public EventHolder(ChatDomainEvent event) {
+            this.event = event;
+            this.eventStatus = EventStatus.PENDING;
+        }
+    }
+
+    private enum EventStatus {
+        PENDING, SUCCEEDED, FAILED
+    }
+
+    // 채널 정책 변경 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleChannelPolicyChanged(ChannelPolicyChanged event) implements ChannelEventHandlerCommand { }
+
+    // 채널 이름 변경 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleChannelNameEdited(ChannelNameEdited event) implements ChannelEventHandlerCommand { }
+
+    // 채널 참여 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleUserJoined(UserJoined event) implements ChannelEventHandlerCommand { }
+
+    // 채널 탈퇴 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMemberLeft(MemberLeft event) implements ChannelEventHandlerCommand { }
+
+    // 채널 초대 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleUserInvited(UserInvited event) implements ChannelEventHandlerCommand { }
+
+    // 매니저 승격 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePromotedToManager(PromotedToManager event) implements ChannelEventHandlerCommand { }
+
+    // 멤버 강등 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleDemotedToMember(DemotedToMember event) implements ChannelEventHandlerCommand { }
+
+    // 권한 추가 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePermissionAdded(PermissionAdded event) implements ChannelEventHandlerCommand { }
+
+    // 권한 삭제 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandlePermissionRemoved(PermissionRemoved event) implements ChannelEventHandlerCommand { }
+
+    // 멤버 강퇴 도메인 이벤트를 처리하는 메시지 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMemberKicked(MemberKicked event) implements ChannelEventHandlerCommand { }
+
+    // 채팅 메시지 변경 도메인 이벤트 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMessageEdited(MessageEdited event) implements ChannelEventHandlerCommand { }
+
+    // 채팅 메시지 삭제 도메인 이벤트 : ChannelEntity -> ChannelEventHandlerEntity
+    record HandleMessageDeleted(MessageDeleted event) implements ChannelEventHandlerCommand { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatDomainEvent.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/actor/ChatDomainEvent.java
@@ -1,0 +1,60 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import java.time.LocalDateTime;
+
+public interface ChatDomainEvent {
+
+    Long channelId();
+
+    Long eventId();
+
+    LocalDateTime occurredAt();
+
+    // 채널 메타데이터 관련 도메인 이벤트
+    interface ChannelMetadataEvent extends ChatDomainEvent { }
+
+    // 채널 정책 변경 도메인 이벤트
+    record ChannelPolicyChanged(Long channelId, Long eventId, LocalDateTime occurredAt, Channel channel) implements ChannelMetadataEvent { }
+
+    // 채널 이름 변경 도메인 이벤트
+    record ChannelNameEdited(Long channelId, Long eventId, LocalDateTime occurredAt, Channel channel) implements ChannelMetadataEvent { }
+
+    // 채널 참여자가 변경되는 도메인 이벤트
+    interface ChannelMembershipEvent extends ChatDomainEvent { }
+
+    // 채널 참여 도메인 이벤트
+    record UserJoined(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 탈퇴 도메인 이벤트
+    record MemberLeft(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 초대 도메인 이벤트
+    record UserInvited(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 채널 강퇴 도메인 이벤트
+    record MemberKicked(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 매니저 승격 도메인 이벤트
+    record PromotedToManager(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 멤버 강등 도메인 이벤트
+    record DemotedToMember(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership) implements ChannelMembershipEvent { }
+
+    // 권한 추가 도메인 이벤트
+    record PermissionAdded(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership, ChannelPermissionType permissionType) implements ChannelMembershipEvent { }
+
+    // 권한 삭제 도메인 이벤트
+    record PermissionRemoved(Long channelId, Long eventId, LocalDateTime occurredAt, ChannelMembership channelMembership, ChannelPermissionType permissionType) implements ChannelMembershipEvent { }
+
+    // 채팅 메시지 관련 도메인 이벤트
+    interface MessageEvent extends ChatDomainEvent { }
+
+    // 메시지 수정 도메인 이벤트
+    record MessageEdited(Long channelId, Long eventId, LocalDateTime occurredAt, ChatMessage updatedMessage) implements MessageEvent { }
+
+    // 메시지 삭제 도메인 이벤트
+    record MessageDeleted(Long channelId, Long eventId, LocalDateTime occurredAt, Long deletedMessageId) implements MessageEvent { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/in/ChannelProtocol.java
@@ -1,5 +1,6 @@
 package com.tok.pekko.domain.chat.port.in;
 
+import com.tok.pekko.domain.channel.model.Channel;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import com.tok.pekko.global.common.CborSerializable;
 import com.tok.pekko.domain.chat.actor.ChatMessage;
@@ -40,4 +41,10 @@ public interface ChannelProtocol {
 
     // ChannelEntity가 관리하고 있는 ChannelReaderActor 중 유효하지 않은 ChannelReaderActor의 제거 요청을 받는 메시지 : ChannelReaderRegistryActor -> ChannelEntity
     record RemoveShutdownReader(String readerName) implements ChannelEntityCommand { }
+
+    // 영속화된 채널과 모든 채널 참여자를 동기화하기 위한 메시지 : 외부 -> ChannelEntity
+    record SyncChannel(Channel channel) implements ChannelEntityCommand { }
+
+    // ChannelEntity를 외부에서 종료시키기 위한 메시지 : 외부 -> ChannelEntity
+    record Shutdown() implements ChannelEntityCommand { }
 }

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelActorStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelActorStoragePort.java
@@ -1,0 +1,13 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import org.apache.pekko.actor.typed.ActorRef;
+
+public interface ChannelActorStoragePort {
+
+    void find(Long channelId, ActorRef<ChannelEntityCommand> replyTo);
+
+    void update(Channel channel, Long eventId, ActorRef<ChannelEventHandlerCommand> replyTo);
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelEventHandlerProtocol.java
@@ -1,0 +1,21 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.global.common.CborSerializable;
+
+public interface ChannelEventHandlerProtocol {
+
+    interface ChannelEventHandlerCommand extends CborSerializable { }
+
+    // ChannelMembership 영속화 시 생성된 PK를 ChannelEntity에서 관리하는 Channel에 반영하기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record NotifyStoredMembership(ChannelMembership channelMembership) implements ChannelEventHandlerCommand { }
+
+    // 도메인 이벤트 처리가 성공되었음을 전파받기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record EventSucceeded(Long eventId) implements ChannelEventHandlerCommand { }
+
+    // 도메인 이벤트 처리가 실패되었음을 전파받기 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record EventFailed(Long eventId, Throwable throwable) implements ChannelEventHandlerCommand { }
+
+    // ChannelEventHandlerEntity 종료를 위한 메시지 : 외부 -> ChannelEventHandlerEntity
+    record Shutdown() implements ChannelEventHandlerCommand { }
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipActorStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/ChannelMembershipActorStoragePort.java
@@ -1,0 +1,26 @@
+package com.tok.pekko.domain.chat.port.out;
+
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import org.apache.pekko.actor.typed.ActorRef;
+
+public interface ChannelMembershipActorStoragePort {
+
+    void join(Long eventId, ChannelId channelId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void leave(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void inviteUser(Long eventId, ChannelId channelId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void promoteToManager(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void demoteToMember(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void addPermission(Long eventId, ChannelMembership channelMembership, ChannelPermissionType permission, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void removePermission(Long eventId, ChannelMembership channelMembership, ChannelPermissionType permission, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void kickMember(Long eventId, ChannelMembership channelMembership, ActorRef<ChannelEventHandlerCommand> replyTo);
+}

--- a/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/chat/port/out/MessageStoragePort.java
@@ -2,6 +2,7 @@ package com.tok.pekko.domain.chat.port.out;
 
 import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
 import com.tok.pekko.domain.chat.port.out.ClientSessionProtocol.ClientSessionCommand;
 import org.apache.pekko.actor.typed.ActorRef;
 
@@ -12,6 +13,10 @@ public interface MessageStoragePort {
     void update(Long messageId, String updatedMessage, ActorRef<ChannelEntityCommand> replyTo);
 
     void delete(Long messageId, ActorRef<ChannelEntityCommand> replyTo);
+
+    void update(Long eventId, ChatMessage updatedMessage, ActorRef<ChannelEventHandlerCommand> replyTo);
+
+    void delete(Long eventId, Long messageId, ActorRef<ChannelEventHandlerCommand> replyTo);
 
     void findHistory(
             Long channelId,

--- a/pekko/src/main/java/com/tok/pekko/global/config/app/AppConfig.java
+++ b/pekko/src/main/java/com/tok/pekko/global/config/app/AppConfig.java
@@ -1,10 +1,13 @@
 package com.tok.pekko.global.config.app;
 
 import java.time.Clock;
+import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,5 +19,22 @@ public class AppConfig {
     @Bean
     public Clock clock() {
         return Clock.system(timeZoneProperties.timezone());
+    }
+
+    @Bean(name = "databaseScheduler", destroyMethod = "dispose")
+    public Scheduler databaseScheduler() {
+        int poolSize = Runtime.getRuntime().availableProcessors() * 2;
+        return Schedulers.fromExecutor(
+                Executors.newFixedThreadPool(
+                        poolSize,
+                        runnable -> {
+                            Thread thread = new Thread(runnable);
+
+                            thread.setName("db-pool-" + thread.getId());
+                            thread.setDaemon(false);
+                            return thread;
+                        }
+                )
+        );
     }
 }

--- a/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapterTest.java
+++ b/pekko/src/test/java/com/tok/pekko/adapter/out/persistence/MessageStorageAdapterTest.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +60,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         ChatMessage message = ChatMessage.create(
                 1L,
                 100L,
@@ -100,7 +102,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         ChatMessage message = ChatMessage.create(
                 1L,
                 100L,
@@ -124,7 +127,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         ChatMessage message = ChatMessage.create(
                 1L,
                 100L,
@@ -148,7 +152,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 2L;
         long messageSequence = 10L;
@@ -180,7 +185,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 2L;
         long messageSequence = 10L;
@@ -202,7 +208,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 2L;
         long messageSequence = 10L;
@@ -222,7 +229,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 3L;
         int size = 50;
@@ -254,7 +262,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 3L;
         int size = 50;
@@ -273,7 +282,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
 
         Long channelId = 3L;
         int size = 50;
@@ -292,7 +302,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         ChatMessage message = ChatMessage.create(1L, 100L, 1L, "Test", LocalDateTime.now(), LocalDateTime.now());
 
         given(messageRepository.save(any())).willReturn(message);
@@ -320,7 +331,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ClientSessionCommand> replyProbe = testKit.createTestProbe(ClientSessionCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         List<ChatMessage> historyMessages = List.of(
                 ChatMessage.create(1L, 100L, 1L, "Message", LocalDateTime.now(), LocalDateTime.now())
         );
@@ -350,7 +362,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         List<ChatMessage> recentMessages = List.of(
                 ChatMessage.create(1L, 100L, 1L, "Recent", LocalDateTime.now(), LocalDateTime.now())
         );
@@ -380,7 +393,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
 
         willDoNothing().given(messageRepository).delete(eq(messageId));
@@ -401,7 +415,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
 
         willThrow(new RuntimeException("Database error")).given(messageRepository).delete(anyLong());
@@ -418,7 +433,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
 
         willDoNothing().given(messageRepository).delete(anyLong());
@@ -446,7 +462,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
         String updatedMessage = "Updated Message";
 
@@ -464,7 +481,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
         String updatedMessage = "Updated Message";
 
@@ -482,7 +500,8 @@ class MessageStorageAdapterTest {
         // given
         TestProbe<ChannelEntityCommand> replyProbe = testKit.createTestProbe(ChannelEntityCommand.class);
         MessageRepository messageRepository = mock(MessageRepository.class);
-        MessageStorageAdapter adapter = new MessageStorageAdapter(messageRepository);
+        Scheduler scheduler = Schedulers.immediate();
+        MessageStorageAdapter adapter = new MessageStorageAdapter(scheduler, messageRepository);
         Long messageId = 1L;
         String updatedMessage = "Updated Message";
 

--- a/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntityTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/chat/actor/ChannelEventHandlerEntityTest.java
@@ -1,0 +1,776 @@
+package com.tok.pekko.domain.chat.actor;
+
+import com.tok.pekko.domain.channel.model.Channel;
+import com.tok.pekko.domain.channel.model.ChannelMembership;
+import com.tok.pekko.domain.channel.model.ChannelPermissionType;
+import com.tok.pekko.domain.channel.model.ChannelRole;
+import com.tok.pekko.domain.channel.model.vo.ChannelId;
+import com.tok.pekko.domain.channel.model.vo.ChannelManagePermissions;
+import com.tok.pekko.domain.channel.model.vo.ChannelPolicy;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.DomainEventProcessed;
+import com.tok.pekko.domain.chat.actor.ChannelEntity.SyncStoredMembership;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleDemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberKicked;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMemberLeft;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleMessageEdited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandlePromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserInvited;
+import com.tok.pekko.domain.chat.actor.ChannelEventHandlerEntity.HandleUserJoined;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.ChannelNameEdited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.ChannelPolicyChanged;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.DemotedToMember;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MemberKicked;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MemberLeft;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MessageDeleted;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.MessageEdited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PermissionAdded;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PermissionRemoved;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.PromotedToManager;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.UserInvited;
+import com.tok.pekko.domain.chat.actor.ChatDomainEvent.UserJoined;
+import com.tok.pekko.domain.chat.port.in.ChannelProtocol.ChannelEntityCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.ChannelEventHandlerCommand;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventFailed;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.EventSucceeded;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.NotifyStoredMembership;
+import com.tok.pekko.domain.chat.port.out.ChannelEventHandlerProtocol.Shutdown;
+import com.tok.pekko.domain.chat.port.out.ChannelMembershipActorStoragePort;
+import com.tok.pekko.domain.chat.port.out.MessageStoragePort;
+import com.tok.pekko.domain.user.model.vo.UserId;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.ClusterSharding;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityRef;
+import org.apache.pekko.cluster.sharding.typed.javadsl.EntityTypeKey;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"NonAsciiCharacters", "unchecked"})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ChannelEventHandlerEntityTest {
+
+    private static ActorTestKit testKit;
+
+    @BeforeAll
+    static void setup() {
+        testKit = ActorTestKit.create();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        testKit.shutdownTestKit();
+    }
+
+    @Test
+    void HandleChannelPolicyChanged_메시지를_받으면_ChannelActorStoragePort에_채널_업데이트를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelPolicy newPolicy = ChannelPolicy.defaultPolicy().updatePublic(false);
+        Channel channel = Channel.create("test", 1L, newPolicy, LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelPolicyChanged event = new ChannelPolicyChanged(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelPolicyChanged(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+
+    @Test
+    void HandleChannelNameEdited_메시지를_받으면_ChannelActorStoragePort에_채널_업데이트를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("edited-name", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited event = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelNameEdited(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+
+    @Test
+    void HandleUserJoined_메시지를_받으면_ChannelMembershipActorStoragePort에_join을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).join(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        UserJoined event = new UserJoined(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleUserJoined(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).join(
+                eq(1L),
+                eq(membership.getChannelId()),
+                eq(membership),
+                any()
+        );
+    }
+
+    @Test
+    void HandleMemberLeft_메시지를_받으면_ChannelMembershipActorStoragePort에_leave를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).leave(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MemberLeft event = new MemberLeft(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleMemberLeft(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).leave(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleUserInvited_메시지를_받으면_ChannelMembershipActorStoragePort에_inviteUser를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).inviteUser(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(3L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        UserInvited event = new UserInvited(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleUserInvited(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).inviteUser(
+                eq(1L),
+                eq(membership.getChannelId()),
+                eq(membership),
+                any()
+        );
+    }
+
+    @Test
+    void HandlePromotedToManager_메시지를_받으면_ChannelMembershipActorStoragePort에_promoteToManager를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).promoteToManager(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                2L,
+                ChannelRole.MANAGER,
+                ChannelManagePermissions.ofManager(),
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PromotedToManager event = new PromotedToManager(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandlePromotedToManager(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).promoteToManager(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleDemotedToMember_메시지를_받으면_ChannelMembershipActorStoragePort에_demoteToMember를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).demoteToMember(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        DemotedToMember event = new DemotedToMember(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleDemotedToMember(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).demoteToMember(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandlePermissionAdded_메시지를_받으면_ChannelMembershipActorStoragePort에_addPermission을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).addPermission(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+        ChannelPermissionType permission = ChannelPermissionType.MESSAGE_EDIT;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PermissionAdded event = new PermissionAdded(channelId, 1L, occurredAt, membership, permission);
+
+        // when
+        eventHandler.tell(new HandlePermissionAdded(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).addPermission(
+                eq(1L),
+                eq(membership),
+                eq(permission),
+                any()
+        );
+    }
+
+    @Test
+    void HandlePermissionRemoved_메시지를_받으면_ChannelMembershipActorStoragePort에_removePermission을_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).removePermission(any(), any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MANAGER,
+                LocalDateTime.now()
+        );
+        ChannelPermissionType permission = ChannelPermissionType.MEMBER_KICK;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        PermissionRemoved event = new PermissionRemoved(channelId, 1L, occurredAt, membership, permission);
+
+        // when
+        eventHandler.tell(new HandlePermissionRemoved(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).removePermission(
+                eq(1L),
+                eq(membership),
+                eq(permission),
+                any()
+        );
+    }
+
+    @Test
+    void HandleMemberKicked_메시지를_받으면_ChannelMembershipActorStoragePort에_kickMember를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelMembershipActorStoragePort).kickMember(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                ChannelId.create(channelId),
+                UserId.create(2L),
+                ChannelRole.MEMBER,
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MemberKicked event = new MemberKicked(channelId, 1L, occurredAt, membership);
+
+        // when
+        eventHandler.tell(new HandleMemberKicked(event));
+
+        // then
+        verify(channelMembershipActorStoragePort, timeout(1000)).kickMember(eq(1L), eq(membership), any());
+    }
+
+    @Test
+    void HandleMessageEdited_메시지를_받으면_MessageStoragePort에_update를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(messageStoragePort).update(anyLong(), any(ChatMessage.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChatMessage updatedMessage = new ChatMessage(
+                1L,
+                channelId,
+                100L,
+                1L,
+                "Updated message",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MessageEdited event = new MessageEdited(channelId, 1L, occurredAt, updatedMessage);
+
+        // when
+        eventHandler.tell(new HandleMessageEdited(event));
+
+        // then
+        verify(messageStoragePort, timeout(1000)).update(eq(1L), eq(updatedMessage), any());
+    }
+
+    @Test
+    void HandleMessageDeleted_메시지를_받으면_MessageStoragePort에_delete를_요청한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(messageStoragePort).delete(any(), any(), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Long deletedMessageId = 10L;
+        LocalDateTime occurredAt = LocalDateTime.now();
+        MessageDeleted event = new MessageDeleted(channelId, 1L, occurredAt, deletedMessageId);
+
+        // when
+        eventHandler.tell(new HandleMessageDeleted(event));
+
+        // then
+        verify(messageStoragePort, timeout(1000)).delete(eq(1L), eq(deletedMessageId), any());
+    }
+
+    @Test
+    void EventSucceeded_메시지를_받으면_ChannelEntity에_DomainEventProcessed를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited domainEvent = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+        eventHandler.tell(new HandleChannelNameEdited(domainEvent));
+
+        // when
+        eventHandler.tell(new EventSucceeded(1L));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(DomainEventProcessed.class));
+    }
+
+    @Test
+    void EventFailed_메시지를_받으면_ChannelEntity에_DomainEventProcessed를_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited domainEvent = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+        eventHandler.tell(new HandleChannelNameEdited(domainEvent));
+
+        Throwable error = new RuntimeException("Storage failed");
+
+        // when
+        eventHandler.tell(new EventFailed(1L, error));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(DomainEventProcessed.class));
+    }
+
+    @Test
+    void NotifyStoredMembership_메시지를_받으면_ChannelEntity에_SyncStoredMembership을_전송한다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        ChannelMembership membership = ChannelMembership.create(
+                1L,
+                channelId,
+                2L,
+                ChannelRole.MEMBER,
+                ChannelManagePermissions.ofMember(),
+                LocalDateTime.now()
+        );
+
+        // when
+        eventHandler.tell(new NotifyStoredMembership(membership));
+
+        // then
+        verify(channelEntity, timeout(1000)).tell(any(SyncStoredMembership.class));
+    }
+
+    @Test
+    void Shutdown_메시지를_받으면_ChannelEventHandlerEntity가_종료된다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        TestProbe<ChannelEventHandlerCommand> probe = testKit.createTestProbe();
+        probe.expectNoMessage(Duration.ofMillis(100));
+
+        // when
+        eventHandler.tell(new Shutdown());
+
+        // then
+        probe.expectTerminated(eventHandler, Duration.ofSeconds(3));
+    }
+
+    @Test
+    void 동일한_eventId로_여러_번_메시지를_받으면_중복_처리하지_않는다() {
+        // given
+        Long channelId = 1L;
+        ClusterSharding clusterSharding = mock(ClusterSharding.class);
+        EntityRef<ChannelEntityCommand> channelEntity = mock(EntityRef.class);
+
+        when(clusterSharding.entityRefFor(any(EntityTypeKey.class), anyString())).thenReturn(channelEntity);
+
+        MessageStoragePort messageStoragePort = mock(MessageStoragePort.class);
+        ChannelActorStoragePort channelActorStoragePort = mock(ChannelActorStoragePort.class);
+        ChannelMembershipActorStoragePort channelMembershipActorStoragePort = mock(ChannelMembershipActorStoragePort.class);
+
+        doNothing().when(channelActorStoragePort).update(any(Channel.class), any(Long.class), any());
+
+        ActorRef<ChannelEventHandlerCommand> eventHandler = testKit.spawn(
+                ChannelEventHandlerEntity.create(
+                        clusterSharding,
+                        channelId,
+                        messageStoragePort,
+                        channelActorStoragePort,
+                        channelMembershipActorStoragePort
+                )
+        );
+
+        Channel channel = Channel.create("test", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelNameEdited event = new ChannelNameEdited(channelId, 1L, occurredAt, channel);
+
+        // when
+        eventHandler.tell(new HandleChannelNameEdited(event));
+        eventHandler.tell(new HandleChannelNameEdited(event));
+        eventHandler.tell(new HandleChannelNameEdited(event));
+
+        // then
+        verify(channelActorStoragePort, timeout(1000)).update(eq(channel), eq(1L), any());
+    }
+}


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #31 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
### ChannelEventHandlerEntity

- 발생한 도메인 이벤트를 메시지로 전달받아 영속화를 진행하는 Entity 
- ChannelEntity에 메시지를 추가했지만, 추가적인 연동은 아직 진행하지 않음

### Port 

- ChannelEventHandlerEntity 내부적으로 사용할 Port 추가 
  - ChannelActorStoragePort : Entity(Actor) 내에 채널 관련 도메인 이벤트를 영속화하기 위한 Port
  - ChannelMembershipActorStoragePort : Entity(Actor) 내에 채널 멤버십 관련 도메인 이벤트를 영속화하기 위한 Port 
- DB 관련 Port에서 사용할 스레드 풀(Scheduler) 추가
  - ChannelActorStoragePort, ChannelMembershipActorStoragePort에만 적용 
  - 추후 ChannelEntity와 연동한 이후 사용하지 않는 Port, Adapter 삭제 및 사용 스레드 풀 정리 예정