### PR TITLE
Channel 도메인이 이벤트 기반으로 동작하도록 변경

### DIFF
--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
@@ -365,6 +365,193 @@ public class Channel {
         }
     }
 
+    public boolean canJoinUser(UserId userId) {
+        if (channelPolicy.isPrivate()) {
+            return false;
+        }
+        return !memberships.containsKey(userId);
+    }
+
+    public boolean canInviteMember(UserId inviterId, UserId inviteeId) {
+        ChannelMembership inviterMembership = memberships.get(inviterId);
+
+        if (inviterMembership == null) {
+            return false;
+        }
+        if (inviterMembership.cannotInviteMember()) {
+            return false;
+        }
+        return !memberships.containsKey(inviteeId);
+    }
+
+    public boolean canLeaveMember(UserId memberId) {
+        ChannelMembership channelMembership = memberships.get(memberId);
+
+        if (channelMembership == null) {
+            return false;
+        }
+        return !channelMembership.isOwner();
+    }
+
+    public boolean canKickMember(UserId executorId, UserId targetUserId) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        if (!executorMembership.canKickMember()) {
+            return false;
+        }
+
+        ChannelMembership targetUserMembership = memberships.get(targetUserId);
+
+        if (targetUserMembership == null) {
+            return false;
+        }
+        return targetUserMembership.isMember();
+    }
+
+    public boolean canAddPermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
+        ChannelMembership grantorMembership = memberships.get(grantorId);
+
+        if (grantorMembership == null) {
+            return false;
+        }
+        if (grantorMembership.cannotManagePermission()) {
+            return false;
+        }
+
+        ChannelMembership granteeMembership = memberships.get(granteeId);
+
+        if (granteeMembership == null) {
+            return false;
+        }
+        if (granteeMembership.isNotManager()) {
+            return false;
+        }
+        return granteeMembership.lacksPermission(permission);
+    }
+
+    public boolean canRemovePermission(UserId grantorId, UserId granteeId, ChannelPermissionType permission) {
+        ChannelMembership grantorMembership = memberships.get(grantorId);
+
+        if (grantorMembership == null) {
+            return false;
+        }
+        if (grantorMembership.cannotManagePermission()) {
+            return false;
+        }
+
+        ChannelMembership granteeMembership = memberships.get(granteeId);
+
+        if (granteeMembership == null) {
+            return false;
+        }
+        if (granteeMembership.isNotManager()) {
+            return false;
+        }
+        return granteeMembership.hasPermission(permission);
+    }
+
+    public boolean canPromoteToManager(UserId executorId, UserId targetUserId) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        if (executorMembership.cannotManageRole()) {
+            return false;
+        }
+
+        ChannelMembership targetUserMembership = memberships.get(targetUserId);
+
+        if (targetUserMembership == null) {
+            return false;
+        }
+        if (targetUserMembership.isOwner()) {
+            return false;
+        }
+        return targetUserMembership.isNotManager();
+    }
+
+    public boolean canDemoteToMember(UserId executorId, UserId targetUserId) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        if (executorMembership.cannotManageRole()) {
+            return false;
+        }
+
+        ChannelMembership targetUserMembership = memberships.get(targetUserId);
+
+        if (targetUserMembership == null) {
+            return false;
+        }
+        if (targetUserMembership.isOwner()) {
+            return false;
+        }
+        return !targetUserMembership.isMember();
+    }
+
+    public boolean canEditName(UserId changerId) {
+        ChannelMembership channelMembership = memberships.get(changerId);
+
+        if (channelMembership == null) {
+            return false;
+        }
+        return channelMembership.canEditChannelName();
+    }
+
+    public boolean canChangeChannelPolicy(UserId changerId) {
+        ChannelMembership executorMembership = memberships.get(changerId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        return executorMembership.canChangeChannelPolicy();
+    }
+
+    public boolean canDeleteChannel(UserId deleterId) {
+        ChannelMembership deleterMembership = memberships.get(deleterId);
+
+        if (deleterMembership == null) {
+            return false;
+        }
+        return deleterMembership.canDeleteChannel();
+    }
+
+    public boolean canMemberEditMessage(UserId executorId, ChatMessage message) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotEditMessage()) {
+            return false;
+        }
+        return !channelPolicy.cannotEditOwnMessage();
+    }
+
+    public boolean canMemberDeleteMessage(UserId executorId, ChatMessage message) {
+        ChannelMembership executorMembership = memberships.get(executorId);
+
+        if (executorMembership == null) {
+            return false;
+        }
+        if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotDeleteMessage()) {
+            return false;
+        }
+        return !channelPolicy.cannotDeleteOwnMessage();
+    }
+
+    public boolean canMemberSendMessage(UserId senderId) {
+        ChannelMembership senderMembership = memberships.get(senderId);
+
+        return senderMembership != null;
+    }
+
     public static class ChannelMembershipNotFoundException extends IllegalArgumentException {
 
         public ChannelMembershipNotFoundException() {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/Channel.java
@@ -7,8 +7,11 @@ import com.tok.pekko.domain.chat.actor.ChatMessage;
 import com.tok.pekko.domain.user.model.vo.UserId;
 import com.tok.pekko.global.common.ActorThreadSafe;
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -17,12 +20,12 @@ import lombok.Getter;
 @ActorThreadSafe
 public class Channel {
 
-    private final ChannelId channelId;
-    private final String name;
+    private ChannelId channelId;
+    private String name;
+    private ChannelPolicy channelPolicy;
     private final UserId creatorId;
-    private final ChannelPolicy channelPolicy;
-    private final Map<UserId, ChannelMembership> memberships;
     private final LocalDateTime createdAt;
+    private final Map<UserId, ChannelMembership> memberships;
 
     public static Channel create(String name, Long creatorId, ChannelPolicy channelPolicy, LocalDateTime createdAt) {
         validateName(name);
@@ -80,14 +83,8 @@ public class Channel {
     }
 
     public Channel withAssignedId(Long id) {
-        return new Channel(
-                ChannelId.create(id),
-                this.name,
-                this.creatorId,
-                this.channelPolicy,
-                this.memberships,
-                this.createdAt
-        );
+        this.channelId = ChannelId.create(id);
+        return this;
     }
 
     public ChannelMembership joinUser(UserId userId, ChannelRole role, LocalDateTime joinedAt) {
@@ -288,14 +285,8 @@ public class Channel {
 
         validateName(newName);
 
-        return new Channel(
-                this.channelId,
-                newName,
-                this.creatorId,
-                this.channelPolicy,
-                this.memberships,
-                this.createdAt
-        );
+        this.name = newName;
+        return this;
     }
 
     public Channel changeChannelPolicy(UserId changerId, ChannelPolicy channelPolicy) {
@@ -308,14 +299,8 @@ public class Channel {
             throw new ChannelOperationForbiddenException("채널 정책을 변경할 권한이 없습니다.");
         }
 
-        return new Channel(
-                this.channelId,
-                this.name,
-                this.creatorId,
-                channelPolicy,
-                this.memberships,
-                this.createdAt
-        );
+        this.channelPolicy = channelPolicy;
+        return this;
     }
 
     public void validateDeleteChannel(UserId deleterId) {
@@ -450,6 +435,7 @@ public class Channel {
         if (granteeMembership.isNotManager()) {
             return false;
         }
+
         return granteeMembership.hasPermission(permission);
     }
 
@@ -471,6 +457,7 @@ public class Channel {
         if (targetUserMembership.isOwner()) {
             return false;
         }
+
         return targetUserMembership.isNotManager();
     }
 
@@ -492,6 +479,7 @@ public class Channel {
         if (targetUserMembership.isOwner()) {
             return false;
         }
+
         return !targetUserMembership.isMember();
     }
 
@@ -501,6 +489,7 @@ public class Channel {
         if (channelMembership == null) {
             return false;
         }
+
         return channelMembership.canEditChannelName();
     }
 
@@ -510,6 +499,7 @@ public class Channel {
         if (executorMembership == null) {
             return false;
         }
+
         return executorMembership.canChangeChannelPolicy();
     }
 
@@ -531,6 +521,7 @@ public class Channel {
         if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotEditMessage()) {
             return false;
         }
+
         return !channelPolicy.cannotEditOwnMessage();
     }
 
@@ -543,6 +534,7 @@ public class Channel {
         if (message.isNotWriter(executorId.getValue()) && executorMembership.cannotDeleteMessage()) {
             return false;
         }
+
         return !channelPolicy.cannotDeleteOwnMessage();
     }
 
@@ -550,6 +542,152 @@ public class Channel {
         ChannelMembership senderMembership = memberships.get(senderId);
 
         return senderMembership != null;
+    }
+
+    public void applyEvents(List<ChannelDomainEvent> events) {
+        events.forEach(this::applyEvent);
+    }
+
+    private void applyEvent(ChannelDomainEvent event) {
+        event.apply(this);
+    }
+
+    private ChannelMembership createMembershipFromPrimitives(
+            Long channelId,
+            Long userId,
+            String role,
+            List<String> managerPermissions,
+            LocalDateTime joinedAt
+    ) {
+        ChannelRole channelRole = ChannelRole.find(role);
+        ChannelId channelIdValue = ChannelId.create(channelId);
+        UserId userIdValue = UserId.create(userId);
+
+        if (channelRole.isManager()) {
+            Set<ChannelPermissionType> permissions = toPermissionSet(managerPermissions);
+            ChannelManagePermissions managePermissions = ChannelManagePermissions.ofManager(permissions);
+
+            return ChannelMembership.createManager(channelIdValue, userIdValue, managePermissions, joinedAt);
+        }
+
+        return ChannelMembership.create(channelIdValue, userIdValue, channelRole, joinedAt);
+    }
+
+    private Set<ChannelPermissionType> toPermissionSet(List<String> permissions) {
+        if (permissions == null || permissions.isEmpty()) {
+            return EnumSet.noneOf(ChannelPermissionType.class);
+        }
+
+        EnumSet<ChannelPermissionType> permissionSet = EnumSet.noneOf(ChannelPermissionType.class);
+        permissions.forEach(permission -> permissionSet.add(ChannelPermissionType.valueOf(permission)));
+
+        return permissionSet;
+    }
+
+    void applyChannelNameEdited(String newName) {
+        validateName(newName);
+
+        this.name = newName;
+    }
+
+    void applyChannelPolicyChanged(boolean canEditOwnMessage, boolean canDeleteOwnMessage, boolean isPublic) {
+        this.channelPolicy = new ChannelPolicy(canEditOwnMessage, canDeleteOwnMessage, isPublic);
+    }
+
+    void applyUserJoined(Long channelId, Long userId, String role, List<String> managerPermissions, LocalDateTime joinedAt) {
+        UserId userIdValue = UserId.create(userId);
+
+        if (!canJoinUser(userIdValue)) {
+            return;
+        }
+
+        ChannelMembership membership = createMembershipFromPrimitives(channelId, userId, role, managerPermissions, joinedAt);
+
+        memberships.put(membership.getUserId(), membership);
+    }
+
+    void applyUserInvited(Long channelId, Long userId, String role, List<String> managerPermissions, LocalDateTime joinedAt) {
+        applyUserJoined(channelId, userId, role, managerPermissions, joinedAt);
+    }
+
+    void applyMemberLeft(Long userId) {
+        UserId userIdValue = UserId.create(userId);
+        ChannelMembership membership = memberships.get(userIdValue);
+
+        if (membership == null || membership.isOwner()) {
+            return;
+        }
+
+        memberships.remove(userIdValue);
+    }
+
+    void applyMemberKicked(Long userId) {
+        UserId userIdValue = UserId.create(userId);
+        ChannelMembership membership = memberships.get(userIdValue);
+
+        if (membership == null || membership.isNotMember()) {
+            return;
+        }
+
+        memberships.remove(userIdValue);
+    }
+
+    void applyPromotedToManager(Long userId, List<String> managerPermissions) {
+        UserId userIdValue = UserId.create(userId);
+        ChannelMembership existingMembership = memberships.get(userIdValue);
+
+        if (existingMembership == null || existingMembership.isOwner() || existingMembership.isManager()) {
+            return;
+        }
+
+        Set<ChannelPermissionType> permissions = toPermissionSet(managerPermissions);
+        ChannelMembership membership = existingMembership.promoteToManager(ChannelManagePermissions.ofManager(permissions));
+
+        memberships.put(membership.getUserId(), membership);
+    }
+
+    void applyDemotedToMember(Long userId) {
+        ChannelMembership existing = memberships.get(UserId.create(userId));
+
+        if (existing == null) {
+            return;
+        }
+
+        ChannelMembership membership = existing.demoteToMember();
+
+        memberships.put(membership.getUserId(), membership);
+    }
+
+    void applyPermissionAdded(Long userId, String permissionType) {
+        ChannelMembership membership = memberships.get(UserId.create(userId));
+
+        if (membership == null) {
+            return;
+        }
+        if (membership.isNotManager()) {
+            return;
+        }
+
+        ChannelPermissionType permission = ChannelPermissionType.valueOf(permissionType);
+        ChannelMembership updated = membership.addPermission(permission);
+
+        memberships.put(updated.getUserId(), updated);
+    }
+
+    void applyPermissionRemoved(Long userId, String permissionType) {
+        ChannelMembership membership = memberships.get(UserId.create(userId));
+
+        if (membership == null) {
+            return;
+        }
+        if (membership.isNotManager()) {
+            return;
+        }
+
+        ChannelPermissionType permission = ChannelPermissionType.valueOf(permissionType);
+        ChannelMembership updated = membership.removePermission(permission);
+
+        memberships.put(updated.getUserId(), updated);
     }
 
     public static class ChannelMembershipNotFoundException extends IllegalArgumentException {

--- a/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelDomainEvent.java
+++ b/pekko/src/main/java/com/tok/pekko/domain/channel/model/ChannelDomainEvent.java
@@ -1,0 +1,120 @@
+package com.tok.pekko.domain.channel.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChannelDomainEvent {
+
+    record ChannelNameEdited(Long channelId, Long changerId, String newName, LocalDateTime occurredAt) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyChannelNameEdited(newName);
+        }
+    }
+
+    record ChannelPolicyChanged(
+            Long channelId,
+            Long changerId,
+            boolean canEditOwnMessage,
+            boolean canDeleteOwnMessage,
+            boolean isPublic,
+            LocalDateTime occurredAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyChannelPolicyChanged(canEditOwnMessage, canDeleteOwnMessage, isPublic);
+        }
+    }
+
+    record UserJoined(
+            Long channelId,
+            Long userId,
+            String role,
+            List<String> managerPermissions,
+            LocalDateTime joinedAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyUserJoined(channelId, userId, role, managerPermissions, joinedAt);
+        }
+    }
+
+    record UserInvited(
+            Long channelId,
+            Long userId,
+            String role,
+            List<String> managerPermissions,
+            LocalDateTime joinedAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyUserInvited(channelId, userId, role, managerPermissions, joinedAt);
+        }
+    }
+
+    record MemberLeft(Long channelId, Long userId, LocalDateTime occurredAt) implements ChannelDomainEvent {
+        @Override
+        public void apply(Channel channel) {
+            channel.applyMemberLeft(userId);
+        }
+    }
+
+    record MemberKicked(Long channelId, Long userId, LocalDateTime occurredAt) implements ChannelDomainEvent {
+        @Override
+        public void apply(Channel channel) {
+            channel.applyMemberKicked(userId);
+        }
+    }
+
+    record PromotedToManager(
+            Long userId,
+            List<String> managerPermissions,
+            LocalDateTime occurredAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyPromotedToManager(userId, managerPermissions);
+        }
+    }
+
+    record DemotedToMember(Long channelId, Long userId, LocalDateTime occurredAt) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyDemotedToMember(userId);
+        }
+    }
+
+    record PermissionAdded(
+            Long channelId,
+            Long userId,
+            String permissionType,
+            LocalDateTime occurredAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyPermissionAdded(userId, permissionType);
+        }
+    }
+
+    record PermissionRemoved(
+            Long channelId,
+            Long userId,
+            String permissionType,
+            LocalDateTime occurredAt
+    ) implements ChannelDomainEvent {
+
+        @Override
+        public void apply(Channel channel) {
+            channel.applyPermissionRemoved(userId, permissionType);
+        }
+    }
+
+    void apply(Channel channel);
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelDomainEventTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelDomainEventTest.java
@@ -1,0 +1,189 @@
+package com.tok.pekko.domain.channel.model;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChannelDomainEventTest {
+
+    @Test
+    void 채널_도메인_이벤트를_통해_채널_이름을_변경한다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.ChannelNameEdited(1L, 1L, "new-name", occurredAt);
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyChannelNameEdited("new-name");
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_채널_정책을_변경한다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.ChannelPolicyChanged(1L, 1L, false, false, false, occurredAt);
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyChannelPolicyChanged(false, false, false);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_멤버가_추가된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime joinedAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.UserJoined(
+                1L,
+                2L,
+                ChannelRole.MEMBER.name(),
+                List.of(),
+                joinedAt
+        );
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyUserJoined(1L, 2L, ChannelRole.MEMBER.name(), List.of(), joinedAt);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_초대된_멤버가_추가된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime invitedAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.UserInvited(
+                1L,
+                2L,
+                ChannelRole.MEMBER.name(),
+                List.of(),
+                invitedAt
+        );
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyUserInvited(1L, 2L, ChannelRole.MEMBER.name(), List.of(), invitedAt);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_멤버가_나간다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.MemberLeft(1L, 2L, occurredAt);
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyMemberLeft(2L);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_멤버가_강퇴된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.MemberKicked(1L, 2L, occurredAt);
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyMemberKicked(2L);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_매니저로_승격된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.PromotedToManager(
+                2L,
+                List.of(ChannelPermissionType.MESSAGE_EDIT.name()),
+                occurredAt
+        );
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyPromotedToManager(2L, List.of(ChannelPermissionType.MESSAGE_EDIT.name()));
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_멤버로_강등된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.DemotedToMember(1L, 2L, occurredAt);
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyDemotedToMember(2L);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_권한이_추가된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.PermissionAdded(
+                1L,
+                2L,
+                ChannelPermissionType.MEMBER_KICK.name(),
+                occurredAt
+        );
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyPermissionAdded(2L, ChannelPermissionType.MEMBER_KICK.name());
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    void 채널_도메인_이벤트를_통해_권한이_삭제된다() {
+        // given
+        Channel channel = mock(Channel.class);
+        LocalDateTime occurredAt = LocalDateTime.now();
+        ChannelDomainEvent event = new ChannelDomainEvent.PermissionRemoved(
+                1L,
+                2L,
+                ChannelPermissionType.MEMBER_KICK.name(),
+                occurredAt
+        );
+
+        // when
+        event.apply(channel);
+
+        // then
+        verify(channel, times(1)).applyPermissionRemoved(2L, ChannelPermissionType.MEMBER_KICK.name());
+        verifyNoMoreInteractions(channel);
+    }
+}

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelMembershipTest.java
@@ -28,40 +28,21 @@ class ChannelMembershipTest {
         LocalDateTime joinedAt = LocalDateTime.now();
 
         // when
-        ChannelMembership membership = ChannelMembership.create(channelId, userId, role, joinedAt);
+        ChannelMembership actual = ChannelMembership.create(channelId, userId, role, joinedAt);
 
         // then
         assertAll(
-                () -> assertThat(membership).isNotNull(),
-                () -> assertThat(membership.getId()).isEqualTo(ChannelMembershipId.EMPTY_CHANNEL_MEMBERSHIP_ID),
-                () -> assertThat(membership.getChannelId()).isEqualTo(channelId),
-                () -> assertThat(membership.getUserId()).isEqualTo(userId),
-                () -> assertThat(membership.getRole()).isEqualTo(role),
-                () -> assertThat(membership.getJoinedAt()).isEqualTo(joinedAt)
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual.getId()).isEqualTo(ChannelMembershipId.EMPTY_CHANNEL_MEMBERSHIP_ID),
+                () -> assertThat(actual.getChannelId()).isEqualTo(channelId),
+                () -> assertThat(actual.getUserId()).isEqualTo(userId),
+                () -> assertThat(actual.getRole()).isEqualTo(role),
+                () -> assertThat(actual.getJoinedAt()).isEqualTo(joinedAt)
         );
     }
 
     @Test
-    void null_채널_ID로는_채널_참여자를_초기화할_수_없다() {
-        // when & then
-        assertThatThrownBy(() -> ChannelMembership.create(null, UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("채널 ID는 필수입니다.");
-    }
-
-    @Test
-    void null_사용자_ID로는_채널_참여자를_초기화할_수_없다() {
-        // given
-        ChannelId channelId = ChannelId.create(10L);
-
-        // when & then
-        assertThatThrownBy(() -> ChannelMembership.create(channelId, null, ChannelRole.MEMBER, LocalDateTime.now()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("사용자 ID는 필수입니다.");
-    }
-
-    @Test
-    void 비어있는_사용자_ID로는_채널_참여자를_초기화할_수_없다() {
+    void 비어_있는_사용자_ID로는_채널_참여자를_초기화할_수_없다() {
         // given
         ChannelId channelId = ChannelId.create(10L);
 
@@ -77,10 +58,10 @@ class ChannelMembershipTest {
         ChannelId channelId = ChannelId.create(10L);
 
         // when
-        ChannelMembership membership = ChannelMembership.create(channelId, UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
+        ChannelMembership actual = ChannelMembership.create(channelId, UserId.create(1L), ChannelRole.MEMBER, LocalDateTime.now());
 
         // then
-        assertThat(membership.getPermissions().isEmpty()).isTrue();
+        assertThat(actual.getPermissions().isEmpty()).isTrue();
     }
 
     @Test
@@ -93,13 +74,13 @@ class ChannelMembershipTest {
         ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
 
         // when
-        ChannelMembership membership = ChannelMembership.createManager(channelId, userId, permissions, joinedAt);
+        ChannelMembership actual = ChannelMembership.createManager(channelId, userId, permissions, joinedAt);
 
         // then
         assertAll(
-                () -> assertThat(membership.getRole()).isEqualTo(ChannelRole.MANAGER),
-                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
-                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue()
+                () -> assertThat(actual.getRole()).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(actual.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue()
         );
     }
 
@@ -115,15 +96,15 @@ class ChannelMembershipTest {
         ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(perms);
 
         // when
-        ChannelMembership membership = ChannelMembership.create(memberId, channelIdVal, userIdVal, role, permissions, joinedAt);
+        ChannelMembership actual = ChannelMembership.create(memberId, channelIdVal, userIdVal, role, permissions, joinedAt);
 
         // then
         assertAll(
-                () -> assertThat(membership.getId()).isEqualTo(ChannelMembershipId.create(memberId)),
-                () -> assertThat(membership.getChannelId()).isEqualTo(ChannelId.create(channelIdVal)),
-                () -> assertThat(membership.getUserId()).isEqualTo(UserId.create(userIdVal)),
-                () -> assertThat(membership.getRole()).isEqualTo(role),
-                () -> assertThat(membership.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue()
+                () -> assertThat(actual.getId()).isEqualTo(ChannelMembershipId.create(memberId)),
+                () -> assertThat(actual.getChannelId()).isEqualTo(ChannelId.create(channelIdVal)),
+                () -> assertThat(actual.getUserId()).isEqualTo(UserId.create(userIdVal)),
+                () -> assertThat(actual.getRole()).isEqualTo(role),
+                () -> assertThat(actual.getPermissions().has(ChannelPermissionType.MESSAGE_EDIT)).isTrue()
         );
     }
 
@@ -133,15 +114,15 @@ class ChannelMembershipTest {
         UserId userId = UserId.create(1L);
         LocalDateTime joinedAt = LocalDateTime.now();
 
-        ChannelMembership membership1 = ChannelMembership.create(1L, 10L, userId.getValue(), ChannelRole.MEMBER,
+        ChannelMembership actual = ChannelMembership.create(1L, 10L, userId.getValue(), ChannelRole.MEMBER,
                 ChannelManagePermissions.ofMember(), joinedAt);
-        ChannelMembership membership2 = ChannelMembership.create(1L, 10L, userId.getValue(), ChannelRole.OWNER,
+        ChannelMembership actual2 = ChannelMembership.create(1L, 10L, userId.getValue(), ChannelRole.OWNER,
                 ChannelManagePermissions.ofOwner(), joinedAt);
 
         // when & then
         assertAll(
-                () -> assertThat(membership1).isEqualTo(membership2),
-                () -> assertThat(membership1).hasSameHashCodeAs(membership2)
+                () -> assertThat(actual).isEqualTo(actual2),
+                () -> assertThat(actual).hasSameHashCodeAs(actual2)
         );
     }
 
@@ -152,15 +133,15 @@ class ChannelMembershipTest {
         ChannelRole role = ChannelRole.MEMBER;
         LocalDateTime joinedAt = LocalDateTime.now();
 
-        ChannelMembership membership1 = ChannelMembership.create(1L, 10L, userId.getValue(), role,
+        ChannelMembership actual = ChannelMembership.create(1L, 10L, userId.getValue(), role,
                 ChannelManagePermissions.ofMember(), joinedAt);
-        ChannelMembership membership2 = ChannelMembership.create(2L, 10L, userId.getValue(), role,
+        ChannelMembership actual2 = ChannelMembership.create(2L, 10L, userId.getValue(), role,
                 ChannelManagePermissions.ofMember(), joinedAt);
 
         // when & then
         assertAll(
-                () -> assertThat(membership1).isNotEqualTo(membership2),
-                () -> assertThat(membership1).doesNotHaveSameHashCodeAs(membership2)
+                () -> assertThat(actual).isNotEqualTo(actual2),
+                () -> assertThat(actual).doesNotHaveSameHashCodeAs(actual2)
         );
     }
 
@@ -171,11 +152,11 @@ class ChannelMembershipTest {
         UserId userId = UserId.create(1L);
         ChannelRole role = ChannelRole.MEMBER;
         LocalDateTime joinedAt = LocalDateTime.now();
-        ChannelMembership membership = ChannelMembership.create(channelId, userId, role, joinedAt);
+        ChannelMembership channelMembership = ChannelMembership.create(channelId, userId, role, joinedAt);
         Long assignedId = 100L;
 
         // when
-        ChannelMembership actual = membership.withAssignedId(assignedId);
+        ChannelMembership actual = channelMembership.withAssignedId(assignedId);
 
         // then
         assertAll(
@@ -195,16 +176,16 @@ class ChannelMembershipTest {
         ChannelRole role = ChannelRole.MANAGER;
         LocalDateTime joinedAt = LocalDateTime.now();
 
-        ChannelMembership membership = ChannelMembership.create(channelId, userId, role, joinedAt);
+        ChannelMembership channelMembership = ChannelMembership.create(channelId, userId, role, joinedAt);
         Set<ChannelPermissionType> newPerms = EnumSet.of(ChannelPermissionType.MESSAGE_EDIT, ChannelPermissionType.MEMBER_KICK);
         ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager(newPerms);
 
         // when
-        ChannelMembership updatedMembership = membership.updatePermissions(newPermissions);
+        ChannelMembership actual = channelMembership.updatePermissions(newPermissions);
 
         // then
-        assertThat(updatedMembership.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue();
-        assertThat(updatedMembership.getChannelId()).isEqualTo(channelId);
+        assertThat(actual.getPermissions().has(ChannelPermissionType.MEMBER_KICK)).isTrue();
+        assertThat(actual.getChannelId()).isEqualTo(channelId);
     }
 
     @Test
@@ -215,11 +196,11 @@ class ChannelMembershipTest {
         ChannelRole role = ChannelRole.MEMBER;
         LocalDateTime joinedAt = LocalDateTime.now();
 
-        ChannelMembership membership = ChannelMembership.create(channelId, userId, role, joinedAt);
+        ChannelMembership actual = ChannelMembership.create(channelId, userId, role, joinedAt);
         ChannelManagePermissions newPermissions = ChannelManagePermissions.ofManager();
 
         // when & then
-        assertThatThrownBy(() -> membership.updatePermissions(newPermissions))
+        assertThatThrownBy(() -> actual.updatePermissions(newPermissions))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("매니저가 아니라면 채널 권한을 관리할 수 없습니다.");
     }

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
@@ -821,4 +821,136 @@ class ChannelTest {
                 .isInstanceOf(Channel.ChannelMembershipNotFoundException.class)
                 .hasMessage("채널 멤버를 찾을 수 없습니다.");
     }
+
+    @Test
+    void 비공개_채널은_canJoinUser가_false를_반환한다() {
+        // given
+        ChannelPolicy privatePolicy = new ChannelPolicy(true, true, false);
+        Channel channel = Channel.create("private", 1L, privatePolicy, LocalDateTime.now());
+        UserId userId = UserId.create(2L);
+
+        // when & then
+        assertThat(channel.canJoinUser(userId)).isFalse();
+    }
+
+    @Test
+    void 이미_참여한_사용자는_canJoinUser가_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId userId = UserId.create(2L);
+        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        // when & then
+        assertThat(channel.canJoinUser(userId)).isFalse();
+    }
+
+    @Test
+    void 초대자가_없으면_canInviteMember가_false를_반환한다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId inviterId = UserId.create(2L);
+        UserId inviteeId = UserId.create(3L);
+
+        // when & then
+        assertThat(channel.canInviteMember(inviterId, inviteeId)).isFalse();
+    }
+
+    @Test
+    void 초대자가_권한이_없으면_canInviteMember가_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId inviterId = UserId.create(2L);
+        memberships.put(inviterId, ChannelMembership.create(ChannelId.create(1L), inviterId, ChannelRole.MEMBER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+        UserId inviteeId = UserId.create(3L);
+
+        // when & then
+        assertThat(channel.canInviteMember(inviterId, inviteeId)).isFalse();
+    }
+
+    @Test
+    void 매니저_권한이_없으면_canKickMember가_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId executorId = UserId.create(2L);
+        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MANAGER, createdAt));
+        UserId targetUserId = UserId.create(3L);
+        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MEMBER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        // when & then
+        assertThat(channel.canKickMember(executorId, targetUserId)).isFalse();
+    }
+
+    @Test
+    void 권한_추가_Grantor가_멤버이면_canAddPermission이_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId grantorId = UserId.create(2L);
+        memberships.put(grantorId, ChannelMembership.create(ChannelId.create(1L), grantorId, ChannelRole.MEMBER, createdAt));
+        UserId granteeId = UserId.create(3L);
+        memberships.put(granteeId, ChannelMembership.create(ChannelId.create(1L), granteeId, ChannelRole.MANAGER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        // when & then
+        assertThat(channel.canAddPermission(grantorId, granteeId, ChannelPermissionType.MESSAGE_DELETE)).isFalse();
+    }
+
+    @Test
+    void 이미_매니저인_사용자는_canPromoteToManager가_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId executorId = UserId.create(2L);
+        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.OWNER, createdAt));
+        UserId targetUserId = UserId.create(3L);
+        memberships.put(targetUserId, ChannelMembership.create(ChannelId.create(1L), targetUserId, ChannelRole.MANAGER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        // when & then
+        assertThat(channel.canPromoteToManager(executorId, targetUserId)).isFalse();
+    }
+
+    @Test
+    void 채널명_변경_권한이_없으면_canEditName이_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId managerId = UserId.create(2L);
+        memberships.put(managerId, ChannelMembership.create(ChannelId.create(1L), managerId, ChannelRole.MANAGER, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+
+        // when & then
+        assertThat(channel.canEditName(managerId)).isFalse();
+    }
+
+    @Test
+    void 멤버가_아니면_canMemberSendMessage가_false를_반환한다() {
+        // given
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), LocalDateTime.now());
+        UserId senderId = UserId.create(2L);
+
+        // when & then
+        assertThat(channel.canMemberSendMessage(senderId)).isFalse();
+    }
+
+    @Test
+    void 자신의_메시지가_아니고_권한이_없으면_canMemberEditMessage가_false를_반환한다() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId executorId = UserId.create(2L);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MEMBER_KICK));
+        memberships.put(executorId, ChannelMembership.create(1L, 1L, executorId.getValue(), ChannelRole.MANAGER, permissions, createdAt));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
+        ChatMessage message = ChatMessage.create(1L, 99L, 1L, "hello", createdAt, createdAt);
+
+        // when & then
+        assertThat(channel.canMemberEditMessage(executorId, message)).isFalse();
+    }
 }

--- a/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
+++ b/pekko/src/test/java/com/tok/pekko/domain/channel/model/ChannelTest.java
@@ -14,6 +14,7 @@ import com.tok.pekko.domain.user.model.vo.UserId;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -210,10 +211,10 @@ class ChannelTest {
         Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
         // when
-        ChannelMembership promoted = channel.promoteToManager(executorId, targetUserId);
+        ChannelMembership actual = channel.promoteToManager(executorId, targetUserId);
 
         // then
-        assertThat(promoted.isManager()).isTrue();
+        assertThat(actual.isManager()).isTrue();
     }
 
     @Test
@@ -295,10 +296,10 @@ class ChannelTest {
         Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
         // when
-        ChannelMembership demoted = channel.demoteToMember(executorId, targetUserId);
+        ChannelMembership actual = channel.demoteToMember(executorId, targetUserId);
 
         // then
-        assertThat(demoted.isMember()).isTrue();
+        assertThat(actual.isMember()).isTrue();
     }
 
     @Test
@@ -380,11 +381,11 @@ class ChannelTest {
         Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
         // when
-        ChannelMembership updatedMembership = channel.addPermission(grantorId, granteeId, ChannelPermissionType.MEMBER_KICK);
+        ChannelMembership actual = channel.addPermission(grantorId, granteeId, ChannelPermissionType.MEMBER_KICK);
 
         // then
         assertAll(
-                () -> assertThat(updatedMembership.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue(),
+                () -> assertThat(actual.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue(),
                 () -> assertThat(channel.getMemberships().get(granteeId).hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue()
         );
     }
@@ -456,11 +457,11 @@ class ChannelTest {
         Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, createdAt);
 
         // when
-        ChannelMembership removedPermissionMembership = channel.removePermission(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT);
+        ChannelMembership actual = channel.removePermission(grantorId, granteeId, ChannelPermissionType.MESSAGE_EDIT);
 
         // then
         assertAll(
-                () -> assertThat(removedPermissionMembership.lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
                 () -> assertThat(channel.getMemberships().get(granteeId).lacksPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue()
         );
     }
@@ -952,5 +953,503 @@ class ChannelTest {
 
         // when & then
         assertThat(channel.canMemberEditMessage(executorId, message)).isFalse();
+    }
+
+    @Test
+    void 도메인_이벤트로_채널_이름과_정책을_적용할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), now);
+        ChannelDomainEvent nameEdited = new ChannelDomainEvent.ChannelNameEdited(1L, 1L, "random", now);
+        ChannelDomainEvent policyChanged = new ChannelDomainEvent.ChannelPolicyChanged(1L, 1L, false, false, false, now);
+
+        // when
+        channel.applyEvents(List.of(nameEdited, policyChanged));
+
+        // then
+        assertAll(
+                () -> assertThat(channel.getName()).isEqualTo("random"),
+                () -> assertThat(channel.getChannelPolicy().canEditOwnMessage()).isFalse(),
+                () -> assertThat(channel.getChannelPolicy().canDeleteOwnMessage()).isFalse(),
+                () -> assertThat(channel.getChannelPolicy().isPublic()).isFalse()
+        );
+    }
+
+    @Test
+    void 도메인_이벤트로_멤버가_추가된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), now);
+        ChannelDomainEvent joinEvent = new ChannelDomainEvent.UserJoined(
+                1L,
+                2L,
+                ChannelRole.MEMBER.name(),
+                List.of(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(joinEvent));
+
+        // then
+        assertThat(channel.getMemberships()).containsKey(UserId.create(2L));
+    }
+
+    @Test
+    void 도메인_이벤트로_매니저가_멤버로_강등된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MESSAGE_EDIT));
+        memberships.put(
+                userId,
+                ChannelMembership.create(1L, 1L, userId.getValue(), ChannelRole.MANAGER, permissions, now)
+        );
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent demoteEvent = new ChannelDomainEvent.DemotedToMember(1L, userId.getValue(), now);
+
+        // when
+        channel.applyEvents(List.of(demoteEvent));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertAll(
+                () -> assertThat(actual.getRole()).isEqualTo(ChannelRole.MEMBER),
+                () -> assertThat(actual.getPermissions().isEmpty()).isTrue()
+        );
+    }
+
+    @Test
+    void 도메인_이벤트로_권한을_추가할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager();
+        memberships.put(
+                userId,
+                ChannelMembership.create(1L, 1L, userId.getValue(), ChannelRole.MANAGER, permissions, now)
+        );
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent addPermission = new ChannelDomainEvent.PermissionAdded(
+                1L,
+                userId.getValue(),
+                ChannelPermissionType.MEMBER_KICK.name(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(addPermission));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertThat(actual.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue();
+    }
+
+    @Test
+    void 도메인_이벤트로_권한을_제거할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MESSAGE_DELETE));
+        memberships.put(
+                userId,
+                ChannelMembership.create(1L, 1L, userId.getValue(), ChannelRole.MANAGER, permissions, now)
+        );
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent removePermission = new ChannelDomainEvent.PermissionRemoved(
+                1L,
+                userId.getValue(),
+                ChannelPermissionType.MESSAGE_DELETE.name(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(removePermission));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertThat(actual.lacksPermission(ChannelPermissionType.MESSAGE_DELETE)).isTrue();
+    }
+
+    @Test
+    void canMemberDeleteMessage는_권한이_없으면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId executorId = UserId.create(1L);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MEMBER_INVITE));
+        memberships.put(executorId, ChannelMembership.create(1L, 1L, executorId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChatMessage message = ChatMessage.create(1L, 99L, 1L, "hello", now, now);
+
+        // when & then
+        assertThat(channel.canMemberDeleteMessage(executorId, message)).isFalse();
+    }
+
+    @Test
+    void canMemberDeleteMessage는_자신의_메시지면_true를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId executorId = UserId.create(1L);
+        memberships.put(executorId, ChannelMembership.create(ChannelId.create(1L), executorId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChatMessage message = ChatMessage.create(1L, executorId.getValue(), 1L, "hello", now, now);
+
+        // when & then
+        assertThat(channel.canMemberDeleteMessage(executorId, message)).isTrue();
+    }
+
+    @Test
+    void applyEvents로_여러_도메인_이벤트를_순서대로_적용할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), now);
+        ChannelDomainEvent join = new ChannelDomainEvent.UserJoined(1L, 2L, ChannelRole.MEMBER.name(), List.of(), now);
+        ChannelDomainEvent promote = new ChannelDomainEvent.PromotedToManager(2L, List.of(ChannelPermissionType.MESSAGE_EDIT.name()), now);
+        ChannelDomainEvent addPermission = new ChannelDomainEvent.PermissionAdded(1L, 2L, ChannelPermissionType.MEMBER_KICK.name(), now);
+        ChannelDomainEvent nameEdit = new ChannelDomainEvent.ChannelNameEdited(1L, 1L, "renamed", now);
+
+        // when
+        channel.applyEvents(List.of(join, promote, addPermission, nameEdit));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(UserId.create(2L));
+        assertAll(
+                () -> assertThat(channel.getName()).isEqualTo("renamed"),
+                () -> assertThat(actual.getRole()).isEqualTo(ChannelRole.MANAGER),
+                () -> assertThat(actual.hasPermission(ChannelPermissionType.MESSAGE_EDIT)).isTrue(),
+                () -> assertThat(actual.hasPermission(ChannelPermissionType.MEMBER_KICK)).isTrue()
+        );
+    }
+
+    @Test
+    void applyMemberLeft_오너면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent left = new ChannelDomainEvent.MemberLeft(1L, ownerId.getValue(), now);
+
+        // when
+        channel.applyEvents(List.of(left));
+
+        // then
+        assertThat(channel.getMemberships()).containsKey(ownerId);
+    }
+
+    @Test
+    void applyMemberKicked_멤버가_아니면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        UserId managerId = UserId.create(1L);
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MEMBER_KICK));
+        memberships.put(managerId, ChannelMembership.create(1L, 1L, managerId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent kick = new ChannelDomainEvent.MemberKicked(1L, 99L, now);
+
+        // when
+        channel.applyEvents(List.of(kick));
+
+        // then
+        assertThat(channel.getMemberships()).hasSize(1);
+    }
+
+    @Test
+    void applyPromotedToManager_이미_매니저면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager();
+        memberships.put(userId, ChannelMembership.create(1L, 1L, userId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent promote = new ChannelDomainEvent.PromotedToManager(userId.getValue(), List.of(), now);
+
+        // when
+        channel.applyEvents(List.of(promote));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertThat(actual.getPermissions().size()).isEqualTo(permissions.size());
+    }
+
+    @Test
+    void applyPromotedToManager_멤버가_없으면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), now);
+        ChannelDomainEvent promote = new ChannelDomainEvent.PromotedToManager(2L, List.of(), now);
+
+        // when
+        channel.applyEvents(List.of(promote));
+
+        // then
+        assertThat(channel.getMemberships()).isEmpty();
+    }
+
+    @Test
+    void applyPermissionAdded_매니저가_아니면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent addPerm = new ChannelDomainEvent.PermissionAdded(
+                1L,
+                userId.getValue(),
+                ChannelPermissionType.MEMBER_KICK.name(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(addPerm));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertThat(actual.hasPermission(ChannelPermissionType.MEMBER_KICK)).isFalse();
+    }
+
+    @Test
+    void applyPermissionRemoved_매니저가_아니면_무시된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId userId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(userId, ChannelMembership.create(ChannelId.create(1L), userId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+        ChannelDomainEvent removePerm = new ChannelDomainEvent.PermissionRemoved(
+                1L,
+                userId.getValue(),
+                ChannelPermissionType.MEMBER_KICK.name(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(removePerm));
+
+        // then
+        ChannelMembership actual = channel.getMemberships().get(userId);
+        assertThat(actual.hasPermission(ChannelPermissionType.MEMBER_KICK)).isFalse();
+    }
+
+    @Test
+    void 도메인_이벤트로_초대된_멤버가_추가된다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Channel channel = Channel.create("general", 1L, ChannelPolicy.defaultPolicy(), now);
+        ChannelDomainEvent invitedEvent = new ChannelDomainEvent.UserInvited(
+                1L,
+                2L,
+                ChannelRole.MEMBER.name(),
+                List.of(),
+                now
+        );
+
+        // when
+        channel.applyEvents(List.of(invitedEvent));
+
+        // then
+        assertThat(channel.getMemberships()).containsKey(UserId.create(2L));
+    }
+
+    @Test
+    void canRemovePermission_오너가_권한을_가진_매니저에게서_제거할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MESSAGE_EDIT));
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        memberships.put(managerId, ChannelMembership.create(1L, 1L, managerId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canRemovePermission(ownerId, managerId, ChannelPermissionType.MESSAGE_EDIT);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void canRemovePermission_권한_없는_사용자는_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId memberId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager(EnumSet.of(ChannelPermissionType.MESSAGE_EDIT));
+        memberships.put(memberId, ChannelMembership.create(ChannelId.create(1L), memberId, ChannelRole.MEMBER, now));
+        memberships.put(managerId, ChannelMembership.create(1L, 1L, managerId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canRemovePermission(memberId, managerId, ChannelPermissionType.MESSAGE_EDIT);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canRemovePermission_권한이_없는_매니저면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        ChannelManagePermissions permissions = ChannelManagePermissions.ofManager();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        memberships.put(managerId, ChannelMembership.create(1L, 1L, managerId.getValue(), ChannelRole.MANAGER, permissions, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canRemovePermission(ownerId, managerId, ChannelPermissionType.MESSAGE_DELETE);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canDemoteToMember_오너는_매니저를_강등할_수_있다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        memberships.put(managerId, ChannelMembership.create(ChannelId.create(1L), managerId, ChannelRole.MANAGER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDemoteToMember(ownerId, managerId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void canDemoteToMember_권한이_없으면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId memberId = UserId.create(1L);
+        UserId managerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(memberId, ChannelMembership.create(ChannelId.create(1L), memberId, ChannelRole.MEMBER, now));
+        memberships.put(managerId, ChannelMembership.create(ChannelId.create(1L), managerId, ChannelRole.MANAGER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDemoteToMember(memberId, managerId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canDemoteToMember_타겟이_멤버면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        UserId targetId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        memberships.put(targetId, ChannelMembership.create(ChannelId.create(1L), targetId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDemoteToMember(ownerId, targetId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canDemoteToMember_타겟이_오너면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        UserId targetOwnerId = UserId.create(2L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        memberships.put(targetOwnerId, ChannelMembership.create(ChannelId.create(1L), targetOwnerId, ChannelRole.OWNER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDemoteToMember(ownerId, targetOwnerId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canChangeChannelPolicy_오너는_true를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canChangeChannelPolicy(ownerId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void canChangeChannelPolicy_오너가_아니면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId memberId = UserId.create(1L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(memberId, ChannelMembership.create(ChannelId.create(1L), memberId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canChangeChannelPolicy(memberId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void canDeleteChannel_오너면_true를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId ownerId = UserId.create(1L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(ownerId, ChannelMembership.create(ChannelId.create(1L), ownerId, ChannelRole.OWNER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDeleteChannel(ownerId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void canDeleteChannel_오너가_아니면_false를_반환한다() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        UserId memberId = UserId.create(1L);
+        Map<UserId, ChannelMembership> memberships = new HashMap<>();
+        memberships.put(memberId, ChannelMembership.create(ChannelId.create(1L), memberId, ChannelRole.MEMBER, now));
+        Channel channel = Channel.create(1L, "general", 1L, ChannelPolicy.defaultPolicy(), memberships, now);
+
+        // when
+        boolean actual = channel.canDeleteChannel(memberId);
+
+        // then
+        assertThat(actual).isFalse();
     }
 }


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #33 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->

- Channel 관련 도메인 이벤트 정의
  - Visitor 패턴 방식으로 Channel 상태를 변경할 수 있도록 변경 
- Channel을 가변으로 변경
- Channel 도메인은 두 가지 방식으로 상태가 변경될 수 있도록 설정
  - 기존 비즈니스 로직을 수행하고, 그 결과로 Channel 상태를 변경 
  - 검증을 통해 Channel의 상태를 변경할 수 있는지 확인하고, 변경하고자 하는 상태에 따른 도메인 이벤트를 발생시켜 Channel 상태를 변경